### PR TITLE
Remove finish method

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -333,12 +333,6 @@ impl Capture {
         self.packet_data.append(packet).unwrap();
     }
 
-    pub fn finish(&mut self) {
-        for i in 0..self.endpoints.len() as usize {
-            self.ep_transfer_end(i, false);
-        }
-    }
-
     pub fn print_storage_summary(&self) {
         let mut overhead: u64 =
             self.packet_index.size() +

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -527,14 +527,9 @@ impl Capture {
 
     fn transfer_end(&mut self) {
         let endpoint_id = self.transaction_state.endpoint_id;
-        let add_item = self.last_item_endpoint != (endpoint_id as i16);
-        self.ep_transfer_end(endpoint_id, add_item);
-    }
-
-    fn ep_transfer_end(&mut self, endpoint_id: usize, add_item: bool) {
-        let ep_data = &mut self.endpoint_data[endpoint_id];
+        let ep_data = &self.endpoint_data[endpoint_id];
         if ep_data.transaction_count > 0 {
-            if add_item {
+            if self.last_item_endpoint != (endpoint_id as i16) {
                 self.item_index.push(self.transfer_index.len()).unwrap();
                 self.last_item_endpoint = endpoint_id as i16;
             }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -518,6 +518,7 @@ impl Capture {
         let ep_data = &mut self.endpoint_data[endpoint_id];
         ep_data.transaction_start = ep_data.transaction_ids.len();
         ep_data.transaction_count = 0;
+        ep_data.transfer_index.push(ep_data.transaction_start).unwrap();
     }
 
     fn transfer_append(&mut self, success: bool) {
@@ -539,8 +540,6 @@ impl Capture {
     fn ep_transfer_end(&mut self, endpoint_id: usize, add_item: bool) {
         let ep_data = &mut self.endpoint_data[endpoint_id];
         if ep_data.transaction_count > 0 {
-            let start = ep_data.transaction_start;
-            ep_data.transfer_index.push(start).unwrap();
             if add_item {
                 self.item_index.push(self.transfer_index.len()).unwrap();
                 self.last_item_endpoint = endpoint_id as i16;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,6 @@ fn main() {
     while let Ok(packet) = pcap.next() {
         cap.handle_raw_packet(&packet);
     }
-    cap.finish();
     cap.print_storage_summary();
     let capture = Arc::new(Mutex::new(cap));
 


### PR DESCRIPTION
The only work still needed in the `finish` method was to add an entry to the endpoint’s transfer index, if a transfer was left in progress at the end of capture.

This step is moved to `transfer_start`, the `finish` method is removed, and `ep_transfer_end` is merged into `transfer_end`.