### PR TITLE
Decode descriptors to correctly identify endpoint types

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -472,16 +472,19 @@ impl Configuration {
                 endpoint_descriptors:
                     Vec::with_capacity(iface_desc.num_endpoints as usize),
             };
-            for _ in 0 .. iface.descriptor.num_endpoints {
+            while iface.endpoint_descriptors.len() <
+                iface.descriptor.num_endpoints as usize
+            {
                 if offset + ep_size > bytes.len() {
                     break;
                 }
                 let ep_bytes = &bytes[offset .. offset + ep_size];
                 let ep_desc =
                     pod_read_unaligned::<EndpointDescriptor>(ep_bytes);
-                offset += ep_size;
+                offset += ep_desc.length as usize;
                 if ep_desc.descriptor_type != DescriptorType::Endpoint as u8 {
-                    break;
+                    // Could be HID or other class descriptor; skip over it.
+                    continue;
                 }
                 iface.endpoint_descriptors.push(ep_desc);
             };

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1039,8 +1039,10 @@ impl Capture {
                         (Out, true, SETUP, OUT) |
                         (In,  true, IN,    IN ) |
                         (Out, true, OUT,   OUT) => {
-                            ep_data.payload.extend(
-                                &self.transaction_state.payload);
+                            if self.transaction_state.completed() {
+                                ep_data.payload.extend(
+                                    &self.transaction_state.payload);
+                            }
                             // Await status stage.
                             DecodeStatus::CONTINUE
                         },


### PR DESCRIPTION
This PR stacks on #18 and adds interpretation within the decode loop for:

1. `GetDescriptor` requests that successfully read:
   - Device descriptors
   - Configuration descriptors, including:
     - Interface descriptors, including:
       - Endpoint descriptors
2. `SetConfiguration` requests that change a device configuration.

The latest read copies of all these descriptors are stored in a hierarchy of the form:
```
device -> configuration -> interface -> endpoint
```
Once both a `GetDescriptor` request for a configuration and a `SetConfiguration` request for that configuration have been captured, the endpoint types `Bulk`, `Isochronous` or `Interrupt` are assigned to endpoints  as specified in the active configuration. Endpoints for which we do not yet have a confirmed identification are labelled as `Unidentified`.

Eventually this will need to get more complicated, because:
- `SetInterface` requests and alternate settings also need to be handled.
- Endpoint types can change as a result of configuration and interface changes.
  - The decode loop will handle this by updating the current state as it goes.
  - The UI needs to be able to decode using the correct type at past times in the capture.
  - Changes will therefore need to be streamed out and indexed like other data.
  - At the moment the UI just accesses the current state of the hierarchy.