### PR TITLE
Fix reuse of Expander widgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,7 @@ dependencies = [
  "bufreaderwriter",
  "bytemuck",
  "bytemuck_derive",
+ "glib",
  "gtk4",
  "humansize",
  "num-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ bufreaderwriter = "0.1.2"
 bytemuck = { version = "1.8.0", features = ["extern_crate_alloc"] }
 bytemuck_derive = "1.0.1"
 gtk = { version = "*", package = "gtk4" }
+glib = "0.15.5"
 num_enum = "0.5.6"
 once_cell = "1.5"
 pcap = "0.9.1"


### PR DESCRIPTION
Closes #19.

There were two problems:

1. When reusing an Expander, it may be in the wrong state - expanded or not expanded. We need to set whether it is expanded in the bind routine.

2. Connecting the expanded signal does not remove the previous connection. We need to store the SignalHandlerId returned by the connect call, and use this in the unbind routine to disconnect the signal.

This is in draft, because I would like to find a solution that does not require unsafe blocks. Currently, the SignalHandlerId is stashed on the Expander using GObject's `set_data` method.