### PR TITLE
Further improvements to types and Rust usage in capture & decoder modules

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -125,6 +125,9 @@ pub enum EndpointState {
     Ending = 3,
 }
 
+pub const INVALID_EP_NUM: u8 = 0x10;
+pub const FRAMING_EP_NUM: u8 = 0x11;
+
 #[derive(Copy, Clone, Debug)]
 pub enum EndpointType {
     Unidentified,
@@ -177,10 +180,10 @@ impl DeviceData {
     pub fn endpoint_type(&self, number: EndpointNum) -> EndpointType {
         use EndpointType::*;
         match number.0 {
+            INVALID_EP_NUM => Invalid,
+            FRAMING_EP_NUM => Framing,
             0 => Normal(usb::EndpointType::Control),
-            0x10 => Framing,
-            0x11 => Invalid,
-            _ => match self.endpoint_types.get(number.0 as usize) {
+            n => match self.endpoint_types.get(n as usize) {
                 Some(ep_type) => *ep_type,
                 None => Unidentified
             }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -23,6 +23,7 @@ use crate::usb::{
     InterfaceField,
     EndpointNum,
     EndpointField,
+    UTF16ByteVec,
 };
 
 use bytemuck_derive::{Pod, Zeroable};
@@ -155,7 +156,7 @@ pub struct DeviceData {
     pub configurations: Vec<Option<Configuration>>,
     pub config_number: Option<ConfigNum>,
     pub endpoint_types: Vec<EndpointType>,
-    pub strings: Vec<Option<Vec<u8>>>,
+    pub strings: Vec<Option<UTF16ByteVec>>,
 }
 
 impl DeviceData {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -223,20 +223,6 @@ impl Interface {
     }
 }
 
-pub struct Capture {
-    pub item_index: HybridIndex<TransferId>,
-    pub packet_index: HybridIndex<PacketByteId>,
-    pub packet_data: FileVec<u8>,
-    pub transaction_index: HybridIndex<PacketId>,
-    pub transfer_index: FileVec<TransferIndexEntry>,
-    pub devices: FileVec<Device>,
-    pub device_data: VecMap<DeviceId, DeviceData>,
-    pub endpoints: FileVec<Endpoint>,
-    pub endpoint_traffic: VecMap<EndpointId, EndpointTraffic>,
-    pub endpoint_states: FileVec<u8>,
-    pub endpoint_state_index: HybridIndex<Id<u8>>,
-}
-
 pub struct Transaction {
     pid: PID,
     packet_id_range: Range<PacketId>,
@@ -279,14 +265,28 @@ pub fn fmt_index<T>(idx: &HybridIndex<T>) -> String
             fmt_size(idx.size()))
 }
 
+pub struct Capture {
+    pub packet_data: FileVec<u8>,
+    pub packet_index: HybridIndex<PacketByteId>,
+    pub transaction_index: HybridIndex<PacketId>,
+    pub transfer_index: FileVec<TransferIndexEntry>,
+    pub item_index: HybridIndex<TransferId>,
+    pub devices: FileVec<Device>,
+    pub device_data: VecMap<DeviceId, DeviceData>,
+    pub endpoints: FileVec<Endpoint>,
+    pub endpoint_traffic: VecMap<EndpointId, EndpointTraffic>,
+    pub endpoint_states: FileVec<u8>,
+    pub endpoint_state_index: HybridIndex<Id<u8>>,
+}
+
 impl Capture {
     pub fn new() -> Result<Self, CaptureError> {
         Ok(Capture {
-            item_index: HybridIndex::new(1)?,
-            packet_index: HybridIndex::new(2)?,
             packet_data: FileVec::new()?,
+            packet_index: HybridIndex::new(2)?,
             transaction_index: HybridIndex::new(1)?,
             transfer_index: FileVec::new()?,
+            item_index: HybridIndex::new(1)?,
             devices: FileVec::new()?,
             device_data: VecMap::new(),
             endpoints: FileVec::new()?,

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -650,9 +650,8 @@ impl ItemSource<TrafficItem> for Capture {
         use EndpointState::*;
         use TrafficItem::*;
         let endpoint_count = self.endpoints.len() as usize;
-        const MIN_LEN: usize = " └─".len();
-        let string_length = MIN_LEN + endpoint_count;
-        let mut connectors = String::with_capacity(string_length);
+        let max_string_length = endpoint_count + "    └──".len();
+        let mut connectors = String::with_capacity(max_string_length);
         let transfer_id = match item {
             Transfer(i) | Transaction(i, _) | Packet(i, ..) => *i
         };

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -189,8 +189,8 @@ impl DeviceData {
             if let Some(Some(config)) = &self.configurations.get(idx) {
                 for iface in &config.interfaces {
                     for ep_desc in &iface.endpoint_descriptors {
-                        let number = ep_desc.endpoint_address & 0x0F;
-                        let index = number as usize;
+                        let ep_number = ep_desc.endpoint_address.number();
+                        let index = ep_number.0 as usize;
                         if let Some(ep_type) =
                             self.endpoint_types.get_mut(index)
                         {
@@ -905,10 +905,8 @@ impl ItemSource<DeviceItem> for Capture {
                 let config = data.get_configuration(conf)?;
                 let iface = config.get_interface(iface)?;
                 let desc = iface.get_endpoint_descriptor(ep)?;
-                format!("Endpoint {} {}",
-                    desc.endpoint_address & 0x7F,
-                    if desc.endpoint_address & 0x80 != 0 {"IN"} else {"OUT"}
-                )
+                let addr = desc.endpoint_address;
+                format!("Endpoint {} {}", addr.number(), addr.direction())
             },
             EndpointDescriptorField(dev, conf, iface, ep, field) => {
                 let data = self.get_device_data(dev)?;

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -230,9 +230,9 @@ pub struct Capture {
     pub transaction_index: HybridIndex<PacketId>,
     pub transfer_index: FileVec<TransferIndexEntry>,
     pub devices: FileVec<Device>,
-    pub device_data: Vec<DeviceData>,
+    pub device_data: VecMap<DeviceId, DeviceData>,
     pub endpoints: FileVec<Endpoint>,
-    pub endpoint_traffic: Vec<EndpointTraffic>,
+    pub endpoint_traffic: VecMap<EndpointId, EndpointTraffic>,
     pub endpoint_states: FileVec<u8>,
     pub endpoint_state_index: HybridIndex<Id<u8>>,
 }
@@ -308,9 +308,9 @@ impl Capture {
             transaction_index: HybridIndex::new(1)?,
             transfer_index: FileVec::new()?,
             devices: FileVec::new()?,
-            device_data: Vec::new(),
+            device_data: VecMap::new(),
             endpoints: FileVec::new()?,
-            endpoint_traffic: Vec::new(),
+            endpoint_traffic: VecMap::new(),
             endpoint_states: FileVec::new()?,
             endpoint_state_index: HybridIndex::new(1)?,
         })
@@ -366,8 +366,7 @@ impl Capture {
     pub fn endpoint_traffic(&mut self, endpoint_id: EndpointId)
         -> Result<&mut EndpointTraffic, CaptureError>
     {
-        let idx = endpoint_id.value as usize;
-        self.endpoint_traffic.get_mut(idx).ok_or(IndexError)
+        self.endpoint_traffic.get_mut(endpoint_id).ok_or(IndexError)
     }
 
     fn transfer_range(&mut self, entry: &TransferIndexEntry)
@@ -479,13 +478,13 @@ impl Capture {
     pub fn get_device_data(&self, id: &DeviceId)
         -> Result<&DeviceData, CaptureError>
     {
-        self.device_data.get(id.value as usize).ok_or(IndexError)
+        self.device_data.get(*id).ok_or(IndexError)
     }
 
     pub fn get_device_data_mut(&mut self, id: &DeviceId)
         -> Result<&mut DeviceData, CaptureError>
     {
-        self.device_data.get_mut(id.value as usize).ok_or(IndexError)
+        self.device_data.get_mut(*id).ok_or(IndexError)
     }
 
     pub fn try_get_configuration(&self, dev: &DeviceId, conf: &ConfigNum)

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -5,28 +5,7 @@ use crate::id::{Id, HasLength};
 use crate::file_vec::{FileVec, FileVecError};
 use crate::hybrid_index::{HybridIndex, HybridIndexError, Number};
 use crate::vec_map::VecMap;
-use crate::usb::{
-    self,
-    PID,
-    PacketFields,
-    SetupFields,
-    Direction,
-    DeviceDescriptor,
-    Configuration,
-    Interface,
-    EndpointDescriptor,
-    ControlTransfer,
-    DeviceAddr,
-    DeviceField,
-    StringId,
-    ConfigNum,
-    ConfigField,
-    InterfaceNum,
-    InterfaceField,
-    EndpointNum,
-    EndpointField,
-    UTF16ByteVec,
-};
+use crate::usb::{self, prelude::*};
 
 use bytemuck_derive::{Pod, Zeroable};
 use num_enum::{IntoPrimitive, FromPrimitive};
@@ -981,4 +960,22 @@ mod tests {
             }
         }
     }
+}
+
+pub mod prelude {
+    pub use super::{
+        Capture,
+        CaptureError,
+        Device,
+        DeviceId,
+        DeviceData,
+        Endpoint,
+        EndpointId,
+        EndpointType,
+        EndpointState,
+        EndpointTraffic,
+        EndpointTransactionId,
+        PacketId,
+        TransferIndexEntry,
+    };
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -973,9 +973,13 @@ pub mod prelude {
         EndpointId,
         EndpointType,
         EndpointState,
+        EndpointStateId,
         EndpointTraffic,
         EndpointTransactionId,
+        EndpointTransferId,
         PacketId,
+        TransactionId,
+        TransferId,
         TransferIndexEntry,
     };
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -299,19 +299,19 @@ impl<'cap> Decoder<'cap> {
         Ok(endpoint_id)
     }
 
-    fn current_endpoint_data(&self)
-        -> Result<&EndpointData, CaptureError>
-    {
-        let endpoint_id = self.transaction_state.endpoint_id
-                                                .ok_or(IndexError)?;
+    fn current_endpoint_id(&self) -> Result<EndpointId, CaptureError> {
+        self.transaction_state.endpoint_id.ok_or(IndexError)
+    }
+
+    fn current_endpoint_data(&self) -> Result<&EndpointData, CaptureError> {
+        let endpoint_id = self.current_endpoint_id()?;
         self.endpoint_data.get(endpoint_id).ok_or(IndexError)
     }
 
     fn current_endpoint_data_mut(&mut self)
         -> Result<&mut EndpointData, CaptureError>
     {
-        let endpoint_id = self.transaction_state.endpoint_id
-                                                .ok_or(IndexError)?;
+        let endpoint_id = self.current_endpoint_id()?;
         self.endpoint_data.get_mut(endpoint_id).ok_or(IndexError)
     }
 
@@ -522,8 +522,7 @@ impl<'cap> Decoder<'cap> {
                       success: bool)
         -> Result<(), CaptureError>
     {
-        let endpoint_id = self.transaction_state.endpoint_id
-                                                .ok_or(IndexError)?;
+        let endpoint_id = self.current_endpoint_id()?;
         let ep_data = self.endpoint_data.get_mut(endpoint_id)
                                         .ok_or(IndexError)?;
         let ep_traf = self.capture.endpoint_traffic.get_mut(endpoint_id)
@@ -546,8 +545,7 @@ impl<'cap> Decoder<'cap> {
                        success: bool)
         -> Result<(), CaptureError>
     {
-        let endpoint_id = self.transaction_state.endpoint_id
-                                                .ok_or(IndexError)?;
+        let endpoint_id = self.current_endpoint_id()?;
         let ep_traf = self.capture.endpoint_traffic.get_mut(endpoint_id)
                                                    .ok_or(IndexError)?;
         ep_traf.transaction_ids.push(transaction_id)?;
@@ -563,8 +561,7 @@ impl<'cap> Decoder<'cap> {
     fn transfer_end(&mut self)
         -> Result<(), CaptureError>
     {
-        let endpoint_id = self.transaction_state.endpoint_id
-                                                .ok_or(IndexError)?;
+        let endpoint_id = self.current_endpoint_id()?;
         let ep_data = self.current_endpoint_data()?;
         if ep_data.transaction_count > 0 {
             let transfer_end_id =

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -345,7 +345,7 @@ impl<'cap> Decoder<'cap> {
         -> Result<&DeviceData, CaptureError>
     {
         let ep_data = self.current_endpoint_data()?;
-        self.capture.get_device_data(&ep_data.device_id)
+        self.capture.device_data(&ep_data.device_id)
     }
 
     fn current_device_data_mut(&mut self)
@@ -353,7 +353,7 @@ impl<'cap> Decoder<'cap> {
     {
         let ep_data = self.current_endpoint_data()?;
         let device_id = ep_data.device_id;
-        self.capture.get_device_data_mut(&device_id)
+        self.capture.device_data_mut(&device_id)
     }
 
     fn decode_request(&mut self, fields: SetupFields)

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,44 +1,7 @@
 use std::mem::size_of;
 
-use crate::usb::{
-    self,
-    PID,
-    PacketFields,
-    TokenFields,
-    SetupFields,
-    Direction,
-    StandardRequest,
-    RequestType,
-    Recipient,
-    DescriptorType,
-    DeviceDescriptor,
-    ConfigDescriptor,
-    Configuration,
-    DeviceAddr,
-    ConfigNum,
-    EndpointNum,
-    StringId,
-    UTF16ByteVec,
-};
-
-use crate::capture::{
-    Capture,
-    CaptureError,
-    Device,
-    DeviceId,
-    DeviceData,
-    Endpoint,
-    EndpointId,
-    EndpointType,
-    EndpointState,
-    EndpointTraffic,
-    EndpointTransactionId,
-    PacketId,
-    TransferIndexEntry,
-    INVALID_EP_NUM,
-    FRAMING_EP_NUM,
-};
-
+use crate::usb::{self, prelude::*};
+use crate::capture::{prelude::*, INVALID_EP_NUM, FRAMING_EP_NUM};
 use crate::hybrid_index::HybridIndex;
 use crate::vec_map::{VecMap, Key};
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -16,6 +16,7 @@ use crate::usb::{
     DeviceAddr,
     ConfigNum,
     EndpointNum,
+    UTF16ByteVec,
 };
 
 use crate::capture::{
@@ -391,7 +392,7 @@ impl<'cap> Decoder<'cap> {
             },
             (Recipient::Device, DescriptorType::String) => {
                 if length >= 2 {
-                    let string = payload[2..length].to_vec();
+                    let string = UTF16ByteVec(payload[2..length].to_vec());
                     let dev_data = self.current_device_data_mut()?;
                     let strings = &mut dev_data.strings;
                     let string_id = (fields.value & 0xFF) as usize;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -32,6 +32,8 @@ use crate::capture::{
     EndpointTransactionId,
     PacketId,
     TransferIndexEntry,
+    INVALID_EP_NUM,
+    FRAMING_EP_NUM,
 };
 
 use crate::hybrid_index::HybridIndex;
@@ -157,8 +159,8 @@ impl<'cap> Decoder<'cap> {
             last_item_endpoint: None,
             transaction_state: TransactionState::default(),
         };
-        decoder.add_endpoint(DeviceAddr(0), EndpointNum(0x11))?;
-        decoder.add_endpoint(DeviceAddr(0), EndpointNum(0x10))?;
+        decoder.add_endpoint(DeviceAddr(0), EndpointNum(INVALID_EP_NUM))?;
+        decoder.add_endpoint(DeviceAddr(0), EndpointNum(FRAMING_EP_NUM))?;
         Ok(decoder)
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -118,6 +118,13 @@ impl Key for EndpointKey {
     fn id(self) -> usize {
         self.dev_addr.0 as usize * 16 + self.ep_num.0 as usize
     }
+
+    fn key(id: usize) -> EndpointKey {
+        EndpointKey {
+            dev_addr: DeviceAddr((id / 16) as u8),
+            ep_num: EndpointNum((id % 16) as u8),
+        }
+    }
 }
 
 pub struct Decoder<'cap> {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -155,7 +155,7 @@ pub struct Decoder<'cap> {
     capture: &'cap mut Capture,
     device_index: VecMap<DeviceAddr, DeviceId>,
     endpoint_index: VecMap<EndpointKey, EndpointId>,
-    endpoint_data: Vec<EndpointData>,
+    endpoint_data: VecMap<EndpointId, EndpointData>,
     last_endpoint_state: Vec<u8>,
     last_item_endpoint: Option<EndpointId>,
     transaction_state: TransactionState,
@@ -167,7 +167,7 @@ impl<'cap> Decoder<'cap> {
             capture,
             device_index: VecMap::new(),
             endpoint_index: VecMap::new(),
-            endpoint_data: Vec::new(),
+            endpoint_data: VecMap::new(),
             last_endpoint_state: Vec::new(),
             last_item_endpoint: None,
             transaction_state: TransactionState::default(),
@@ -330,8 +330,7 @@ impl<'cap> Decoder<'cap> {
     {
         let endpoint_id = self.transaction_state.endpoint_id
                                                 .ok_or(IndexError)?;
-        self.endpoint_data.get(endpoint_id.value as usize)
-                          .ok_or(IndexError)
+        self.endpoint_data.get(endpoint_id).ok_or(IndexError)
     }
 
     fn current_endpoint_data_mut(&mut self)
@@ -339,8 +338,7 @@ impl<'cap> Decoder<'cap> {
     {
         let endpoint_id = self.transaction_state.endpoint_id
                                                 .ok_or(IndexError)?;
-        self.endpoint_data.get_mut(endpoint_id.value as usize)
-                          .ok_or(IndexError)
+        self.endpoint_data.get_mut(endpoint_id).ok_or(IndexError)
     }
 
     fn current_device_data(&self)
@@ -557,10 +555,10 @@ impl<'cap> Decoder<'cap> {
         self.last_item_endpoint = Some(endpoint_id);
         self.add_transfer_entry(endpoint_id, true)?;
         let ep_data =
-            self.endpoint_data.get_mut(endpoint_id.value as usize)
+            self.endpoint_data.get_mut(endpoint_id)
                               .ok_or(IndexError)?;
         let ep_traf =
-            self.capture.endpoint_traffic.get_mut(endpoint_id.value as usize)
+            self.capture.endpoint_traffic.get_mut(endpoint_id)
                                          .ok_or(IndexError)?;
         ep_data.transaction_start = ep_traf.transaction_ids.next_id();
         ep_data.transaction_count = 0;
@@ -572,8 +570,7 @@ impl<'cap> Decoder<'cap> {
         -> Result<(), CaptureError>
     {
         let endpoint_id = self.transaction_state.endpoint_id
-                                                .ok_or(IndexError)?
-                                                .value as usize;
+                                                .ok_or(IndexError)?;
         let ep_data = self.endpoint_data.get_mut(endpoint_id)
                                         .ok_or(IndexError)?;
         let ep_traf = self.capture.endpoint_traffic.get_mut(endpoint_id)

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -525,8 +525,7 @@ impl<'cap> Decoder<'cap> {
         let endpoint_id = self.current_endpoint_id()?;
         let ep_data = self.endpoint_data.get_mut(endpoint_id)
                                         .ok_or(IndexError)?;
-        let ep_traf = self.capture.endpoint_traffic.get_mut(endpoint_id)
-                                                   .ok_or(IndexError)?;
+        let ep_traf = self.capture.endpoint_traffic(endpoint_id)?;
         let ep_transaction_id = ep_traf.transaction_ids.push(transaction_id)?;
         ep_data.transaction_count = 1;
         if success {
@@ -546,8 +545,7 @@ impl<'cap> Decoder<'cap> {
         -> Result<(), CaptureError>
     {
         let endpoint_id = self.current_endpoint_id()?;
-        let ep_traf = self.capture.endpoint_traffic.get_mut(endpoint_id)
-                                                   .ok_or(IndexError)?;
+        let ep_traf = self.capture.endpoint_traffic(endpoint_id)?;
         ep_traf.transaction_ids.push(transaction_id)?;
         let ep_data = self.endpoint_data.get_mut(endpoint_id)
                                         .ok_or(IndexError)?;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -153,6 +153,9 @@ impl<'cap> Decoder<'cap> {
         Ok(decoder)
     }
 
+    const INVALID_EP_ID: EndpointId = EndpointId::constant(0);
+    const FRAMING_EP_ID: EndpointId = EndpointId::constant(1);
+
     pub fn handle_raw_packet(&mut self, packet: &[u8])
         -> Result<(), CaptureError>
     {
@@ -214,9 +217,9 @@ impl<'cap> Decoder<'cap> {
         state.last = state.first;
         self.transaction_state.endpoint_id = Some(
             match PacketFields::from_packet(packet) {
-                PacketFields::SOF(_) => EndpointId::from(1),
+                PacketFields::SOF(_) => Decoder::FRAMING_EP_ID,
                 PacketFields::Token(token) => self.token_endpoint(&token)?,
-                _ => EndpointId::from(0)
+                _ => Decoder::INVALID_EP_ID,
             }
         );
         Ok(())

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -148,8 +148,12 @@ impl<'cap> Decoder<'cap> {
             last_item_endpoint: None,
             transaction_state: TransactionState::default(),
         };
-        decoder.add_endpoint(DeviceAddr(0), EndpointNum(INVALID_EP_NUM))?;
-        decoder.add_endpoint(DeviceAddr(0), EndpointNum(FRAMING_EP_NUM))?;
+        let invalid_id =
+            decoder.add_endpoint(DeviceAddr(0), EndpointNum(INVALID_EP_NUM))?;
+        let framing_id =
+            decoder.add_endpoint(DeviceAddr(0), EndpointNum(FRAMING_EP_NUM))?;
+        assert!(invalid_id == Decoder::INVALID_EP_ID);
+        assert!(framing_id == Decoder::FRAMING_EP_ID);
         Ok(decoder)
     }
 

--- a/src/file_vec.rs
+++ b/src/file_vec.rs
@@ -35,22 +35,28 @@ impl<T: Pod + Default> FileVec<T> {
         })
     }
 
-    pub fn push(&mut self, item: &T) -> Result<(), FileVecError> where T: Pod {
+    pub fn push(&mut self, item: &T)
+       -> Result<Id<T>, FileVecError> where T: Pod
+    {
         let data= bytes_of(item);
         self.file.write_all(data)?;
         self.file_length += data.len() as u64;
+        let id = Id::<T>::from(self.item_count);
         self.item_count += 1;
-        Ok(())
+        Ok(id)
     }
 
-    pub fn append(&mut self, items: &[T]) -> Result<(), FileVecError> where T: Pod {
+    pub fn append(&mut self, items: &[T])
+       -> Result<Id<T>, FileVecError> where T: Pod
+    {
         for item in items {
             let data = bytes_of(item);
             self.file.write_all(data)?;
             self.file_length += data.len() as u64;
         }
+        let id = Id::<T>::from(self.item_count);
         self.item_count += items.len() as u64;
-        Ok(())
+        Ok(id)
     }
 
     pub fn get(&mut self, id: Id<T>) -> Result<T, FileVecError> {

--- a/src/file_vec.rs
+++ b/src/file_vec.rs
@@ -82,10 +82,6 @@ impl<T: Pod + Default> FileVec<T> {
         Ok(result)
     }
 
-    pub fn next_id(&self) -> Id<T> {
-       Id::<T>::from(self.item_count)
-    }
-
     pub fn len(&self) -> u64 {
         self.item_count
     }

--- a/src/hybrid_index.rs
+++ b/src/hybrid_index.rs
@@ -183,10 +183,6 @@ impl<T: Number + Copy> HybridIndex<T> {
         })
     }
 
-    pub fn next_id(&self) -> Id<T> {
-        Id::<T>::from(self.total_count)
-    }
-
     pub fn len(&self) -> u64 {
         self.total_count
     }

--- a/src/hybrid_index.rs
+++ b/src/hybrid_index.rs
@@ -68,7 +68,8 @@ impl<T: Number + Copy> HybridIndex<T> {
         })
     }
 
-    pub fn push(&mut self, id: T) -> Result<(), HybridIndexError> {
+    pub fn push(&mut self, id: T) -> Result<Id<T>, HybridIndexError>
+    {
         if self.entries.is_empty() {
             let first_entry = Entry {
                 base_value: id.to_u64(),
@@ -104,9 +105,10 @@ impl<T: Number + Copy> HybridIndex<T> {
                 last_entry.increments.set_count(count + 1);
             }
         }
+        let new_id = Id::<T>::from(self.total_count);
         self.total_count += 1;
         self.last_value = id.to_u64();
-        Ok(())
+        Ok(new_id)
     }
 
     pub fn get(&mut self, id: Id<T>) -> Result<T, HybridIndexError> {

--- a/src/hybrid_index.rs
+++ b/src/hybrid_index.rs
@@ -165,7 +165,7 @@ impl<T: Number + Copy> HybridIndex<T> {
         Ok(result)
     }
 
-    pub fn get_target_range(&mut self, id: Id<T>, target_length: u64)
+    pub fn target_range(&mut self, id: Id<T>, target_length: u64)
         -> Result<Range<T>, HybridIndexError>
     {
         Ok(if id.value + 2 > self.len() {

--- a/src/id.rs
+++ b/src/id.rs
@@ -60,3 +60,12 @@ impl<T> From<Id<T>> for u64 {
       id.value
    }
 }
+
+impl<T> Id<T> {
+   pub const fn constant(i: u64) -> Self {
+      Id::<T> {
+         _marker: PhantomData,
+         value: i
+      }
+   }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod id;
 mod file_vec;
 mod hybrid_index;
 mod usb;
+mod vec_map;
 
 fn create_view<Item: 'static, Model, RowData>(capture: &Arc<Mutex<Capture>>)
         -> ListView

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -54,6 +54,11 @@ pub struct DeviceField(pub u8);
 #[derive(Copy, Clone, Debug, PartialEq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
+pub struct StringId(pub u8);
+
+#[derive(Copy, Clone, Debug, PartialEq, Default,
+         Pod, Zeroable, From, Into, Display)]
+#[repr(transparent)]
 pub struct ConfigNum(pub u8);
 
 #[derive(Copy, Clone, Debug, PartialEq, Default,
@@ -363,9 +368,9 @@ pub struct DeviceDescriptor {
     pub vendor_id: u16,
     pub product_id: u16,
     pub device_version: u16,
-    pub manufacturer_str_id: u8,
-    pub product_str_id: u8,
-    pub serial_str_id: u8,
+    pub manufacturer_str_id: StringId,
+    pub product_str_id: StringId,
+    pub serial_str_id: StringId,
     pub num_configurations: u8
 }
 
@@ -412,7 +417,7 @@ pub struct ConfigDescriptor {
     pub total_length: u16,
     pub num_interfaces: u8,
     pub config_value: u8,
-    pub config_str_id: u8,
+    pub config_str_id: StringId,
     pub attributes: u8,
     pub max_power: u8
 }
@@ -451,7 +456,7 @@ pub struct InterfaceDescriptor {
     pub interface_class: u8,
     pub interface_subclass: u8,
     pub interface_protocol: u8,
-    pub interface_str_id: u8,
+    pub interface_str_id: StringId,
 }
 
 #[allow(clippy::useless_format)]
@@ -642,10 +647,10 @@ impl ControlTransfer {
     }
 }
 
-fn fmt_str_id(strings: &[Option<Vec<u8>>], id: u8) -> String {
-    match id {
+fn fmt_str_id(strings: &[Option<Vec<u8>>], id: StringId) -> String {
+    match id.0 {
         0 => "(none)".to_string(),
-        _ => match &strings[id as usize] {
+        n => match &strings[n as usize] {
             Some(bytes) => format!("#{} {}", id, fmt_utf16(bytes)),
             None => format!("#{} (not seen)", id)
         }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -753,3 +753,34 @@ mod tests {
         }
     }
 }
+
+pub mod prelude {
+    pub use super::{
+        PID,
+        PacketFields,
+        TokenFields,
+        SetupFields,
+        Direction,
+        StandardRequest,
+        RequestType,
+        Recipient,
+        DescriptorType,
+        DeviceDescriptor,
+        ConfigDescriptor,
+        InterfaceDescriptor,
+        EndpointDescriptor,
+        Configuration,
+        Interface,
+        ControlTransfer,
+        DeviceAddr,
+        DeviceField,
+        StringId,
+        ConfigNum,
+        ConfigField,
+        InterfaceNum,
+        InterfaceField,
+        EndpointNum,
+        EndpointField,
+        UTF16ByteVec,
+    };
+}

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -100,6 +100,27 @@ impl EndpointAddr {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Default,
+         Pod, Zeroable, From, Into, Display)]
+#[repr(transparent)]
+pub struct EndpointAttr(pub u8);
+
+impl EndpointAttr {
+    pub fn endpoint_type(&self) -> EndpointType {
+        EndpointType::from(self.0 & 0x03)
+    }
+}
+
+#[derive(Copy, Clone, Debug, FromPrimitive)]
+#[repr(u8)]
+pub enum EndpointType {
+    #[default]
+    Control     = 0,
+    Isochronous = 1,
+    Bulk        = 2,
+    Interrupt   = 3,
+}
+
 bitfield! {
     #[derive(Debug)]
     pub struct SOFFields(u16);
@@ -462,7 +483,7 @@ pub struct EndpointDescriptor {
     pub length: u8,
     pub descriptor_type: u8,
     pub endpoint_address: EndpointAddr,
-    pub attributes: u8,
+    pub attributes: EndpointAttr,
     pub max_packet_size: u16,
     pub interval: u8,
 }
@@ -474,7 +495,7 @@ impl EndpointDescriptor {
         0 => format!("Length: {} bytes", self.length),
         1 => format!("Type: 0x{:02X}", self.descriptor_type),
         2 => format!("Endpoint address: 0x{:02X}", self.endpoint_address.0),
-        3 => format!("Attributes: 0x{:02X}", self.attributes),
+        3 => format!("Attributes: 0x{:02X}", self.attributes.0),
         4 => format!("Max packet size: {} bytes", {
             let size: u16 = self.max_packet_size; size }),
         5 => format!("Interval: 0x{:02X}", self.interval),

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -126,6 +126,19 @@ pub enum EndpointType {
     Interrupt   = 3,
 }
 
+#[derive(Copy, Clone, Debug, Default, Pod, Zeroable)]
+#[repr(C)]
+pub struct BCDVersion {
+    pub minor: u8,
+    pub major: u8,
+}
+
+impl std::fmt::Display for BCDVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:X}.{:02X}", self.major, self.minor)
+    }
+}
+
 bitfield! {
     #[derive(Debug)]
     pub struct SOFFields(u16);
@@ -360,14 +373,14 @@ impl StandardFeature {
 pub struct DeviceDescriptor {
     pub length: u8,
     pub descriptor_type: u8,
-    pub usb: u16,
+    pub usb_version: BCDVersion,
     pub device_class: u8,
     pub device_subclass: u8,
     pub device_protocol: u8,
     pub max_packet_size_0: u8,
     pub vendor_id: u16,
     pub product_id: u16,
-    pub device_version: u16,
+    pub device_version: BCDVersion,
     pub manufacturer_str_id: StringId,
     pub product_str_id: StringId,
     pub serial_str_id: StringId,
@@ -386,16 +399,14 @@ impl DeviceDescriptor {
         match id.0 {
         0  => format!("Length: {} bytes", self.length),
         1  => format!("Type: 0x{:02X}", self.descriptor_type),
-        2  => format!("USB Version: {:X}.{:02X}",
-                      self.usb >> 8, self.usb & 0xFF),
+        2  => format!("USB Version: {}", self.usb_version),
         3  => format!("Class: 0x{:02X}", self.device_class),
         4  => format!("Subclass: 0x{:02X}", self.device_subclass),
         5  => format!("Protocol: 0x{:02X}", self.device_protocol),
         6  => format!("Max EP0 packet size: {} bytes", self.max_packet_size_0),
         7  => format!("Vendor ID: 0x{:04X}", self.vendor_id),
         8  => format!("Product ID: 0x{:04X}", self.product_id),
-        9  => format!("Version: {:X}.{:02X}",
-                      self.device_version >> 8, self.device_version & 0xFF),
+        9  => format!("Version: {}", self.device_version),
         10 => format!("Manufacturer string: {}",
                       fmt_str_id(strings, self.manufacturer_str_id)),
         11 => format!("Product string: {}",

--- a/src/vec_map.rs
+++ b/src/vec_map.rs
@@ -6,6 +6,8 @@ use crate::id::Id;
 
 pub trait Key {
     fn id(self) -> usize;
+
+    fn key(id: usize) -> Self;
 }
 
 pub struct VecMap<K, V> where K: Key {
@@ -32,8 +34,9 @@ impl<K, V> VecMap<K, V> where K: Key {
         self.vec.len()
     }
 
-    pub fn push(&mut self, value: V) {
-        self.vec.push(Some(value))
+    pub fn push(&mut self, value: V) -> K {
+        self.vec.push(Some(value));
+        K::key(self.vec.len())
     }
 
     pub fn get(&self, index: K) -> Option<&V> {
@@ -65,15 +68,23 @@ impl<K, V> Default for VecMap<K, V> where K: Key {
     }
 }
 
-impl<T> Key for T where T: Into<u8> {
+impl<T> Key for T where T: From<u8> + Into<u8> {
     fn id(self) -> usize {
         self.into() as usize
+    }
+
+    fn key(id: usize) -> T {
+        T::from(id.try_into().unwrap())
     }
 }
 
 impl<T> Key for Id<T> {
     fn id(self) -> usize {
         self.value as usize
+    }
+
+    fn key(id: usize) -> Id<T> {
+        Id::<T>::from(id as u64)
     }
 }
 

--- a/src/vec_map.rs
+++ b/src/vec_map.rs
@@ -1,0 +1,66 @@
+use std::marker::PhantomData;
+use std::iter::FilterMap;
+use std::slice::Iter;
+
+pub struct VecMap<K, V> {
+    _marker: PhantomData<K>,
+    vec: Vec<Option<V>>,
+}
+
+impl<K, V> VecMap<K, V> {
+    pub fn new() -> Self {
+        VecMap::<K, V> {
+            _marker: PhantomData,
+            vec: Vec::new(),
+        }
+    }
+
+    pub fn with_capacity(size: u8) -> Self {
+        VecMap::<K, V> {
+            _marker: PhantomData,
+            vec: Vec::with_capacity(size as usize),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    pub fn push(&mut self, value: V) {
+        self.vec.push(Some(value))
+    }
+}
+
+impl<K, V> VecMap<K, V> where K: Into<u8> {
+    pub fn get(&self, index: K) -> Option<&V> {
+        match self.vec.get(index.into() as usize) {
+            Some(opt) => opt.as_ref(),
+            None => None
+        }
+    }
+
+    pub fn get_mut(&mut self, index: K) -> Option<&mut V> {
+        match self.vec.get_mut(index.into() as usize) {
+            Some(opt) => opt.as_mut(),
+            None => None
+        }
+    }
+
+    pub fn set(&mut self, index: K, value: V) {
+        let index = index.into() as usize;
+        if index >= self.vec.len() {
+            self.vec.resize_with(index + 1, || {None})
+        }
+        self.vec[index] = Some(value);
+    }
+}
+
+impl<'v, K, V> IntoIterator for &'v VecMap<K, V> {
+    type Item = &'v V;
+    type IntoIter =
+        FilterMap<Iter<'v, Option<V>>, fn(&Option<V>) -> Option<&V>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.iter().filter_map(Option::<V>::as_ref)
+    }
+}

--- a/src/vec_map.rs
+++ b/src/vec_map.rs
@@ -2,6 +2,8 @@ use std::marker::PhantomData;
 use std::iter::FilterMap;
 use std::slice::Iter;
 
+use crate::id::Id;
+
 pub trait Key {
     fn id(self) -> usize;
 }
@@ -66,6 +68,12 @@ impl<K, V> Default for VecMap<K, V> where K: Key {
 impl<T> Key for T where T: Into<u8> {
     fn id(self) -> usize {
         self.into() as usize
+    }
+}
+
+impl<T> Key for Id<T> {
+    fn id(self) -> usize {
+        self.value as usize
     }
 }
 

--- a/src/vec_map.rs
+++ b/src/vec_map.rs
@@ -57,12 +57,19 @@ impl<K, V> VecMap<K, V> where K: Key {
     }
 }
 
+impl<K, V> Default for VecMap<K, V> where K: Key {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> Key for T where T: Into<u8> {
     fn id(self) -> usize {
         self.into() as usize
     }
 }
 
+#[allow(clippy::type_complexity)]
 impl<'v, K, V> IntoIterator for &'v VecMap<K, V> where K: Key {
     type Item = &'v V;
     type IntoIter =


### PR DESCRIPTION
This PR builds on the work in #33. The common theme is to make better use of the Rust type system in order to streamline the code in the `capture` & `decoder` modules and, more generally, to write better Rust.

The main changes include:

- Add further types to the `usb` module to encapsulate more conversion and formatting details. These include `EndpointAddr`, `EndpointType`, `StringId`, `BCDVersion`, `UTF16Bytes` and `UTF16ByteVec`.

- Add a `VecMap<K, V>` type to use in place of `Vec`. This has two key properties:
  - Indices can be of a specific newtype, converted to `usize` internally. This removes a lot of `x as usize` conversions in the code.
  - Items can be inserted at a specific index, with the underlying `Vec<Option<V>>` being enlarged as necessary. This removes several places where we were doing this by hand.

- Prevent the decoder from peeking ahead at what the ID of a stream item will be. Instead, return an ID only when an item is pushed out to the stream. This enforces the property that no item can be referred to by ID from another stream, before it has been output itself. Several parts of the decoder were not keeping to this rule and have been refactored accordingly.

- Rename methods in line with Rust API guidelines, in particular eliminating a lot of `get_` prefixes.

- Add preludes to the `usb` and `capture` modules to avoid lengthy import lists.