### PR TITLE
Add side pane showing device/configuration/interface/endpoint hierarchy.

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1607,23 +1607,6 @@ impl Capture {
                 "Endpoint {}", ep)
         }
     }
-
-    pub fn get_device_connectors(&mut self, item: &DeviceItem) -> String {
-        use DeviceItem::*;
-        format!("{}{}",
-            match item {
-                Device(..)        => "",
-                Configuration(..) => " └─",
-                Interface(..)     => "    └─",
-                Endpoint(..)      => "       └─",
-            },
-            match (item, self.device_child_count(item)) {
-                (Endpoint(..), _) => "",
-                (_,            0) => "   ",
-                (_,            _) => "",
-            }
-        )
-    }
 }
 
 #[cfg(test)]

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -472,16 +472,19 @@ impl Configuration {
                 endpoint_descriptors:
                     Vec::with_capacity(iface_desc.num_endpoints as usize),
             };
-            for _ in 0 .. iface.descriptor.num_endpoints {
+            while iface.endpoint_descriptors.len() <
+                iface.descriptor.num_endpoints as usize
+            {
                 if offset + ep_size > bytes.len() {
                     break;
                 }
                 let ep_bytes = &bytes[offset .. offset + ep_size];
                 let ep_desc =
                     pod_read_unaligned::<EndpointDescriptor>(ep_bytes);
-                offset += ep_size;
+                offset += ep_desc.length as usize;
                 if ep_desc.descriptor_type != DescriptorType::Endpoint as u8 {
-                    break;
+                    // Could be HID or other class descriptor; skip over it.
+                    continue;
                 }
                 iface.endpoint_descriptors.push(ep_desc);
             };

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -52,6 +52,14 @@ pub enum Item {
     Packet(u64, u64, u64),
 }
 
+#[derive(Clone)]
+pub enum DeviceItem {
+    Device(u64),
+    Configuration(u64, u8),
+    Interface(u64, u8, u8),
+    Endpoint(u64, u8, u8, u8)
+}
+
 bitfield! {
     #[derive(Debug)]
     pub struct SOFFields(u16);

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1534,6 +1534,24 @@ impl Capture {
             data: data,
         }
     }
+
+    pub fn get_device_item(&mut self, _parent: &Option<DeviceItem>, _index: u64)
+        -> DeviceItem
+    {
+        todo!();
+    }
+
+    pub fn device_item_count(&mut self, _parent: &Option<DeviceItem>) -> u64 {
+        todo!();
+    }
+
+    pub fn get_device_summary(&mut self, _item: &DeviceItem) -> String {
+        todo!();
+    }
+
+    pub fn get_device_connectors(&mut self, _item: &DeviceItem) -> String {
+        todo!();
+    }
 }
 
 #[cfg(test)]

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1611,7 +1611,7 @@ impl Capture {
         -> DeviceItem
     {
         match parent {
-            None => DeviceItem::Device(index),
+            None => DeviceItem::Device(index + 1),
             Some(item) => self.device_child(item, index)
         }
     }
@@ -1647,7 +1647,7 @@ impl Capture {
 
     pub fn device_item_count(&mut self, parent: &Option<DeviceItem>) -> u64 {
         match parent {
-            None => self.device_data.len() as u64,
+            None => (self.device_data.len() - 1) as u64,
             Some(item) => self.device_child_count(item),
         }
     }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1696,7 +1696,8 @@ impl Capture {
         match item {
             Device(dev) => {
                 let data = &self.device_data[*dev as usize];
-                format!("Device {}: {}", dev,
+                let device = self.devices.get(*dev).unwrap();
+                format!("Device {}: {}", device.address,
                     match data.device_descriptor {
                         Some(descriptor) => format!(
                             "{:04X}:{:04X}",

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1039,8 +1039,10 @@ impl Capture {
                         (Out, true, SETUP, OUT) |
                         (In,  true, IN,    IN ) |
                         (Out, true, OUT,   OUT) => {
-                            ep_data.payload.extend(
-                                &self.transaction_state.payload);
+                            if self.transaction_state.completed() {
+                                ep_data.payload.extend(
+                                    &self.transaction_state.payload);
+                            }
                             // Await status stage.
                             DecodeStatus::CONTINUE
                         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,11 +131,27 @@ fn main() {
         let scrolled_window = gtk::ScrolledWindow::builder()
             .hscrollbar_policy(gtk::PolicyType::Automatic) // Disable horizontal scrolling
             .min_content_height(480)
-            .min_content_width(360)
+            .min_content_width(640)
             .build();
 
         scrolled_window.set_child(Some(&listview));
-        window.set_child(Some(&scrolled_window));
+
+        let device_tree = gtk::TreeView::new();
+        let device_window = gtk::ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Automatic)
+            .min_content_height(480)
+            .min_content_width(240)
+            .child(&device_tree)
+            .build();
+
+        let paned = gtk::Paned::builder()
+            .orientation(Orientation::Horizontal)
+            .wide_handle(true)
+            .start_child(&scrolled_window)
+            .end_child(&device_window)
+            .build();
+
+        window.set_child(Some(&paned));
         window.show();
     });
     application.run_with_args::<&str>(&[]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use gtk::{
     Orientation,
 };
 use row_data::{RowData, GenericRowData};
+use model::GenericModel;
 
 mod capture;
 use capture::Capture;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use gtk::gio::ListModel;
 use gtk::{
     prelude::*,
+    ListView,
     Label,
     Expander,
     TreeListModel,
@@ -24,6 +25,83 @@ use capture::Capture;
 
 mod file_vec;
 mod hybrid_index;
+
+fn create_view(capture: &Arc<Mutex<Capture>>) -> ListView
+{
+    let cap = capture.clone();
+    let model = model::Model::new(cap, None);
+    let cap = capture.clone();
+    let tree_model = TreeListModel::new(&model, false, false, move |o| {
+        let row = o.downcast_ref::<RowData>().unwrap();
+        let parent_item = row.get_item();
+        match cap.lock().unwrap().item_count(&parent_item) {
+            0 => None,
+            _ => Some(
+                model::Model::new(cap.clone(), parent_item)
+                    .upcast::<ListModel>()
+            )
+        }
+    });
+    let selection_model = SingleSelection::new(Some(&tree_model));
+    let factory = SignalListItemFactory::new();
+    factory.connect_setup(move |_, list_item| {
+        let container = gtk::Box::new(Orientation::Horizontal, 5);
+        let conn_label = Label::new(None);
+        let text_label = Label::new(None);
+        let expander = Expander::new(None);
+        container.append(&conn_label);
+        container.append(&expander);
+        container.append(&text_label);
+        list_item.set_child(Some(&container));
+    });
+    factory.connect_bind(move |_, list_item| {
+        let treelistrow = list_item
+            .item()
+            .expect("The item has to exist.")
+            .downcast::<TreeListRow>()
+            .expect("The item has to be a TreeListRow.");
+
+        let row = treelistrow
+            .item()
+            .expect("The item has to exist.")
+            .downcast::<RowData>()
+            .expect("The item has to be RowData.");
+
+        let container = list_item
+            .child()
+            .expect("The child has to exist")
+            .downcast::<gtk::Box>()
+            .expect("The child must be a gtk::Box.");
+
+        let conn_label = container
+            .first_child()
+            .expect("The child has to exist")
+            .downcast::<Label>()
+            .expect("The child must be a Label.");
+
+        let expander = conn_label
+            .next_sibling()
+            .expect("The child has to exist")
+            .downcast::<Expander>()
+            .expect("The child must be a Expander.");
+
+        let text_label = container
+            .last_child()
+            .expect("The child has to exist")
+            .downcast::<Label>()
+            .expect("The child must be a Label.");
+
+        let conn = format!("<tt>{}</tt>", row.property::<String>("conn"));
+        let text = row.property::<String>("text");
+        conn_label.set_markup(&conn);
+        text_label.set_text(&text);
+        expander.set_visible(treelistrow.is_expandable());
+        expander.connect_expanded_notify(move |expander| {
+            treelistrow.set_expanded(expander.is_expanded());
+        });
+    });
+    ListView::new(Some(&selection_model), Some(&factory))
+}
 
 fn main() {
     let application = gtk::Application::new(
@@ -48,85 +126,7 @@ fn main() {
             .title("Packetry")
             .build();
 
-        // Create the top-level model
-        let cap = capture.clone();
-        let model = model::Model::new(cap, None);
-
-        let cap = capture.clone();
-        let treemodel = TreeListModel::new(&model, false, false, move |o| {
-            let row = o.downcast_ref::<RowData>().unwrap();
-            let parent_item = row.get_item();
-            match cap.lock().unwrap().item_count(&parent_item) {
-                0 => None,
-                _ => Some(
-                    model::Model::new(cap.clone(), parent_item)
-                        .upcast::<ListModel>()
-                )
-            }
-        });
-        let selection_model = SingleSelection::new(Some(&treemodel));
-
-        // Create factory for binding row data -> list item widgets
-        let factory = SignalListItemFactory::new();
-        factory.connect_setup(move |_, list_item| {
-            let container = gtk::Box::new(Orientation::Horizontal, 5);
-            let conn_label = Label::new(None);
-            let text_label = Label::new(None);
-            let expander = Expander::new(None);
-            container.append(&conn_label);
-            container.append(&expander);
-            container.append(&text_label);
-            list_item.set_child(Some(&container));
-        });
-        factory.connect_bind(move |_, list_item| {
-            let treelistrow = list_item
-                .item()
-                .expect("The item has to exist.")
-                .downcast::<TreeListRow>()
-                .expect("The item has to be a TreeListRow.");
-
-            let row = treelistrow
-                .item()
-                .expect("The item has to exist.")
-                .downcast::<RowData>()
-                .expect("The item has to be RowData.");
-
-            let container = list_item
-                .child()
-                .expect("The child has to exist")
-                .downcast::<gtk::Box>()
-                .expect("The child must be a gtk::Box.");
-
-            let conn_label = container
-                .first_child()
-                .expect("The child has to exist")
-                .downcast::<Label>()
-                .expect("The child must be a Label.");
-
-            let expander = conn_label
-                .next_sibling()
-                .expect("The child has to exist")
-                .downcast::<Expander>()
-                .expect("The child must be a Expander.");
-
-            let text_label = container
-                .last_child()
-                .expect("The child has to exist")
-                .downcast::<Label>()
-                .expect("The child must be a Label.");
-
-            let conn = format!("<tt>{}</tt>", row.property::<String>("conn"));
-            let text = row.property::<String>("text");
-            conn_label.set_markup(&conn);
-            text_label.set_text(&text);
-            expander.set_visible(treelistrow.is_expandable());
-            expander.connect_expanded_notify(move |expander| {
-                treelistrow.set_expanded(expander.is_expanded());
-            });
-        });
-
-        // Finally, create a view around the model/factory
-        let listview = gtk::ListView::new(Some(&selection_model), Some(&factory));
+        let listview = create_view(&capture);
 
         let scrolled_window = gtk::ScrolledWindow::builder()
             .hscrollbar_policy(gtk::PolicyType::Automatic) // Disable horizontal scrolling

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,9 @@ fn main() {
 
         scrolled_window.set_child(Some(&listview));
 
-        let device_tree = gtk::TreeView::new();
+        let device_tree = create_view::<capture::DeviceItem,
+                                        model::DeviceModel,
+                                        row_data::DeviceRowData>(&capture);
         let device_window = gtk::ScrolledWindow::builder()
             .hscrollbar_policy(gtk::PolicyType::Automatic)
             .min_content_height(480)

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use gtk::{
     SingleSelection,
     Orientation,
 };
-use row_data::RowData;
+use row_data::{RowData, GenericRowData};
 
 mod capture;
 use capture::Capture;

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -7,7 +7,7 @@ use crate::capture::{self, Capture};
 
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
-use crate::row_data::RowData;
+use crate::row_data::{RowData, GenericRowData};
 
 #[derive(Default)]
 pub struct Model {

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -7,12 +7,18 @@ use crate::capture::{self, Capture};
 
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
-use crate::row_data::{RowData, GenericRowData};
+use crate::row_data::{RowData, DeviceRowData, GenericRowData};
 
 #[derive(Default)]
 pub struct Model {
     pub(super) capture: RefCell<Arc<Mutex<Capture>>>,
     pub(super) parent: RefCell<Option<capture::Item>>,
+}
+
+#[derive(Default)]
+pub struct DeviceModel {
+    pub(super) capture: RefCell<Arc<Mutex<Capture>>>,
+    pub(super) parent: RefCell<Option<capture::DeviceItem>>,
 }
 
 /// Basic declaration of our type for the GObject type system
@@ -21,10 +27,17 @@ impl ObjectSubclass for Model {
     const NAME: &'static str = "Model";
     type Type = super::Model;
     type Interfaces = (gio::ListModel,);
+}
+#[glib::object_subclass]
+impl ObjectSubclass for DeviceModel {
+    const NAME: &'static str = "DeviceModel";
+    type Type = super::DeviceModel;
+    type Interfaces = (gio::ListModel,);
 
 }
 
 impl ObjectImpl for Model {}
+impl ObjectImpl for DeviceModel {}
 
 impl ListModelImpl for Model {
     fn item_type(&self, _list_model: &Self::Type) -> glib::Type {
@@ -40,5 +53,22 @@ impl ListModelImpl for Model {
         let summary = cap.get_summary(&item);
         let connectors = cap.get_connectors(&item);
         Some(RowData::new(Some(item), &summary, &connectors).upcast::<glib::Object>())
+    }
+}
+
+impl ListModelImpl for DeviceModel {
+    fn item_type(&self, _list_model: &Self::Type) -> glib::Type {
+        DeviceRowData::static_type()
+    }
+    fn n_items(&self, _list_model: &Self::Type) -> u32 {
+        self.capture.borrow().lock().unwrap().device_item_count(&self.parent.borrow()) as u32
+    }
+    fn item(&self, _list_model: &Self::Type, position: u32) -> Option<glib::Object> {
+        let arc = self.capture.borrow();
+        let mut cap = arc.lock().unwrap();
+        let item = cap.get_device_item(&self.parent.borrow(), position as u64);
+        let summary = cap.get_device_summary(&item);
+        let connectors = cap.get_device_connectors(&item);
+        Some(DeviceRowData::new(Some(item), &summary, &connectors).upcast::<glib::Object>())
     }
 }

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -52,7 +52,11 @@ impl ListModelImpl for Model {
         let item = cap.get_item(&self.parent.borrow(), position as u64);
         let summary = cap.get_summary(&item);
         let connectors = cap.get_connectors(&item);
-        Some(RowData::new(Some(item), &summary, &connectors).upcast::<glib::Object>())
+        let properties: &[(&str, &dyn ToValue)] = &[
+            ("text", &summary),
+            ("conn", &connectors),
+        ];
+        Some(RowData::new(Some(item), properties).upcast::<glib::Object>())
     }
 }
 
@@ -68,7 +72,9 @@ impl ListModelImpl for DeviceModel {
         let mut cap = arc.lock().unwrap();
         let item = cap.get_device_item(&self.parent.borrow(), position as u64);
         let summary = cap.get_device_summary(&item);
-        let connectors = cap.get_device_connectors(&item);
-        Some(DeviceRowData::new(Some(item), &summary, &connectors).upcast::<glib::Object>())
+        let properties: &[(&str, &dyn ToValue)] = &[
+            ("text", &summary),
+        ];
+        Some(DeviceRowData::new(Some(item), properties).upcast::<glib::Object>())
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -13,11 +13,14 @@ use crate::capture::{self, Capture};
 glib::wrapper! {
     pub struct Model(ObjectSubclass<imp::Model>) @implements gio::ListModel;
 }
+glib::wrapper! {
+    pub struct DeviceModel(ObjectSubclass<imp::DeviceModel>) @implements gio::ListModel;
+}
 
 pub trait GenericModel<Item> {
     fn new(capture: Arc<Mutex<Capture>>, parent: Option<Item>) -> Self;
     fn set_capture(&mut self, capture: Arc<Mutex<Capture>>);
-    fn set_parent(&mut self, parent: Option<capture::Item>);
+    fn set_parent(&mut self, parent: Option<Item>);
 }
 
 // Constructor for new instances. This simply calls glib::Object::new()
@@ -34,6 +37,26 @@ impl GenericModel<capture::Item> for Model {
     }
 
     fn set_parent(&mut self, parent: Option<capture::Item>) {
+        self.imp().parent.replace(parent);
+    }
+}
+
+impl GenericModel<capture::DeviceItem> for DeviceModel {
+    fn new(capture: Arc<Mutex<Capture>>, parent: Option<capture::DeviceItem>)
+        -> DeviceModel
+    {
+        let mut model: DeviceModel =
+            glib::Object::new(&[]).expect("Failed to create DeviceModel");
+        model.set_capture(capture);
+        model.set_parent(parent);
+        model
+    }
+
+    fn set_capture(&mut self, capture: Arc<Mutex<Capture>>) {
+        self.imp().capture.replace(capture);
+    }
+
+    fn set_parent(&mut self, parent: Option<capture::DeviceItem>) {
         self.imp().parent.replace(parent);
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -14,9 +14,15 @@ glib::wrapper! {
     pub struct Model(ObjectSubclass<imp::Model>) @implements gio::ListModel;
 }
 
+pub trait GenericModel<Item> {
+    fn new(capture: Arc<Mutex<Capture>>, parent: Option<Item>) -> Self;
+    fn set_capture(&mut self, capture: Arc<Mutex<Capture>>);
+    fn set_parent(&mut self, parent: Option<capture::Item>);
+}
+
 // Constructor for new instances. This simply calls glib::Object::new()
-impl Model {
-    pub fn new(capture: Arc<Mutex<Capture>>, parent: Option<capture::Item>) -> Model {
+impl GenericModel<capture::Item> for Model {
+    fn new(capture: Arc<Mutex<Capture>>, parent: Option<capture::Item>) -> Model {
         let mut model: Model = glib::Object::new(&[]).expect("Failed to create Model");
         model.set_capture(capture);
         model.set_parent(parent);

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -1,24 +1,22 @@
 use glib::subclass::prelude::*;
 use gtk::{
     glib::{self, ParamSpec, Value},
-    prelude::*,
 };
 use std::cell::RefCell;
+use std::collections::HashMap;
 use crate::capture;
 
 // The actual data structure that stores our values. This is not accessible
 // directly from the outside.
 pub struct RowData<Item> {
-    text: RefCell<Option<String>>,
-    conn: RefCell<Option<String>>,
+    values: RefCell<HashMap<&'static str, Value>>,
     pub(super) item: RefCell<Option<Item>>,
 }
 
 impl<Item> Default for RowData<Item> {
     fn default() -> Self {
         RowData::<Item> {
-            text: RefCell::new(None),
-            conn: RefCell::new(None),
+            values: RefCell::new(HashMap::new()),
             item: RefCell::new(None),
         }
     }
@@ -97,24 +95,13 @@ impl<Item> ObjectImpl for RowData<Item>
     }
 
     fn set_property(&self, _obj: &Self::Type, _id: usize, value: &Value, pspec: &ParamSpec) {
-        match pspec.name() {
-            "text" => {
-                let text = value.get().unwrap();
-                self.text.replace(text);
-            }
-            "conn" => {
-                let conn = value.get().unwrap();
-                self.conn.replace(conn);
-            }
-            _ => unimplemented!(),
-        }
+        self.values.borrow_mut().insert(pspec.name(), value.clone());
     }
 
     fn property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> Value {
-        match pspec.name() {
-            "text" => self.text.borrow().to_value(),
-            "conn" => self.conn.borrow().to_value(),
-            _ => unimplemented!(),
+        match self.values.borrow().get(pspec.name()) {
+            Some(value) => value.clone(),
+            None => panic!("Property was not set")
         }
     }
 }

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -30,6 +30,11 @@ impl ObjectSubclass for RowData<capture::Item> {
     const NAME: &'static str = "RowData";
     type Type = super::RowData;
 }
+#[glib::object_subclass]
+impl ObjectSubclass for RowData<capture::DeviceItem> {
+    const NAME: &'static str = "DeviceRowData";
+    type Type = super::DeviceRowData;
+}
 
 // The ObjectImpl trait provides the setters/getters for GObject properties.
 // Here we need to provide the values that are internally stored back to the

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -8,16 +8,25 @@ use crate::capture;
 
 // The actual data structure that stores our values. This is not accessible
 // directly from the outside.
-#[derive(Default)]
-pub struct RowData {
+pub struct RowData<Item> {
     text: RefCell<Option<String>>,
     conn: RefCell<Option<String>>,
-    pub(super) item: RefCell<Option<capture::Item>>,
+    pub(super) item: RefCell<Option<Item>>,
+}
+
+impl<Item> Default for RowData<Item> {
+    fn default() -> Self {
+        RowData::<Item> {
+            text: RefCell::new(None),
+            conn: RefCell::new(None),
+            item: RefCell::new(None),
+        }
+    }
 }
 
 // Basic declaration of our type for the GObject type system
 #[glib::object_subclass]
-impl ObjectSubclass for RowData {
+impl ObjectSubclass for RowData<capture::Item> {
     const NAME: &'static str = "RowData";
     type Type = super::RowData;
 }
@@ -28,7 +37,7 @@ impl ObjectSubclass for RowData {
 //
 // This maps between the GObject properties and our internal storage of the
 // corresponding values of the properties.
-impl ObjectImpl for RowData {
+impl<Item> ObjectImpl for RowData<Item> where RowData<Item>: ObjectSubclass {
     fn properties() -> &'static [ParamSpec] {
         use once_cell::sync::Lazy;
         static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -34,6 +34,15 @@ impl ObjectSubclass for RowData<capture::DeviceItem> {
     type Type = super::DeviceRowData;
 }
 
+fn property(name: &'static str, desc: &'static str) -> ParamSpec
+{
+    glib::ParamSpecString::new(
+        name, desc, desc,
+        None, // Default value
+        glib::ParamFlags::READWRITE,
+    )
+}
+
 pub trait Properties {
     fn get_properties() -> &'static [ParamSpec];
 }
@@ -43,20 +52,8 @@ impl Properties for RowData<capture::Item> {
         use once_cell::sync::Lazy;
         static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
             vec![
-                glib::ParamSpecString::new(
-                    "text",
-                    "Text",
-                    "Text",
-                    None, // Default value
-                    glib::ParamFlags::READWRITE,
-                ),
-                glib::ParamSpecString::new(
-                    "conn",
-                    "Connectors",
-                    "Connectors",
-                    None, // Default value
-                    glib::ParamFlags::READWRITE,
-                ),
+                property("text", "Text"),
+                property("conn", "Connectors"),
             ]
         });
         PROPERTIES.as_ref()
@@ -68,13 +65,7 @@ impl Properties for RowData<capture::DeviceItem> {
         use once_cell::sync::Lazy;
         static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
             vec![
-                glib::ParamSpecString::new(
-                    "text",
-                    "Text",
-                    "Text",
-                    None, // Default value
-                    glib::ParamFlags::READWRITE,
-                ),
+                property("text", "Text"),
             ]
         });
         PROPERTIES.as_ref()

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -77,13 +77,6 @@ impl Properties for RowData<capture::DeviceItem> {
                     None, // Default value
                     glib::ParamFlags::READWRITE,
                 ),
-                glib::ParamSpecString::new(
-                    "conn",
-                    "Connectors",
-                    "Connectors",
-                    None, // Default value
-                    glib::ParamFlags::READWRITE,
-                ),
             ]
         });
         PROPERTIES.as_ref()

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -36,14 +36,12 @@ impl ObjectSubclass for RowData<capture::DeviceItem> {
     type Type = super::DeviceRowData;
 }
 
-// The ObjectImpl trait provides the setters/getters for GObject properties.
-// Here we need to provide the values that are internally stored back to the
-// caller, or store whatever new value the caller is providing.
-//
-// This maps between the GObject properties and our internal storage of the
-// corresponding values of the properties.
-impl<Item> ObjectImpl for RowData<Item> where RowData<Item>: ObjectSubclass {
-    fn properties() -> &'static [ParamSpec] {
+pub trait Properties {
+    fn get_properties() -> &'static [ParamSpec];
+}
+
+impl Properties for RowData<capture::Item> {
+    fn get_properties() -> &'static [ParamSpec] {
         use once_cell::sync::Lazy;
         static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
             vec![
@@ -63,8 +61,46 @@ impl<Item> ObjectImpl for RowData<Item> where RowData<Item>: ObjectSubclass {
                 ),
             ]
         });
-
         PROPERTIES.as_ref()
+    }
+}
+
+impl Properties for RowData<capture::DeviceItem> {
+    fn get_properties() -> &'static [ParamSpec] {
+        use once_cell::sync::Lazy;
+        static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
+            vec![
+                glib::ParamSpecString::new(
+                    "text",
+                    "Text",
+                    "Text",
+                    None, // Default value
+                    glib::ParamFlags::READWRITE,
+                ),
+                glib::ParamSpecString::new(
+                    "conn",
+                    "Connectors",
+                    "Connectors",
+                    None, // Default value
+                    glib::ParamFlags::READWRITE,
+                ),
+            ]
+        });
+        PROPERTIES.as_ref()
+    }
+}
+
+// The ObjectImpl trait provides the setters/getters for GObject properties.
+// Here we need to provide the values that are internally stored back to the
+// caller, or store whatever new value the caller is providing.
+//
+// This maps between the GObject properties and our internal storage of the
+// corresponding values of the properties.
+impl<Item> ObjectImpl for RowData<Item>
+    where RowData<Item>: ObjectSubclass + Properties
+{
+    fn properties() -> &'static [ParamSpec] {
+        RowData::<Item>::get_properties()
     }
 
     fn set_property(&self, _obj: &Self::Type, _id: usize, value: &Value, pspec: &ParamSpec) {

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -7,6 +7,7 @@
 mod imp;
 
 use gtk::glib;
+use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use crate::capture;
 
@@ -20,7 +21,7 @@ glib::wrapper! {
 }
 
 pub trait GenericRowData<Item> {
-    fn new(item: Option<Item>, text: &str, conn: &str) -> Self;
+    fn new(item: Option<Item>, properties: &[(&str, &dyn ToValue)]) -> Self;
     fn set_item(&mut self, item: Option<Item>);
     fn get_item(&self) -> Option<Item>;
     fn child_count(&self, capture: &mut capture::Capture) -> u64;
@@ -30,12 +31,11 @@ pub trait GenericRowData<Item> {
 // Constructor for new instances. This simply calls glib::Object::new() with
 // initial values for our two properties and then returns the new instance
 impl GenericRowData<capture::Item> for RowData {
-    fn new(item: Option<capture::Item>, text: &str, conn: &str) -> RowData {
-        let mut row: RowData = glib::Object::new(
-            &[
-                ("text", &text),
-                ("conn", &conn),
-            ]).expect("Failed to create row data");
+    fn new(item: Option<capture::Item>,
+           properties: &[(&str, &dyn ToValue)]) -> RowData
+    {
+        let mut row: RowData =
+            glib::Object::new(properties).expect("Failed to create row data");
         row.set_item(item);
         row
     }
@@ -54,14 +54,11 @@ impl GenericRowData<capture::Item> for RowData {
 }
 
 impl GenericRowData<capture::DeviceItem> for DeviceRowData {
-    fn new(item: Option<capture::DeviceItem>, text: &str, conn: &str)
-        -> DeviceRowData
+    fn new(item: Option<capture::DeviceItem>,
+           properties: &[(&str, &dyn ToValue)]) -> DeviceRowData
     {
-        let mut row: DeviceRowData = glib::Object::new(
-            &[
-                ("text", &text),
-                ("conn", &conn),
-            ]).expect("Failed to create row data");
+        let mut row: DeviceRowData =
+            glib::Object::new(properties).expect("Failed to create row data");
         row.set_item(item);
         row
     }

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -16,12 +16,17 @@ glib::wrapper! {
     pub struct RowData(ObjectSubclass<imp::RowData<capture::Item>>);
 }
 
+pub trait GenericRowData<Item> {
+    fn new(item: Option<Item>, text: &str, conn: &str) -> Self;
+    fn set_item(&mut self, item: Option<Item>);
+    fn get_item(&self) -> Option<Item>;
+}
 
 
 // Constructor for new instances. This simply calls glib::Object::new() with
 // initial values for our two properties and then returns the new instance
-impl RowData {
-    pub fn new(item: Option<capture::Item>, text: &str, conn: &str) -> RowData {
+impl GenericRowData<capture::Item> for RowData {
+    fn new(item: Option<capture::Item>, text: &str, conn: &str) -> RowData {
         let mut row: RowData = glib::Object::new(
             &[
                 ("text", &text),
@@ -35,7 +40,7 @@ impl RowData {
         self.imp().item.replace(item);
     }
 
-    pub fn get_item(&self) -> Option<capture::Item> {
+    fn get_item(&self) -> Option<capture::Item> {
         self.imp().item.borrow().clone()
     }
 }

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -23,6 +23,7 @@ pub trait GenericRowData<Item> {
     fn new(item: Option<Item>, text: &str, conn: &str) -> Self;
     fn set_item(&mut self, item: Option<Item>);
     fn get_item(&self) -> Option<Item>;
+    fn child_count(&self, capture: &mut capture::Capture) -> u64;
 }
 
 
@@ -46,6 +47,10 @@ impl GenericRowData<capture::Item> for RowData {
     fn get_item(&self) -> Option<capture::Item> {
         self.imp().item.borrow().clone()
     }
+
+    fn child_count(&self, capture: &mut capture::Capture) -> u64 {
+        capture.item_count(&self.imp().item.borrow())
+    }
 }
 
 impl GenericRowData<capture::DeviceItem> for DeviceRowData {
@@ -67,5 +72,9 @@ impl GenericRowData<capture::DeviceItem> for DeviceRowData {
 
     fn get_item(&self) -> Option<capture::DeviceItem> {
         self.imp().item.borrow().clone()
+    }
+
+    fn child_count(&self, capture: &mut capture::Capture) -> u64 {
+        capture.device_item_count(&self.imp().item.borrow())
     }
 }

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -13,8 +13,10 @@ use crate::capture;
 // Public part of the RowData type. This behaves like a normal gtk-rs-style GObject
 // binding
 glib::wrapper! {
-    pub struct RowData(ObjectSubclass<imp::RowData>);
+    pub struct RowData(ObjectSubclass<imp::RowData<capture::Item>>);
 }
+
+
 
 // Constructor for new instances. This simply calls glib::Object::new() with
 // initial values for our two properties and then returns the new instance

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -15,6 +15,9 @@ use crate::capture;
 glib::wrapper! {
     pub struct RowData(ObjectSubclass<imp::RowData<capture::Item>>);
 }
+glib::wrapper! {
+    pub struct DeviceRowData(ObjectSubclass<imp::RowData<capture::DeviceItem>>);
+}
 
 pub trait GenericRowData<Item> {
     fn new(item: Option<Item>, text: &str, conn: &str) -> Self;
@@ -41,6 +44,28 @@ impl GenericRowData<capture::Item> for RowData {
     }
 
     fn get_item(&self) -> Option<capture::Item> {
+        self.imp().item.borrow().clone()
+    }
+}
+
+impl GenericRowData<capture::DeviceItem> for DeviceRowData {
+    fn new(item: Option<capture::DeviceItem>, text: &str, conn: &str)
+        -> DeviceRowData
+    {
+        let mut row: DeviceRowData = glib::Object::new(
+            &[
+                ("text", &text),
+                ("conn", &conn),
+            ]).expect("Failed to create row data");
+        row.set_item(item);
+        row
+    }
+
+    fn set_item(&mut self, item: Option<capture::DeviceItem>) {
+        self.imp().item.replace(item);
+    }
+
+    fn get_item(&self) -> Option<capture::DeviceItem> {
         self.imp().item.borrow().clone()
     }
 }


### PR DESCRIPTION
This PR stacks on #18 and #20, and adds a side pane showing the descriptor hierarchy as captured from requests seen.

![image](https://user-images.githubusercontent.com/673823/163791107-b4a7dea2-4d5a-48af-ab0b-a3d366437102.png)

I wanted to avoid duplicating all the UI and GObject boilerplate for a second ListView/TreeListModel, so I've tried to genericise and reuse that as much as possible, but there's still some repetition because of the need to have concrete types at the Rust/GObject boundary.