### PR TITLE
Error handling

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -859,9 +859,9 @@ mod tests {
                 {
                     let mut pcap = pcap::Capture::from_file(cap_path).unwrap();
                     let mut cap = Capture::new().unwrap();
-                    let mut decoder = Decoder::new(&mut cap);
+                    let mut decoder = Decoder::new(&mut cap).unwrap();
                     while let Ok(packet) = pcap.next() {
-                        decoder.handle_raw_packet(&packet);
+                        decoder.handle_raw_packet(&packet).unwrap();
                     }
                     let out_file = File::create(out_path.clone()).unwrap();
                     let mut out_writer = BufWriter::new(out_file);

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+use std::num::TryFromIntError;
 
 use crate::file_vec::{FileVec, FileVecError};
 use crate::hybrid_index::{HybridIndex, HybridIndexError};
@@ -24,6 +25,8 @@ pub enum CaptureError {
     FileVecError(#[from] FileVecError),
     #[error(transparent)]
     HybridIndexError(#[from] HybridIndexError),
+    #[error(transparent)]
+    RangeError(#[from] TryFromIntError),
     #[error("Descriptor missing")]
     DescriptorMissing,
 }
@@ -693,14 +696,14 @@ impl Capture {
                 DeviceDescriptorField(*dev, index as u8),
             Configuration(dev, conf) => match index {
                 0 => ConfigurationDescriptor(*dev, *conf),
-                n => Interface(*dev, *conf, (n - 1).try_into().unwrap()),
+                n => Interface(*dev, *conf, (n - 1).try_into()?),
             },
             ConfigurationDescriptor(dev, conf) =>
                 ConfigurationDescriptorField(*dev, *conf, index as u8),
             Interface(dev, conf, iface) => match index {
                 0 => InterfaceDescriptor(*dev, *conf, *iface),
                 n => EndpointDescriptor(*dev, *conf, *iface,
-                                        (n - 1).try_into().unwrap())
+                                        (n - 1).try_into()?)
             },
             InterfaceDescriptor(dev, conf, iface) =>
                 InterfaceDescriptorField(*dev, *conf, *iface, index as u8),

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -766,8 +766,16 @@ impl Capture {
         })
     }
 
-    fn get_device_data(&self, id: &u64) -> Result<&DeviceData, CaptureError> {
+    pub fn get_device_data(&self, id: &u64)
+        -> Result<&DeviceData, CaptureError>
+    {
         Ok(self.device_data.get(*id as usize).ok_or(IndexError)?)
+    }
+
+    pub fn get_device_data_mut(&mut self, id: &u64)
+        -> Result<&mut DeviceData, CaptureError>
+    {
+        Ok(self.device_data.get_mut(*id as usize).ok_or(IndexError)?)
     }
 
     fn device_child_count(&self, item: &DeviceItem)

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -362,7 +362,7 @@ impl Capture {
             Transaction(transfer_index_id, transaction_id) =>
                 Packet(*transfer_index_id, *transaction_id, {
                     self.transaction_index.get(*transaction_id)? + index}),
-            Packet(..) => panic!("packets do not have children"),
+            Packet(..) => return Err(IndexError)
         })
     }
 
@@ -745,7 +745,7 @@ impl Capture {
             EndpointDescriptor(dev, conf, iface, ep) =>
                  EndpointDescriptorField(*dev, *conf, *iface,
                                          *ep, index as u8),
-            _ => panic!("Item does not have children")
+            _ => return Err(IndexError)
         })
     }
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -215,7 +215,10 @@ pub fn fmt_count(count: u64) -> String {
 }
 
 pub fn fmt_size(size: u64) -> String {
-    size.file_size(options::BINARY).unwrap()
+    match size.file_size(options::BINARY) {
+        Ok(string) => string,
+        Err(e) => format!("<Error: {}>", e)
+    }
 }
 
 pub fn fmt_vec<T>(vec: &FileVec<T>) -> String

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,9 +157,9 @@ fn run() -> Result<(), PacketryError> {
     let args: Vec<_> = std::env::args().collect();
     let mut pcap = pcap::Capture::from_file(&args[1])?;
     let mut cap = Capture::new()?;
-    let mut decoder = Decoder::new(&mut cap);
+    let mut decoder = Decoder::new(&mut cap)?;
     while let Ok(packet) = pcap.next() {
-        decoder.handle_raw_packet(&packet);
+        decoder.handle_raw_packet(&packet)?;
     }
     cap.print_storage_summary();
     let capture = Arc::new(Mutex::new(cap));

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -135,19 +135,13 @@ impl ListModelImpl for Model {
     }
 
     fn n_items(&self, _list_model: &Self::Type) -> u32 {
-        match self.try_n_items() {
-            Ok(count) => count,
-            Err(_) => 0
-        }
+        self.try_n_items().unwrap_or(0)
     }
 
     fn item(&self, _list_model: &Self::Type, position: u32)
         -> Option<glib::Object>
     {
-        match self.try_item(position) {
-            Ok(item) => item,
-            Err(_) => None
-        }
+        self.try_item(position).unwrap_or(None)
     }
 }
 
@@ -157,18 +151,12 @@ impl ListModelImpl for DeviceModel {
     }
 
     fn n_items(&self, _list_model: &Self::Type) -> u32 {
-        match self.try_n_items() {
-            Ok(count) => count,
-            Err(_) => 0
-        }
+        self.try_n_items().unwrap_or(0)
     }
 
     fn item(&self, _list_model: &Self::Type, position: u32)
         -> Option<glib::Object>
     {
-        match self.try_item(position) {
-            Ok(item) => item,
-            Err(_) => None
-        }
+        self.try_item(position).unwrap_or(None)
     }
 }

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -3,21 +3,23 @@
 use gio::subclass::prelude::*;
 use gtk::{gio, glib, prelude::*};
 
-use crate::capture::{self, Capture};
+use crate::capture::{self, Capture, CaptureError};
 
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 use crate::row_data::{RowData, DeviceRowData};
 
+use thiserror::Error;
+
 #[derive(Default)]
 pub struct Model {
-    pub(super) capture: RefCell<Arc<Mutex<Capture>>>,
+    pub(super) capture: RefCell<Option<Arc<Mutex<Capture>>>>,
     pub(super) parent: RefCell<Option<capture::Item>>,
 }
 
 #[derive(Default)]
 pub struct DeviceModel {
-    pub(super) capture: RefCell<Arc<Mutex<Capture>>>,
+    pub(super) capture: RefCell<Option<Arc<Mutex<Capture>>>>,
     pub(super) parent: RefCell<Option<capture::DeviceItem>>,
 }
 
@@ -36,6 +38,94 @@ impl ObjectSubclass for DeviceModel {
 
 }
 
+#[derive(Error, Debug)]
+pub enum ModelError {
+    #[error(transparent)]
+    CaptureError(#[from] CaptureError),
+    #[error("Capture not set")]
+    CaptureNotSet,
+    #[error("Locking capture failed")]
+    LockError,
+}
+
+impl Model {
+    fn try_n_items(&self)
+        -> Result<u32, ModelError>
+    {
+        let opt = self.capture.borrow();
+        let mut cap = match opt.as_ref() {
+            Some(mutex) => match mutex.lock() {
+                Ok(guard) => guard,
+                Err(_) => return Err(ModelError::LockError)
+            },
+            None => return Err(ModelError::CaptureNotSet)
+        };
+        Ok(cap.item_count(&self.parent.borrow())? as u32)
+    }
+
+    fn try_item(&self, position: u32)
+        -> Result<Option<glib::Object>, ModelError>
+    {
+        let opt = self.capture.borrow();
+        let mut cap = match opt.as_ref() {
+            Some(mutex) => match mutex.lock() {
+                Ok(guard) => guard,
+                Err(_) => return Err(ModelError::LockError)
+            },
+            None => return Err(ModelError::CaptureNotSet)
+        };
+        let item = cap.get_item(&self.parent.borrow(),
+                                position as u64)?;
+        let summary = match cap.get_summary(&item) {
+            Ok(string) => string,
+            Err(e) => format!("Error: {:?}", e)
+        };
+        let connectors = match cap.get_connectors(&item) {
+            Ok(string) => string,
+            Err(e) => format!("Error: {:?}", e)
+        };
+        Ok(Some(RowData::new(Some(item), summary, connectors)
+                        .upcast::<glib::Object>()))
+    }
+}
+
+impl DeviceModel {
+    fn try_n_items(&self)
+        -> Result<u32, ModelError>
+    {
+        let opt = self.capture.borrow();
+        let mut cap = match opt.as_ref() {
+            Some(mutex) => match mutex.lock() {
+                Ok(guard) => guard,
+                Err(_) => return Err(ModelError::LockError)
+            },
+            None => return Err(ModelError::CaptureNotSet)
+        };
+        Ok(cap.device_item_count(&self.parent.borrow())? as u32)
+    }
+
+    fn try_item(&self, position: u32)
+        -> Result<Option<glib::Object>, ModelError>
+    {
+        let opt = self.capture.borrow();
+        let mut cap = match opt.as_ref() {
+            Some(mutex) => match mutex.lock() {
+                Ok(guard) => guard,
+                Err(_) => return Err(ModelError::LockError)
+            },
+            None => return Err(ModelError::CaptureNotSet)
+        };
+        let item = cap.get_device_item(&self.parent.borrow(),
+                                       position as u64)?;
+        let summary = match cap.get_device_summary(&item) {
+            Ok(string) => string,
+            Err(e) => format!("Error: {:?}", e)
+        };
+        Ok(Some(DeviceRowData::new(Some(item), summary)
+                              .upcast::<glib::Object>()))
+    }
+}
+
 impl ObjectImpl for Model {}
 impl ObjectImpl for DeviceModel {}
 
@@ -43,16 +133,21 @@ impl ListModelImpl for Model {
     fn item_type(&self, _list_model: &Self::Type) -> glib::Type {
         RowData::static_type()
     }
+
     fn n_items(&self, _list_model: &Self::Type) -> u32 {
-        self.capture.borrow().lock().unwrap().item_count(&self.parent.borrow()) as u32
+        match self.try_n_items() {
+            Ok(count) => count,
+            Err(_) => 0
+        }
     }
-    fn item(&self, _list_model: &Self::Type, position: u32) -> Option<glib::Object> {
-        let arc = self.capture.borrow();
-        let mut cap = arc.lock().unwrap();
-        let item = cap.get_item(&self.parent.borrow(), position as u64);
-        let summary = cap.get_summary(&item);
-        let connectors = cap.get_connectors(&item);
-        Some(RowData::new(Some(item), summary, connectors).upcast::<glib::Object>())
+
+    fn item(&self, _list_model: &Self::Type, position: u32)
+        -> Option<glib::Object>
+    {
+        match self.try_item(position) {
+            Ok(item) => item,
+            Err(_) => None
+        }
     }
 }
 
@@ -60,14 +155,20 @@ impl ListModelImpl for DeviceModel {
     fn item_type(&self, _list_model: &Self::Type) -> glib::Type {
         DeviceRowData::static_type()
     }
+
     fn n_items(&self, _list_model: &Self::Type) -> u32 {
-        self.capture.borrow().lock().unwrap().device_item_count(&self.parent.borrow()) as u32
+        match self.try_n_items() {
+            Ok(count) => count,
+            Err(_) => 0
+        }
     }
-    fn item(&self, _list_model: &Self::Type, position: u32) -> Option<glib::Object> {
-        let arc = self.capture.borrow();
-        let mut cap = arc.lock().unwrap();
-        let item = cap.get_device_item(&self.parent.borrow(), position as u64);
-        let summary = cap.get_device_summary(&item);
-        Some(DeviceRowData::new(Some(item), summary).upcast::<glib::Object>())
+
+    fn item(&self, _list_model: &Self::Type, position: u32)
+        -> Option<glib::Object>
+    {
+        match self.try_item(position) {
+            Ok(item) => item,
+            Err(_) => None
+        }
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -33,7 +33,7 @@ impl GenericModel<capture::Item> for Model {
     }
 
     fn set_capture(&mut self, capture: Arc<Mutex<Capture>>) {
-        self.imp().capture.replace(capture);
+        self.imp().capture.replace(Some(capture));
     }
 
     fn set_parent(&mut self, parent: Option<capture::Item>) {
@@ -53,7 +53,7 @@ impl GenericModel<capture::DeviceItem> for DeviceModel {
     }
 
     fn set_capture(&mut self, capture: Arc<Mutex<Capture>>) {
-        self.imp().capture.replace(capture);
+        self.imp().capture.replace(Some(capture));
     }
 
     fn set_parent(&mut self, parent: Option<capture::DeviceItem>) {

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -65,7 +65,8 @@ impl DeviceRowData {
 pub trait GenericRowData<Item> {
     const CONNECTORS: bool;
     fn get_item(&self) -> Option<Item>;
-    fn child_count(&self, capture: &mut capture::Capture) -> u64;
+    fn child_count(&self, capture: &mut capture::Capture)
+        -> Result<u64, capture::CaptureError>;
     fn get_summary(&self) -> String;
     fn get_connectors(&self) -> Option<String>;
 }
@@ -77,7 +78,9 @@ impl GenericRowData<capture::Item> for RowData {
         self.imp().item.borrow().clone()
     }
 
-    fn child_count(&self, capture: &mut capture::Capture) -> u64 {
+    fn child_count(&self, capture: &mut capture::Capture)
+        -> Result<u64, capture::CaptureError>
+    {
         capture.item_count(&self.imp().item.borrow())
     }
 
@@ -97,7 +100,9 @@ impl GenericRowData<capture::DeviceItem> for DeviceRowData {
         self.imp().item.borrow().clone()
     }
 
-    fn child_count(&self, capture: &mut capture::Capture) -> u64 {
+    fn child_count(&self, capture: &mut capture::Capture)
+        -> Result<u64, capture::CaptureError>
+    {
         capture.device_item_count(&self.imp().item.borrow())
     }
 

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -320,7 +320,7 @@ impl DeviceDescriptor {
                       fmt_str_id(strings, self.product_str_id)),
         12 => format!("Serial string: {}",
                       fmt_str_id(strings, self.serial_str_id)),
-        _ => panic!("Invalid field ID")
+        i  => format!("Error: Invalid field ID {}", i)
         }
     }
 }
@@ -352,7 +352,7 @@ impl ConfigDescriptor {
                       fmt_str_id(strings, self.config_str_id)),
         6 => format!("Attributes: 0x{:02X}", self.attributes),
         7 => format!("Max power: {}mA", self.max_power as u16 * 2),
-        _ => panic!("Invalid field ID")
+        i => format!("Error: Invalid field ID {}", i)
         }
     }
 }
@@ -385,7 +385,7 @@ impl InterfaceDescriptor {
         7 => format!("Protocol: 0x{:02X}", self.interface_protocol),
         8 => format!("Interface string: {}",
                       fmt_str_id(strings, self.interface_str_id)),
-        _ => panic!("Invalid field ID")
+        i => format!("Error: Invalid field ID {}", i)
         }
     }
 }
@@ -412,7 +412,7 @@ impl EndpointDescriptor {
         4 => format!("Max packet size: {} bytes", {
             let size: u16 = self.max_packet_size; size }),
         5 => format!("Interval: 0x{:02X}", self.interval),
-        _ => panic!("Invalid field ID")
+        i => format!("Error: Invalid field ID {}", i)
         }
     }
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -131,6 +131,7 @@ impl RequestTypeFields {
     pub fn direction(&self) -> Direction { Direction::from(self._direction()) }
 }
 
+#[derive(Copy, Clone)]
 pub struct SetupFields {
     pub type_fields: RequestTypeFields,
     pub request: u8,


### PR DESCRIPTION
This replaces #28 and does `Result`-based error handling everywhere. Most methods on `Capture` and `Decoder` now return a `Result<_, CaptureError>`. All uses of `unwrap` outside of tests have been removed.

Since the code makes heavy use of complicated indexing schemes, another likely source of panics was out-of-bound accesses to arrays. So I have made all array access use the `get` and `get_mut` methods, returning an `IndexError` if out-of-bounds. I have made a few exceptions to this where very obviously safe.

The error handling currently effectively stops at the Rust/GObject boundary. Where possible, errors are passed on to the UI, e.g. an error in `get_summary` results in the error text appearing where the summary would go. In other cases however the APIs involved do not allow an easy solution - e.g. the `ListModel` implementation can only return `None` for an item, or `0` for a count. We could potentially figure out ways around this to get an error into a dialog, but since we're going to move more of the model code into Rust I think it will be easier to tackle this later.

There are still some remaining uses of `expect` in GLib/GTK related code. Provided the UI code is sound however, the idea is that it should no longer be possible for it to be forced to crash by a panic in the capture & decoding side - although I may well have missed ways in which this can still happen.