### PR TITLE
Support multiple fields per Item in a Capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "derive_macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +498,7 @@ dependencies = [
  "bufreaderwriter",
  "bytemuck",
  "bytemuck_derive",
+ "derive_macro",
  "gtk4",
  "memmap2",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+derive_macro = { path = "derive_macro" }
+
 bufreaderwriter = "0.1.2"
 bytemuck = { version = "1.8.0", features = ["extern_crate_alloc"] }
 bytemuck_derive = "1.0.1"

--- a/derive_macro/Cargo.toml
+++ b/derive_macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "derive_macro"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[lib]
+proc-macro = true

--- a/derive_macro/src/lib.rs
+++ b/derive_macro/src/lib.rs
@@ -1,0 +1,76 @@
+extern crate proc_macro;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{self, parse_macro_input, spanned::Spanned, MetaNameValue};
+
+#[proc_macro_derive(ItemFields, attributes(name, expander))]
+pub fn item_fields_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = parse_macro_input!(input);
+    let output = impl_item_fields(&ast);
+    proc_macro::TokenStream::from(output)
+}
+
+fn impl_item_fields(ast: &syn::DeriveInput) -> TokenStream {
+    let mut field_idents = vec![];
+    let mut field_names = vec![];
+    let mut expanders = vec![];
+    match &ast.data {
+        syn::Data::Struct(s) => {
+            for field in &s.fields {
+                let field_name = field.attrs.iter().find_map(attr_name);
+                if field_name.is_none() {
+                    return syn::Error::new(field.span(), "field must have a 'name' attribute, e.g '#[name = \"Field Name\"]'").to_compile_error();
+                }
+
+                let expander = field.attrs.iter().find_map(attr_expander).is_some();
+
+                if field.ident.is_none() {
+                    return syn::Error::new(field.span(), "struct field must have an identifier").to_compile_error();
+                };
+                let ident = field.ident.as_ref().unwrap();
+
+                field_idents.push(ident);
+                field_names.push(field_name.unwrap());
+                expanders.push(expander);
+            }
+        },
+        _ => return syn::Error::new(ast.span(), "ItemFields can only be derived on a struct").to_compile_error(),
+    };
+
+    let name = &ast.ident;
+
+    quote! {
+        impl #name {
+            pub fn field_names() -> ::std::vec::Vec<&'static ::std::primitive::str> {
+                ::std::vec![#(#field_names),*]
+            }
+
+            pub fn fields(&self) -> ::std::vec::Vec<&::std::primitive::str> {
+                ::std::vec![#(&self.#field_idents),*]
+            }
+
+            pub fn expanders() -> ::std::vec::Vec<::std::primitive::bool> {
+                ::std::vec![#(#expanders),*]
+            }
+        }
+    }
+}
+
+fn attr_name(attr: &syn::Attribute) -> Option<String> {
+    match &attr.parse_meta().unwrap() {
+        syn::Meta::NameValue(MetaNameValue { path, eq_token: _, lit: syn::Lit::Str(lit_str) } ) => {
+            path.is_ident("name").then(|| lit_str.value())
+        },
+        _ => None,
+    }
+}
+
+fn attr_expander(attr: &syn::Attribute) -> Option<()> {
+    match &attr.parse_meta().unwrap() {
+        syn::Meta::Path(path) => {
+            path.is_ident("expander").then(|| ())
+        },
+        _ => None,
+    }
+}

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -2,6 +2,7 @@ use std::ops::Range;
 
 use crate::file_vec::FileVec;
 use bytemuck_derive::{Pod, Zeroable};
+use derive_macro::ItemFields;
 use num_enum::{IntoPrimitive, FromPrimitive, TryFromPrimitive};
 
 #[derive(Copy, Clone, Debug, IntoPrimitive, FromPrimitive, PartialEq)]
@@ -52,6 +53,13 @@ enum ItemType {
 pub struct Item {
     index: u64,
     item_type: u8,
+}
+
+#[derive(Clone, ItemFields)]
+pub struct ItemFields {
+    #[name = "Summary"]
+    #[expander]
+    pub summary: String,
 }
 
 bitfield! {
@@ -520,7 +528,13 @@ impl Capture {
         }
     }
 
-    pub fn get_summary(&mut self, item: &Item) -> String {
+    pub fn get_fields(&mut self, item: &Item) -> ItemFields {
+        ItemFields {
+            summary: self.get_summary(item),
+        }
+    }
+
+    fn get_summary(&mut self, item: &Item) -> String {
         match ItemType::try_from(item.item_type).unwrap() {
             ItemType::Packet => {
                 let packet = self.get_packet(item.index);

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn main() {
                 .downcast::<Label>()
                 .expect("The child must be a Label.");
 
-            let text = row.property::<String>("text");
+            let text = row.get_fields().unwrap().summary;
             label.set_label(&text);
             expander.set_list_row(Some(&treelistrow));
         });

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -37,7 +37,7 @@ impl ListModelImpl for Model {
         let arc = self.capture.borrow();
         let mut cap = arc.lock().unwrap();
         let item = cap.get_item(&self.parent.borrow(), position as u64);
-        let summary = cap.get_summary(&item);
-        Some(RowData::new(Some(item), &summary).upcast::<glib::Object>())
+        let summary = cap.get_fields(&item);
+        Some(RowData::new(Some(item), Some(summary)).upcast::<glib::Object>())
     }
 }

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -1,17 +1,17 @@
 use glib::subclass::prelude::*;
 use gtk::{
     glib::{self, ParamSpec, Value},
-    prelude::*,
 };
 use std::cell::RefCell;
+use std::rc::Rc;
 use crate::capture;
 
 // The actual data structure that stores our values. This is not accessible
 // directly from the outside.
 #[derive(Default)]
 pub struct RowData {
-    name: RefCell<Option<String>>,
     pub(super) item: RefCell<Option<capture::Item>>,
+    pub(super) fields: RefCell<Option<Rc<capture::ItemFields>>>,
 }
 
 // Basic declaration of our type for the GObject type system
@@ -30,35 +30,15 @@ impl ObjectSubclass for RowData {
 impl ObjectImpl for RowData {
     fn properties() -> &'static [ParamSpec] {
         use once_cell::sync::Lazy;
-        static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
-            vec![
-                glib::ParamSpecString::new(
-                    "text",
-                    "Text",
-                    "Text",
-                    None, // Default value
-                    glib::ParamFlags::READWRITE,
-                ),
-            ]
-        });
-
+        static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| vec![]);
         PROPERTIES.as_ref()
     }
 
-    fn set_property(&self, _obj: &Self::Type, _id: usize, value: &Value, pspec: &ParamSpec) {
-        match pspec.name() {
-            "text" => {
-                let name = value.get().unwrap();
-                self.name.replace(name);
-            }
-            _ => unimplemented!(),
-        }
+    fn set_property(&self, _obj: &Self::Type, _id: usize, _value: &Value, _pspec: &ParamSpec) {
+        unimplemented!()
     }
 
-    fn property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> Value {
-        match pspec.name() {
-            "text" => self.name.borrow().to_value(),
-            _ => unimplemented!(),
-        }
+    fn property(&self, _obj: &Self::Type, _id: usize, _pspec: &ParamSpec) -> Value {
+        unimplemented!()
     }
 }

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -9,6 +9,7 @@ mod imp;
 use gtk::glib;
 use gtk::subclass::prelude::*;
 use crate::capture;
+use std::rc::Rc;
 
 // Public part of the RowData type. This behaves like a normal gtk-rs-style GObject
 // binding
@@ -19,9 +20,10 @@ glib::wrapper! {
 // Constructor for new instances. This simply calls glib::Object::new() with
 // initial values for our two properties and then returns the new instance
 impl RowData {
-    pub fn new(item: Option<capture::Item>, text: &str) -> RowData {
-        let mut row: RowData = glib::Object::new(&[("text", &text)]).expect("Failed to create row data");
+    pub fn new(item: Option<capture::Item>, fields: Option<capture::ItemFields>) -> RowData {
+        let mut row: RowData = glib::Object::new(&[]).expect("Failed to create row data");
         row.set_item(item);
+        row.set_fields(fields);
         row
     }
 
@@ -31,5 +33,18 @@ impl RowData {
 
     pub fn get_item(&self) -> Option<capture::Item> {
         self.imp().item.borrow().clone()
+    }
+
+    pub fn set_fields(&mut self, fields: Option<capture::ItemFields>) {
+        self.imp().fields.replace(
+            match fields {
+                Some(f) => Some(Rc::new(f)),
+                None => None,
+            }
+        );
+    }
+
+    pub fn get_fields(&self) -> Option<Rc<capture::ItemFields>> {
+        self.imp().fields.borrow().clone()
     }
 }


### PR DESCRIPTION
(Marked draft for now as I'll probably need to rebase this after #12 is merged)

This PR adds a method `get_fields` on `Capture` which can return multiple fields as well as the current summary, so that we can display timestamps, ACK/NAK status, etc.

I wanted to set this up in a way that doesn't require the frontend to know all the field names, as it would be cumbersome to update as we add fields. So, this also includes a [procedural macro](https://doc.rust-lang.org/reference/procedural-macros.html) that lets us annotate each field with its name (for column headers in the UI) and whether it should display the TreeExpander widget. The macro then adds some methods that the frontend can use to iterate over the available fields.

fixes #7