### PR TITLE
Integrated version of tree model work

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -58,14 +58,14 @@ pub type DeviceId = Id<Device>;
 pub type EndpointId = Id<Endpoint>;
 pub type EndpointStateId = Id<Id<u8>>;
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub enum TrafficItem {
     Transfer(TransferId),
     Transaction(TransferId, TransactionId),
     Packet(TransferId, TransactionId, PacketId),
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub enum DeviceItem {
     Device(DeviceId),
     DeviceDescriptor(DeviceId),

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -373,40 +373,6 @@ impl Capture {
         self.endpoint_traffic.get_mut(idx).ok_or(IndexError)
     }
 
-    pub fn get_item(&mut self, parent: &Option<TrafficItem>, index: u64)
-        -> Result<TrafficItem, CaptureError>
-    {
-        match parent {
-            None => {
-                let item_id = TrafficItemId::from(index);
-                let transfer_id = self.item_index.get(item_id)?;
-                Ok(TrafficItem::Transfer(transfer_id))
-            },
-            Some(item) => self.get_child(item, index)
-        }
-    }
-
-    pub fn get_child(&mut self, parent: &TrafficItem, index: u64)
-        -> Result<TrafficItem, CaptureError>
-    {
-        use TrafficItem::*;
-        Ok(match parent {
-            Transfer(transfer_id) =>
-                Transaction(*transfer_id, {
-                    let entry = self.transfer_index.get(*transfer_id)?;
-                    let endpoint_id = entry.endpoint_id();
-                    let ep_transfer_id = entry.transfer_id();
-                    let ep_traf = self.endpoint_traffic(endpoint_id)?;
-                    let offset = ep_traf.transfer_index.get(ep_transfer_id)?;
-                    ep_traf.transaction_ids.get(offset + index)?
-                }),
-            Transaction(transfer_id, transaction_id) =>
-                Packet(*transfer_id, *transaction_id, {
-                    self.transaction_index.get(*transaction_id)? + index}),
-            Packet(..) => return Err(IndexError)
-        })
-    }
-
     fn transfer_range(&mut self, entry: &TransferIndexEntry)
         -> Result<Range<EndpointTransactionId>, CaptureError>
     {
@@ -415,228 +381,6 @@ impl Capture {
         let ep_traf = self.endpoint_traffic(endpoint_id)?;
         get_index_range(&mut ep_traf.transfer_index,
                         ep_traf.transaction_ids.len(), ep_transfer_id)
-    }
-
-    pub fn item_count(&mut self, parent: &Option<TrafficItem>)
-        -> Result<u64, CaptureError>
-    {
-        match parent {
-            None => Ok(self.item_index.len()),
-            Some(item) => self.child_count(item)
-        }
-    }
-
-    pub fn child_count(&mut self, parent: &TrafficItem)
-        -> Result<u64, CaptureError>
-    {
-        use TrafficItem::*;
-        Ok(match parent {
-            Transfer(transfer_id) => {
-                let entry = self.transfer_index.get(*transfer_id)?;
-                if entry.is_start() {
-                    self.transfer_range(&entry)?.len()
-                } else {
-                    0
-                }
-            },
-            Transaction(_, transaction_id) => {
-                get_index_range(&mut self.transaction_index,
-                    self.packet_index.len(), *transaction_id)?.len()
-            },
-            Packet(..) => 0,
-        })
-    }
-
-    pub fn get_summary(&mut self, item: &TrafficItem)
-        -> Result<String, CaptureError>
-    {
-        use TrafficItem::*;
-        Ok(match item {
-            Packet(.., packet_id) => {
-                let packet = self.get_packet(*packet_id)?;
-                let pid = PID::from(*packet.get(0).ok_or(IndexError)?);
-                format!("{} packet{}: {:02X?}",
-                    pid,
-                    match PacketFields::from_packet(&packet) {
-                        PacketFields::SOF(sof) => format!(
-                            " with frame number {}, CRC {:02X}",
-                            sof.frame_number(),
-                            sof.crc()),
-                        PacketFields::Token(token) => format!(
-                            " on {}.{}, CRC {:02X}",
-                            token.device_address(),
-                            token.endpoint_number(),
-                            token.crc()),
-                        PacketFields::Data(data) => format!(
-                            " with {} data bytes and CRC {:04X}",
-                            packet.len() - 3,
-                            data.crc),
-                        PacketFields::None => "".to_string()
-                    },
-                    packet)
-            },
-            Transaction(_, transaction_id) => {
-                let transaction = self.get_transaction(*transaction_id)?;
-                let count = transaction.packet_count();
-                match (transaction.pid, transaction.payload_size()) {
-                    (PID::SOF, _) => format!(
-                        "{} SOF packets", count),
-                    (pid, None) => format!(
-                        "{} transaction, {} packets", pid, count),
-                    (pid, Some(size)) => format!(
-                        "{} transaction, {} packets with {} data bytes",
-                        pid, count, size)
-                }
-            },
-            Transfer(transfer_id) => {
-                let entry = self.transfer_index.get(*transfer_id)?;
-                let endpoint_id = entry.endpoint_id();
-                let endpoint = self.endpoints.get(endpoint_id)?;
-                let device_id = endpoint.device_id();
-                let dev_data = &self.get_device_data(&device_id)?;
-                let num = endpoint.number();
-                let ep_type = dev_data.endpoint_type(num);
-                if !entry.is_start() {
-                    return Ok(match ep_type {
-                        EndpointType::Invalid =>
-                            "End of invalid groups".to_string(),
-                        EndpointType::Framing =>
-                            "End of SOF groups".to_string(),
-                        endpoint_type => format!(
-                            "{:?} transfer ending on endpoint {}.{}",
-                            endpoint_type, endpoint.device_address(), num)
-                    })
-                }
-                let range = self.transfer_range(&entry)?;
-                let count = range.len();
-                match ep_type {
-                    EndpointType::Invalid => format!(
-                        "{} invalid groups", count),
-                    EndpointType::Framing => format!(
-                        "{} SOF groups", count),
-                    EndpointType::Control => {
-                        let transfer = self.get_control_transfer(
-                            endpoint.device_address(), endpoint_id, range)?;
-                        transfer.summary()
-                    },
-                    endpoint_type => format!(
-                        "{:?} transfer with {} transactions on endpoint {}.{}",
-                        endpoint_type, count,
-                        endpoint.device_address(), endpoint.number())
-                }
-            }
-        })
-    }
-
-    pub fn get_connectors(&mut self, item: &TrafficItem)
-        -> Result<String, CaptureError>
-    {
-        use EndpointState::*;
-        use TrafficItem::*;
-        let endpoint_count = self.endpoints.len() as usize;
-        const MIN_LEN: usize = " └─".len();
-        let string_length = MIN_LEN + endpoint_count;
-        let mut connectors = String::with_capacity(string_length);
-        let transfer_id = match item {
-            Transfer(i) | Transaction(i, _) | Packet(i, ..) => *i
-        };
-        let entry = self.transfer_index.get(transfer_id)?;
-        let endpoint_id = entry.endpoint_id();
-        let endpoint_state = self.get_endpoint_state(transfer_id)?;
-        let extended = self.transfer_extended(endpoint_id, transfer_id)?;
-        let ep_traf = self.endpoint_traffic(endpoint_id)?;
-        let last_transaction = match item {
-            Transaction(_, transaction_id) | Packet(_, transaction_id, _) => {
-                let range = get_index_range(&mut ep_traf.transfer_index,
-                    ep_traf.transaction_ids.len(), entry.transfer_id())?;
-                let last_transaction_id =
-                    ep_traf.transaction_ids.get(range.end - 1)?;
-                *transaction_id == last_transaction_id
-            }, _ => false
-        };
-        let last_packet = match item {
-            Packet(_, transaction_id, packet_id) => {
-                let range = get_index_range(&mut self.transaction_index,
-                    self.packet_index.len(), *transaction_id)?;
-                *packet_id == range.end - 1
-            }, _ => false
-        };
-        let last = last_transaction && !extended;
-        let mut thru = false;
-        for (i, &state) in endpoint_state.iter().enumerate() {
-            let state = EndpointState::from(state);
-            let active = state != Idle;
-            let on_endpoint = i == endpoint_id.value as usize;
-            thru |= match (item, state, on_endpoint) {
-                (Transfer(..), Starting | Ending, _) => true,
-                (Transaction(..) | Packet(..), _, true) => on_endpoint,
-                _ => false,
-            };
-            connectors.push(match item {
-                Transfer(..) => {
-                    match (state, thru) {
-                        (Idle,     _    ) => ' ',
-                        (Starting, _    ) => '○',
-                        (Ongoing,  false) => '│',
-                        (Ongoing,  true ) => '┼',
-                        (Ending,   _    ) => '└',
-                    }
-                },
-                Transaction(..) => {
-                    match (on_endpoint, active, thru, last) {
-                        (false, false, false, _    ) => ' ',
-                        (false, false, true,  _    ) => '─',
-                        (false, true,  false, _    ) => '│',
-                        (false, true,  true,  _    ) => '┼',
-                        (true,  _,     _,     false) => '├',
-                        (true,  _,     _,     true ) => '└',
-                    }
-                },
-                Packet(..) => {
-                    match (on_endpoint, active, last) {
-                        (false, false, _    ) => ' ',
-                        (false, true,  _    ) => '│',
-                        (true,  _,     false) => '│',
-                        (true,  _,     true ) => ' ',
-                    }
-                }
-            });
-        };
-        let state_length = endpoint_state.len();
-        for _ in state_length..endpoint_count {
-            connectors.push(match item {
-                Transfer(..)    => '─',
-                Transaction(..) => '─',
-                Packet(..)      => ' ',
-            });
-        }
-        connectors.push_str(
-            match (item, last_packet) {
-                (Transfer(_), _) if entry.is_start() => "─",
-                (Transfer(_), _)                     => "──□ ",
-                (Transaction(..), _)                 => "───",
-                (Packet(..), false)                  => "    ├──",
-                (Packet(..), true)                   => "    └──",
-            }
-        );
-        Ok(connectors)
-    }
-
-    fn transfer_extended(&mut self,
-                         endpoint_id: EndpointId,
-                         transfer_id: TransferId)
-        -> Result<bool, CaptureError>
-    {
-        use EndpointState::*;
-        let count = self.transfer_index.len();
-        if transfer_id.value + 1 >= count {
-            return Ok(false);
-        };
-        let state = self.get_endpoint_state(transfer_id + 1)?;
-        Ok(match state.get(endpoint_id.value as usize) {
-            Some(ep_state) => EndpointState::from(*ep_state) == Ongoing,
-            None => false
-        })
     }
 
     fn get_endpoint_state(&mut self, transfer_id: TransferId)
@@ -735,20 +479,301 @@ impl Capture {
         })
     }
 
-    pub fn get_device_item(&mut self, parent: &Option<DeviceItem>, index: u64)
+    pub fn get_device_data(&self, id: &DeviceId)
+        -> Result<&DeviceData, CaptureError>
+    {
+        self.device_data.get(id.value as usize).ok_or(IndexError)
+    }
+
+    pub fn get_device_data_mut(&mut self, id: &DeviceId)
+        -> Result<&mut DeviceData, CaptureError>
+    {
+        self.device_data.get_mut(id.value as usize).ok_or(IndexError)
+    }
+
+    fn transfer_extended(&mut self,
+                         endpoint_id: EndpointId,
+                         transfer_id: TransferId)
+        -> Result<bool, CaptureError>
+    {
+        use EndpointState::*;
+        let count = self.transfer_index.len();
+        if transfer_id.value + 1 >= count {
+            return Ok(false);
+        };
+        let state = self.get_endpoint_state(transfer_id + 1)?;
+        Ok(match state.get(endpoint_id.value as usize) {
+            Some(ep_state) => EndpointState::from(*ep_state) == Ongoing,
+            None => false
+        })
+    }
+}
+
+pub trait ItemSource<Item> {
+    fn item(&mut self, parent: &Option<Item>, index: u64) -> Result<Item, CaptureError>;
+    fn child_item(&mut self, parent: &Item, index: u64) -> Result<Item, CaptureError>;
+    fn item_count(&mut self, parent: &Option<Item>) -> Result<u64, CaptureError>;
+    fn child_count(&mut self, parent: &Item) -> Result<u64, CaptureError>;
+    fn summary(&mut self, item: &Item) -> Result<String, CaptureError>;
+    fn connectors(&mut self, item: &Item) -> Result<String, CaptureError>;
+}
+
+impl ItemSource<TrafficItem> for Capture {
+    fn item(&mut self, parent: &Option<TrafficItem>, index: u64)
+        -> Result<TrafficItem, CaptureError>
+    {
+        match parent {
+            None => {
+                let item_id = TrafficItemId::from(index);
+                let transfer_id = self.item_index.get(item_id)?;
+                Ok(TrafficItem::Transfer(transfer_id))
+            },
+            Some(item) => self.child_item(item, index)
+        }
+    }
+
+    fn child_item(&mut self, parent: &TrafficItem, index: u64)
+        -> Result<TrafficItem, CaptureError>
+    {
+        use TrafficItem::*;
+        Ok(match parent {
+            Transfer(transfer_id) =>
+                Transaction(*transfer_id, {
+                    let entry = self.transfer_index.get(*transfer_id)?;
+                    let endpoint_id = entry.endpoint_id();
+                    let ep_transfer_id = entry.transfer_id();
+                    let ep_traf = self.endpoint_traffic(endpoint_id)?;
+                    let offset = ep_traf.transfer_index.get(ep_transfer_id)?;
+                    ep_traf.transaction_ids.get(offset + index)?
+                }),
+            Transaction(transfer_id, transaction_id) =>
+                Packet(*transfer_id, *transaction_id, {
+                    self.transaction_index.get(*transaction_id)? + index}),
+            Packet(..) => return Err(IndexError)
+        })
+    }
+
+    fn item_count(&mut self, parent: &Option<TrafficItem>)
+        -> Result<u64, CaptureError>
+    {
+        match parent {
+            None => Ok(self.item_index.len()),
+            Some(item) => self.child_count(item)
+        }
+    }
+
+    fn child_count(&mut self, parent: &TrafficItem)
+        -> Result<u64, CaptureError>
+    {
+        use TrafficItem::*;
+        Ok(match parent {
+            Transfer(transfer_id) => {
+                let entry = self.transfer_index.get(*transfer_id)?;
+                if entry.is_start() {
+                    self.transfer_range(&entry)?.len()
+                } else {
+                    0
+                }
+            },
+            Transaction(_, transaction_id) => {
+                get_index_range(&mut self.transaction_index,
+                    self.packet_index.len(), *transaction_id)?.len()
+            },
+            Packet(..) => 0,
+        })
+    }
+
+    fn summary(&mut self, item: &TrafficItem)
+        -> Result<String, CaptureError>
+    {
+        use TrafficItem::*;
+        Ok(match item {
+            Packet(.., packet_id) => {
+                let packet = self.get_packet(*packet_id)?;
+                let pid = PID::from(*packet.get(0).ok_or(IndexError)?);
+                format!("{} packet{}: {:02X?}",
+                    pid,
+                    match PacketFields::from_packet(&packet) {
+                        PacketFields::SOF(sof) => format!(
+                            " with frame number {}, CRC {:02X}",
+                            sof.frame_number(),
+                            sof.crc()),
+                        PacketFields::Token(token) => format!(
+                            " on {}.{}, CRC {:02X}",
+                            token.device_address(),
+                            token.endpoint_number(),
+                            token.crc()),
+                        PacketFields::Data(data) => format!(
+                            " with {} data bytes and CRC {:04X}",
+                            packet.len() - 3,
+                            data.crc),
+                        PacketFields::None => "".to_string()
+                    },
+                    packet)
+            },
+            Transaction(_, transaction_id) => {
+                let transaction = self.get_transaction(*transaction_id)?;
+                let count = transaction.packet_count();
+                match (transaction.pid, transaction.payload_size()) {
+                    (PID::SOF, _) => format!(
+                        "{} SOF packets", count),
+                    (pid, None) => format!(
+                        "{} transaction, {} packets", pid, count),
+                    (pid, Some(size)) => format!(
+                        "{} transaction, {} packets with {} data bytes",
+                        pid, count, size)
+                }
+            },
+            Transfer(transfer_id) => {
+                let entry = self.transfer_index.get(*transfer_id)?;
+                let endpoint_id = entry.endpoint_id();
+                let endpoint = self.endpoints.get(endpoint_id)?;
+                let device_id = endpoint.device_id();
+                let dev_data = &self.get_device_data(&device_id)?;
+                let num = endpoint.number();
+                let ep_type = dev_data.endpoint_type(num);
+                if !entry.is_start() {
+                    return Ok(match ep_type {
+                        EndpointType::Invalid =>
+                            "End of invalid groups".to_string(),
+                        EndpointType::Framing =>
+                            "End of SOF groups".to_string(),
+                        endpoint_type => format!(
+                            "{:?} transfer ending on endpoint {}.{}",
+                            endpoint_type, endpoint.device_address(), num)
+                    })
+                }
+                let range = self.transfer_range(&entry)?;
+                let count = range.len();
+                match ep_type {
+                    EndpointType::Invalid => format!(
+                        "{} invalid groups", count),
+                    EndpointType::Framing => format!(
+                        "{} SOF groups", count),
+                    EndpointType::Control => {
+                        let transfer = self.get_control_transfer(
+                            endpoint.device_address(), endpoint_id, range)?;
+                        transfer.summary()
+                    },
+                    endpoint_type => format!(
+                        "{:?} transfer with {} transactions on endpoint {}.{}",
+                        endpoint_type, count,
+                        endpoint.device_address(), endpoint.number())
+                }
+            }
+        })
+    }
+
+    fn connectors(&mut self, item: &TrafficItem)
+        -> Result<String, CaptureError>
+    {
+        use EndpointState::*;
+        use TrafficItem::*;
+        let endpoint_count = self.endpoints.len() as usize;
+        const MIN_LEN: usize = " └─".len();
+        let string_length = MIN_LEN + endpoint_count;
+        let mut connectors = String::with_capacity(string_length);
+        let transfer_id = match item {
+            Transfer(i) | Transaction(i, _) | Packet(i, ..) => *i
+        };
+        let entry = self.transfer_index.get(transfer_id)?;
+        let endpoint_id = entry.endpoint_id();
+        let endpoint_state = self.get_endpoint_state(transfer_id)?;
+        let extended = self.transfer_extended(endpoint_id, transfer_id)?;
+        let ep_traf = self.endpoint_traffic(endpoint_id)?;
+        let last_transaction = match item {
+            Transaction(_, transaction_id) | Packet(_, transaction_id, _) => {
+                let range = get_index_range(&mut ep_traf.transfer_index,
+                    ep_traf.transaction_ids.len(), entry.transfer_id())?;
+                let last_transaction_id =
+                    ep_traf.transaction_ids.get(range.end - 1)?;
+                *transaction_id == last_transaction_id
+            }, _ => false
+        };
+        let last_packet = match item {
+            Packet(_, transaction_id, packet_id) => {
+                let range = get_index_range(&mut self.transaction_index,
+                    self.packet_index.len(), *transaction_id)?;
+                *packet_id == range.end - 1
+            }, _ => false
+        };
+        let last = last_transaction && !extended;
+        let mut thru = false;
+        for (i, &state) in endpoint_state.iter().enumerate() {
+            let state = EndpointState::from(state);
+            let active = state != Idle;
+            let on_endpoint = i == endpoint_id.value as usize;
+            thru |= match (item, state, on_endpoint) {
+                (Transfer(..), Starting | Ending, _) => true,
+                (Transaction(..) | Packet(..), _, true) => on_endpoint,
+                _ => false,
+            };
+            connectors.push(match item {
+                Transfer(..) => {
+                    match (state, thru) {
+                        (Idle,     _    ) => ' ',
+                        (Starting, _    ) => '○',
+                        (Ongoing,  false) => '│',
+                        (Ongoing,  true ) => '┼',
+                        (Ending,   _    ) => '└',
+                    }
+                },
+                Transaction(..) => {
+                    match (on_endpoint, active, thru, last) {
+                        (false, false, false, _    ) => ' ',
+                        (false, false, true,  _    ) => '─',
+                        (false, true,  false, _    ) => '│',
+                        (false, true,  true,  _    ) => '┼',
+                        (true,  _,     _,     false) => '├',
+                        (true,  _,     _,     true ) => '└',
+                    }
+                },
+                Packet(..) => {
+                    match (on_endpoint, active, last) {
+                        (false, false, _    ) => ' ',
+                        (false, true,  _    ) => '│',
+                        (true,  _,     false) => '│',
+                        (true,  _,     true ) => ' ',
+                    }
+                }
+            });
+        };
+        let state_length = endpoint_state.len();
+        for _ in state_length..endpoint_count {
+            connectors.push(match item {
+                Transfer(..)    => '─',
+                Transaction(..) => '─',
+                Packet(..)      => ' ',
+            });
+        }
+        connectors.push_str(
+            match (item, last_packet) {
+                (Transfer(_), _) if entry.is_start() => "─",
+                (Transfer(_), _)                     => "──□ ",
+                (Transaction(..), _)                 => "───",
+                (Packet(..), false)                  => "    ├──",
+                (Packet(..), true)                   => "    └──",
+            }
+        );
+        Ok(connectors)
+    }
+}
+
+impl ItemSource<DeviceItem> for Capture {
+    fn item(&mut self, parent: &Option<DeviceItem>, index: u64)
         -> Result<DeviceItem, CaptureError>
     {
         match parent {
             None => Ok(DeviceItem::Device(DeviceId::from(index + 1))),
-            Some(item) => self.device_child(item, index)
+            Some(item) => self.child_item(item, index)
         }
     }
 
-    fn device_child(&self, item: &DeviceItem, index: u64)
+    fn child_item(&mut self, parent: &DeviceItem, index: u64)
         -> Result<DeviceItem, CaptureError>
     {
         use DeviceItem::*;
-        Ok(match item {
+        Ok(match parent {
             Device(dev) => match index {
                 0 => DeviceDescriptor(*dev),
                 conf => Configuration(*dev,
@@ -780,32 +805,20 @@ impl Capture {
         })
     }
 
-    pub fn device_item_count(&mut self, parent: &Option<DeviceItem>)
+    fn item_count(&mut self, parent: &Option<DeviceItem>)
         -> Result<u64, CaptureError>
     {
         Ok(match parent {
             None => (self.device_data.len() - 1) as u64,
-            Some(item) => self.device_child_count(item)?,
+            Some(item) => self.child_count(item)?,
         })
     }
 
-    pub fn get_device_data(&self, id: &DeviceId)
-        -> Result<&DeviceData, CaptureError>
-    {
-        self.device_data.get(id.value as usize).ok_or(IndexError)
-    }
-
-    pub fn get_device_data_mut(&mut self, id: &DeviceId)
-        -> Result<&mut DeviceData, CaptureError>
-    {
-        self.device_data.get_mut(id.value as usize).ok_or(IndexError)
-    }
-
-    fn device_child_count(&self, item: &DeviceItem)
+    fn child_count(&mut self, parent: &DeviceItem)
         -> Result<u64, CaptureError>
     {
         use DeviceItem::*;
-        Ok((match item {
+        Ok((match parent {
             Device(dev) =>
                 self.get_device_data(dev)?.configurations.len(),
             DeviceDescriptor(dev) =>
@@ -835,7 +848,7 @@ impl Capture {
         }) as u64)
     }
 
-    pub fn get_device_summary(&mut self, item: &DeviceItem)
+    fn summary(&mut self, item: &DeviceItem)
         -> Result<String, CaptureError>
     {
         use DeviceItem::*;
@@ -906,6 +919,10 @@ impl Capture {
             }
         })
     }
+
+    fn connectors(&mut self, _item: &DeviceItem) -> Result<String, CaptureError> {
+        unimplemented!()
+    }
 }
 
 #[cfg(test)]
@@ -918,15 +935,15 @@ mod tests {
     fn write_item(cap: &mut Capture, item: &TrafficItem, depth: u8,
                   writer: &mut dyn Write)
     {
-        let summary = cap.get_summary(&item).unwrap();
+        let summary = cap.summary(item).unwrap();
         for _ in 0..depth {
             writer.write(b" ").unwrap();
         }
         writer.write(summary.as_bytes()).unwrap();
         writer.write(b"\n").unwrap();
-        let num_children = cap.child_count(&item).unwrap();
+        let num_children = cap.child_count(item).unwrap();
         for child_id in 0..num_children {
-            let child = cap.get_child(&item, child_id).unwrap();
+            let child = cap.child_item(item, child_id).unwrap();
             write_item(cap, &child, depth + 1, writer);
         }
     }
@@ -955,7 +972,7 @@ mod tests {
                     let mut out_writer = BufWriter::new(out_file);
                     let num_items = cap.item_index.len();
                     for item_id in 0 .. num_items {
-                        let item = cap.get_item(&None, item_id).unwrap();
+                        let item = cap.item(&None, item_id).unwrap();
                         write_item(&mut cap, &item, 0, &mut out_writer);
                     }
                 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -920,8 +920,22 @@ impl ItemSource<DeviceItem> for Capture {
         })
     }
 
-    fn connectors(&mut self, _item: &DeviceItem) -> Result<String, CaptureError> {
-        unimplemented!()
+    fn connectors(&mut self, item: &DeviceItem) -> Result<String, CaptureError> {
+        use DeviceItem::*;
+        let depth = match item {
+            Device(..) => 0,
+            DeviceDescriptor(..) => 1,
+            DeviceDescriptorField(..) => 2,
+            Configuration(..) => 1,
+            ConfigurationDescriptor(..) => 2,
+            ConfigurationDescriptorField(..) => 3,
+            Interface(..) => 2,
+            InterfaceDescriptor(..) => 3,
+            InterfaceDescriptorField(..) => 4,
+            EndpointDescriptor(..) => 3,
+            EndpointDescriptorField(..) => 4,
+        };
+        Ok("   ".repeat(depth))
     }
 }
 

--- a/src/expander/mod.rs
+++ b/src/expander/mod.rs
@@ -45,11 +45,13 @@ impl ExpanderWrapper {
         self.imp().handler.take().take()
     }
 
-    pub fn set_connectors(&self, connectors: Option<String>) {
-        if let Some(text) = connectors {
-            self.imp().conn_label.borrow_mut().set_markup(
-                    format!("<tt>{}</tt>", text).as_str());
-        }
+    pub fn set_text(&self, text: String) {
+        self.imp().text_label.borrow_mut().set_text(&text);
+    }
+
+    pub fn set_connectors(&self, connectors: String) {
+        self.imp().conn_label.borrow_mut().set_markup(
+                format!("<tt>{}</tt>", connectors).as_str());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ fn run() -> Result<(), PacketryError> {
             .build();
 
         let listview = create_view::
-            <capture::Item, model::Model, row_data::RowData>(&capture);
+            <capture::TrafficItem, model::TrafficModel, row_data::TrafficRowData>(&capture);
 
         let scrolled_window = gtk::ScrolledWindow::builder()
             .hscrollbar_policy(gtk::PolicyType::Automatic) // Disable horizontal scrolling

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -3,7 +3,7 @@
 use gio::subclass::prelude::*;
 use gtk::{gio, glib, prelude::*};
 
-use crate::capture::{self, Capture, CaptureError};
+use crate::capture::{self, Capture, CaptureError, ItemSource};
 
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
@@ -74,17 +74,9 @@ impl TrafficModel {
             },
             None => return Err(ModelError::CaptureNotSet)
         };
-        let item = cap.get_item(&self.parent.borrow(),
-                                position as u64)?;
-        let summary = match cap.get_summary(&item) {
-            Ok(string) => string,
-            Err(e) => format!("Error: {:?}", e)
-        };
-        let connectors = match cap.get_connectors(&item) {
-            Ok(string) => string,
-            Err(e) => format!("Error: {:?}", e)
-        };
-        Ok(Some(TrafficRowData::new(Some(item), summary, connectors)
+        let item = cap.item(&self.parent.borrow(),
+                            position as u64)?;
+        Ok(Some(TrafficRowData::new(Some(item))
                                .upcast::<glib::Object>()))
     }
 }
@@ -101,7 +93,7 @@ impl DeviceModel {
             },
             None => return Err(ModelError::CaptureNotSet)
         };
-        Ok(cap.device_item_count(&self.parent.borrow())? as u32)
+        Ok(cap.item_count(&self.parent.borrow())? as u32)
     }
 
     fn try_item(&self, position: u32)
@@ -115,13 +107,9 @@ impl DeviceModel {
             },
             None => return Err(ModelError::CaptureNotSet)
         };
-        let item = cap.get_device_item(&self.parent.borrow(),
-                                       position as u64)?;
-        let summary = match cap.get_device_summary(&item) {
-            Ok(string) => string,
-            Err(e) => format!("Error: {:?}", e)
-        };
-        Ok(Some(DeviceRowData::new(Some(item), summary)
+        let item = cap.item(&self.parent.borrow(),
+                            position as u64)?;
+        Ok(Some(DeviceRowData::new(Some(item))
                               .upcast::<glib::Object>()))
     }
 }

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -7,14 +7,14 @@ use crate::capture::{self, Capture, CaptureError};
 
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
-use crate::row_data::{RowData, DeviceRowData};
+use crate::row_data::{TrafficRowData, DeviceRowData};
 
 use thiserror::Error;
 
 #[derive(Default)]
-pub struct Model {
+pub struct TrafficModel {
     pub(super) capture: RefCell<Option<Arc<Mutex<Capture>>>>,
-    pub(super) parent: RefCell<Option<capture::Item>>,
+    pub(super) parent: RefCell<Option<capture::TrafficItem>>,
 }
 
 #[derive(Default)]
@@ -25,9 +25,9 @@ pub struct DeviceModel {
 
 /// Basic declaration of our type for the GObject type system
 #[glib::object_subclass]
-impl ObjectSubclass for Model {
-    const NAME: &'static str = "Model";
-    type Type = super::Model;
+impl ObjectSubclass for TrafficModel {
+    const NAME: &'static str = "TrafficModel";
+    type Type = super::TrafficModel;
     type Interfaces = (gio::ListModel,);
 }
 #[glib::object_subclass]
@@ -48,7 +48,7 @@ pub enum ModelError {
     LockError,
 }
 
-impl Model {
+impl TrafficModel {
     fn try_n_items(&self)
         -> Result<u32, ModelError>
     {
@@ -84,8 +84,8 @@ impl Model {
             Ok(string) => string,
             Err(e) => format!("Error: {:?}", e)
         };
-        Ok(Some(RowData::new(Some(item), summary, connectors)
-                        .upcast::<glib::Object>()))
+        Ok(Some(TrafficRowData::new(Some(item), summary, connectors)
+                               .upcast::<glib::Object>()))
     }
 }
 
@@ -126,12 +126,12 @@ impl DeviceModel {
     }
 }
 
-impl ObjectImpl for Model {}
+impl ObjectImpl for TrafficModel {}
 impl ObjectImpl for DeviceModel {}
 
-impl ListModelImpl for Model {
+impl ListModelImpl for TrafficModel {
     fn item_type(&self, _list_model: &Self::Type) -> glib::Type {
-        RowData::static_type()
+        TrafficRowData::static_type()
     }
 
     fn n_items(&self, _list_model: &Self::Type) -> u32 {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -11,7 +11,7 @@ use crate::capture::{self, Capture};
 
 // Public part of the Model type.
 glib::wrapper! {
-    pub struct Model(ObjectSubclass<imp::Model>) @implements gio::ListModel;
+    pub struct TrafficModel(ObjectSubclass<imp::TrafficModel>) @implements gio::ListModel;
 }
 glib::wrapper! {
     pub struct DeviceModel(ObjectSubclass<imp::DeviceModel>) @implements gio::ListModel;
@@ -24,9 +24,10 @@ pub trait GenericModel<Item> {
 }
 
 // Constructor for new instances. This simply calls glib::Object::new()
-impl GenericModel<capture::Item> for Model {
-    fn new(capture: Arc<Mutex<Capture>>, parent: Option<capture::Item>) -> Model {
-        let mut model: Model = glib::Object::new(&[]).expect("Failed to create Model");
+impl GenericModel<capture::TrafficItem> for TrafficModel {
+    fn new(capture: Arc<Mutex<Capture>>, parent: Option<capture::TrafficItem>) -> Self {
+        let mut model: TrafficModel =
+            glib::Object::new(&[]).expect("Failed to create TrafficModel");
         model.set_capture(capture);
         model.set_parent(parent);
         model
@@ -36,7 +37,7 @@ impl GenericModel<capture::Item> for Model {
         self.imp().capture.replace(Some(capture));
     }
 
-    fn set_parent(&mut self, parent: Option<capture::Item>) {
+    fn set_parent(&mut self, parent: Option<capture::TrafficItem>) {
         self.imp().parent.replace(parent);
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,12 +2,15 @@
 
 mod imp;
 
+use std::rc::Rc;
+use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 
-use crate::capture::{self, Capture};
+use crate::capture::{Capture, TrafficItem, DeviceItem};
+use crate::tree_list_model::{TreeListModel, TreeNode, ModelError};
 
 // Public part of the Model type.
 glib::wrapper! {
@@ -17,47 +20,50 @@ glib::wrapper! {
     pub struct DeviceModel(ObjectSubclass<imp::DeviceModel>) @implements gio::ListModel;
 }
 
-pub trait GenericModel<Item> {
-    fn new(capture: Arc<Mutex<Capture>>, parent: Option<Item>) -> Self;
-    fn set_capture(&mut self, capture: Arc<Mutex<Capture>>);
-    fn set_parent(&mut self, parent: Option<Item>);
+pub trait GenericModel<Item> where Self: Sized {
+    fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError>;
+    fn set_expanded(&self,
+                    node: &Rc<RefCell<TreeNode<Item>>>,
+                    expanded: bool)
+        -> Result<(), ModelError>;
 }
 
-// Constructor for new instances. This simply calls glib::Object::new()
-impl GenericModel<capture::TrafficItem> for TrafficModel {
-    fn new(capture: Arc<Mutex<Capture>>, parent: Option<capture::TrafficItem>) -> Self {
-        let mut model: TrafficModel =
+impl GenericModel<TrafficItem> for TrafficModel {
+    fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError> {
+        let model: TrafficModel =
             glib::Object::new(&[]).expect("Failed to create TrafficModel");
-        model.set_capture(capture);
-        model.set_parent(parent);
-        model
+        let tree = TreeListModel::new(capture)?;
+        model.imp().tree.replace(Some(tree));
+        Ok(model)
     }
 
-    fn set_capture(&mut self, capture: Arc<Mutex<Capture>>) {
-        self.imp().capture.replace(Some(capture));
-    }
-
-    fn set_parent(&mut self, parent: Option<capture::TrafficItem>) {
-        self.imp().parent.replace(parent);
+    fn set_expanded(&self,
+                    node: &Rc<RefCell<TreeNode<TrafficItem>>>,
+                    expanded: bool)
+        -> Result<(), ModelError>
+    {
+        let tree_opt  = self.imp().tree.borrow();
+        let tree = tree_opt.as_ref().unwrap();
+        tree.set_expanded(self, node, expanded)
     }
 }
 
-impl GenericModel<capture::DeviceItem> for DeviceModel {
-    fn new(capture: Arc<Mutex<Capture>>, parent: Option<capture::DeviceItem>)
-        -> DeviceModel
-    {
-        let mut model: DeviceModel =
+impl GenericModel<DeviceItem> for DeviceModel {
+    fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError> {
+        let model: DeviceModel =
             glib::Object::new(&[]).expect("Failed to create DeviceModel");
-        model.set_capture(capture);
-        model.set_parent(parent);
-        model
+        let tree = TreeListModel::new(capture)?;
+        model.imp().tree.replace(Some(tree));
+        Ok(model)
     }
 
-    fn set_capture(&mut self, capture: Arc<Mutex<Capture>>) {
-        self.imp().capture.replace(Some(capture));
-    }
-
-    fn set_parent(&mut self, parent: Option<capture::DeviceItem>) {
-        self.imp().parent.replace(parent);
+    fn set_expanded(&self,
+                    node: &Rc<RefCell<TreeNode<DeviceItem>>>,
+                    expanded: bool)
+        -> Result<(), ModelError>
+    {
+        let tree_opt  = self.imp().tree.borrow();
+        let tree = tree_opt.as_ref().unwrap();
+        tree.set_expanded(self, node, expanded)
     }
 }

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -1,20 +1,20 @@
 use gtk::glib::{self, subclass::prelude::*};
+use std::rc::Rc;
 use std::cell::RefCell;
-use crate::capture;
+
+use crate::capture::{TrafficItem, DeviceItem};
+use crate::tree_list_model::{TreeNode};
 
 // The actual data structure that stores our values. This is not accessible
 // directly from the outside.
 #[derive(Default)]
 pub struct TrafficRowData {
-    pub summary: RefCell<String>,
-    pub connectors: RefCell<String>,
-    pub(super) item: RefCell<Option<capture::TrafficItem>>,
+    pub(super) node: RefCell<Option<Rc<RefCell<TreeNode<TrafficItem>>>>>,
 }
 
 #[derive(Default)]
 pub struct DeviceRowData {
-    pub summary: RefCell<String>,
-    pub(super) item: RefCell<Option<capture::DeviceItem>>,
+    pub(super) node: RefCell<Option<Rc<RefCell<TreeNode<DeviceItem>>>>>,
 }
 
 // Basic declaration of our type for the GObject type system

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -5,10 +5,10 @@ use crate::capture;
 // The actual data structure that stores our values. This is not accessible
 // directly from the outside.
 #[derive(Default)]
-pub struct RowData {
+pub struct TrafficRowData {
     pub summary: RefCell<String>,
     pub connectors: RefCell<String>,
-    pub(super) item: RefCell<Option<capture::Item>>,
+    pub(super) item: RefCell<Option<capture::TrafficItem>>,
 }
 
 #[derive(Default)]
@@ -19,9 +19,9 @@ pub struct DeviceRowData {
 
 // Basic declaration of our type for the GObject type system
 #[glib::object_subclass]
-impl ObjectSubclass for RowData {
-    const NAME: &'static str = "RowData";
-    type Type = super::RowData;
+impl ObjectSubclass for TrafficRowData {
+    const NAME: &'static str = "TrafficRowData";
+    type Type = super::TrafficRowData;
 }
 
 #[glib::object_subclass]
@@ -30,5 +30,5 @@ impl ObjectSubclass for DeviceRowData {
     type Type = super::DeviceRowData;
 }
 
-impl ObjectImpl for RowData {}
+impl ObjectImpl for TrafficRowData {}
 impl ObjectImpl for DeviceRowData {}

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -41,7 +41,6 @@ impl DeviceRowData {
 }
 
 pub trait GenericRowData<Item> {
-    const CONNECTORS: bool;
     fn get_item(&self) -> Option<Item>;
     fn field(&self,
              capture: &Arc<Mutex<Capture>>,
@@ -52,8 +51,6 @@ pub trait GenericRowData<Item> {
 }
 
 impl GenericRowData<TrafficItem> for TrafficRowData {
-    const CONNECTORS: bool = true;
-
     fn get_item(&self) -> Option<TrafficItem> {
         self.imp().item.borrow().clone()
     }
@@ -84,8 +81,6 @@ impl GenericRowData<TrafficItem> for TrafficRowData {
 }
 
 impl GenericRowData<DeviceItem> for DeviceRowData {
-    const CONNECTORS: bool = true;
-
     fn get_item(&self) -> Option<DeviceItem> {
         self.imp().item.borrow().clone()
     }

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -84,7 +84,7 @@ impl GenericRowData<TrafficItem> for TrafficRowData {
 }
 
 impl GenericRowData<DeviceItem> for DeviceRowData {
-    const CONNECTORS: bool = false;
+    const CONNECTORS: bool = true;
 
     fn get_item(&self) -> Option<DeviceItem> {
         self.imp().item.borrow().clone()

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -13,17 +13,17 @@ use crate::capture;
 // Public part of the RowData type. This behaves like a normal gtk-rs-style GObject
 // binding
 glib::wrapper! {
-    pub struct RowData(ObjectSubclass<imp::RowData>);
+    pub struct TrafficRowData(ObjectSubclass<imp::TrafficRowData>);
 }
 glib::wrapper! {
     pub struct DeviceRowData(ObjectSubclass<imp::DeviceRowData>);
 }
 
-impl RowData {
-    pub fn new(item: Option<capture::Item>, summary: String, connectors: String)
-        -> RowData
+impl TrafficRowData {
+    pub fn new(item: Option<capture::TrafficItem>, summary: String, connectors: String)
+        -> TrafficRowData
     {
-        let mut row: RowData =
+        let mut row: TrafficRowData =
             glib::Object::new(&[]).expect("Failed to create row data");
         row.set_item(item);
         row.set_summary(summary);
@@ -31,7 +31,7 @@ impl RowData {
         row
     }
 
-    fn set_item(&mut self, item: Option<capture::Item>) {
+    fn set_item(&mut self, item: Option<capture::TrafficItem>) {
         self.imp().item.replace(item);
     }
 
@@ -71,10 +71,10 @@ pub trait GenericRowData<Item> {
     fn get_connectors(&self) -> Option<String>;
 }
 
-impl GenericRowData<capture::Item> for RowData {
+impl GenericRowData<capture::TrafficItem> for TrafficRowData {
     const CONNECTORS: bool = true;
 
-    fn get_item(&self) -> Option<capture::Item> {
+    fn get_item(&self) -> Option<capture::TrafficItem> {
         self.imp().item.borrow().clone()
     }
 

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -1,0 +1,240 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::marker::PhantomData;
+use std::num::TryFromIntError;
+use std::rc::{Rc, Weak};
+use std::sync::{Arc, Mutex};
+use std::ops::DerefMut;
+
+use gtk::prelude::{IsA, Cast};
+use gtk::glib::Object;
+use gtk::gio::prelude::ListModelExt;
+
+use thiserror::Error;
+
+use crate::capture::{Capture, CaptureError, ItemSource};
+use crate::model::GenericModel;
+use crate::row_data::GenericRowData;
+
+#[derive(Error, Debug)]
+pub enum ModelError {
+    #[error(transparent)]
+    CaptureError(#[from] CaptureError),
+    #[error(transparent)]
+    RangeError(#[from] TryFromIntError),
+    #[error("Locking capture failed")]
+    LockError,
+    #[error("Parent not set (attempting to expand the root node?)")]
+    ParentNotSet,
+    #[error("Node references a dropped parent")]
+    ParentDropped,
+}
+
+pub struct TreeNode<Item> {
+    /// The item at this tree node.
+    item: Option<Item>,
+
+    /// Whether this node is currently expanded.
+    expanded: bool,
+
+    /// Parent of this node in the tree.
+    parent: Option<Weak<RefCell<TreeNode<Item>>>>,
+
+    /// Index of this node below the parent Item.
+    item_index: u32,
+
+    /// Total count of nodes below this node, recursively.
+    ///
+    /// Initially this is set to the number of direct descendants,
+    /// then increased/decreased as nodes are expanded/collapsed.
+    child_count: u32,
+
+    /// List of expanded child nodes directly below this node.
+    children: BTreeMap<u32, Rc<RefCell<TreeNode<Item>>>>,
+}
+
+impl<Item> TreeNode<Item> where Item: Copy {
+    pub fn expanded(&self) -> bool {
+        self.expanded
+    }
+
+    pub fn expandable(&self) -> bool {
+        self.child_count != 0
+    }
+
+    /// Position of this node in a list, relative to its parent node.
+    pub fn relative_position(&self) -> Result<u32, ModelError> {
+        match self.parent.as_ref() {
+            Some(parent_weak) => {
+                let parent_ref = parent_weak.upgrade().ok_or(ModelError::ParentDropped)?;
+                let parent = parent_ref.borrow();
+                // Sum up the `child_count`s of any expanded nodes before this one, and add to `item_index`.
+                Ok(parent.children.iter()
+                    .take_while(|(&key, _)| key < self.item_index)
+                    .map(|(_, node)| node.borrow().child_count)
+                    .sum::<u32>() + self.item_index)
+            },
+            None => Ok(0),
+        }
+
+    }
+
+    pub fn field(&self,
+             capture: &Arc<Mutex<Capture>>,
+             func: Box<dyn
+                Fn(&mut Capture, &Item)
+                    -> Result<String, CaptureError>>)
+        -> String
+    {
+        match self.item {
+            None => "Error: node has no item".to_string(),
+            Some(item) => match capture.lock() {
+                Err(_) => "Error: failed to lock capture".to_string(),
+                Ok(mut guard) => {
+                    let cap = guard.deref_mut();
+                    match func(cap, &item) {
+                        Err(e) => format!("Error: {:?}", e),
+                        Ok(string) => string
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub struct TreeListModel<Item, Model, RowData> {
+    _marker: PhantomData<(Model, RowData)>,
+    capture: Arc<Mutex<Capture>>,
+    root: Rc<RefCell<TreeNode<Item>>>,
+}
+
+impl<Item, Model, RowData> TreeListModel<Item, Model, RowData>
+where Item: Copy,
+      Model: GenericModel<Item> + ListModelExt,
+      RowData: GenericRowData<Item> + IsA<Object> + Cast,
+      Capture: ItemSource<Item>
+{
+    pub fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError> {
+        let mut cap = capture.lock().or(Err(ModelError::LockError))?;
+        let item_count = cap.item_count(&None)?;
+        Ok(TreeListModel {
+            _marker: PhantomData,
+            capture: capture.clone(),
+            root: Rc::new(RefCell::new(TreeNode {
+                item: None,
+                expanded: false,
+                parent: None,
+                item_index: 0,
+                child_count: u32::try_from(item_count)?,
+                children: Default::default(),
+            })),
+        })
+    }
+
+    pub fn set_expanded(&self,
+                        model: &Model,
+                        node_ref: &Rc<RefCell<TreeNode<Item>>>,
+                        expanded: bool)
+        -> Result<(), ModelError>
+    {
+        {
+            let node = node_ref.borrow();
+            if node.expanded() == expanded {
+                return Ok(());
+            }
+
+            {
+                let node_parent_ref = node.parent
+                    .as_ref().ok_or(ModelError::ParentNotSet)?
+                    .upgrade().ok_or(ModelError::ParentDropped)?;
+                let mut node_parent = node_parent_ref.borrow_mut();
+
+                // Add this node to the parent's list of expanded child nodes.
+                if expanded {
+                    node_parent.children.insert(node.item_index, node_ref.clone());
+                } else {
+                    node_parent.children.remove(&node.item_index);
+                }
+            }
+
+            // Traverse back up the tree, modifying `child_count` for expanded/collapsed entries.
+            let mut position = node.relative_position()?;
+            let mut current_node = node_ref.clone();
+            while let Some(parent_weak) = current_node.clone().borrow().parent.as_ref() {
+                let parent = parent_weak.upgrade().ok_or(ModelError::ParentDropped)?;
+                if expanded {
+                    parent.borrow_mut().child_count += node.child_count;
+                } else {
+                    parent.borrow_mut().child_count -= node.child_count;
+                }
+                current_node = parent;
+                position += current_node.borrow().relative_position()? + 1;
+            }
+
+            if expanded {
+                model.items_changed(position, 0, node.child_count);
+            } else {
+                model.items_changed(position, node.child_count, 0);
+            }
+        }
+
+        node_ref.borrow_mut().expanded = expanded;
+        Ok(())
+    }
+
+    // The following methods correspond to the ListModel interface, and can be
+    // called by a GObject wrapper class to implement that interface.
+
+    pub fn n_items(&self) -> u32 {
+        self.root.borrow().child_count
+    }
+
+    pub fn item(&self, position: u32) -> Option<Object> {
+        // First check that the position is valid (must be within the root node's `child_count`).
+        let mut parent_ref = self.root.clone();
+        if position >= parent_ref.borrow().child_count {
+            return None
+        }
+
+        let mut relative_position = position;
+        'outer: loop {
+            for (_, node_rc) in parent_ref.clone().borrow().children.iter() {
+                let node = node_rc.borrow();
+                // If the position is before this node, break out of the loop to look it up.
+                if relative_position < node.item_index {
+                    break;
+                // If the position matches this node, return it.
+                } else if relative_position == node.item_index {
+                    return Some(RowData::new(node_rc.clone()).upcast::<Object>());
+                // If the position is within this node's children, traverse down the tree and repeat.
+                } else if relative_position <= node.item_index + node.child_count {
+                    parent_ref = node_rc.clone();
+                    relative_position -= node.item_index + 1;
+                    continue 'outer;
+                // Otherwise, if the position is after this node,
+                // adjust the relative position for the node's children above.
+                } else {
+                    relative_position -= node.child_count;
+                }
+            }
+            break;
+        }
+
+        // If we've broken out to this point, the node must be directly below `parent` - look it up.
+        let mut cap = self.capture.lock().ok()?;
+        let parent = parent_ref.borrow();
+        let item = cap.item(&parent.item, relative_position as u64).ok()?;
+        let child_count = cap.child_count(&item).ok()?;
+        let node = TreeNode {
+            item: Some(item),
+            expanded: false,
+            parent: Some(Rc::downgrade(&parent_ref)),
+            item_index: relative_position,
+            child_count: child_count.try_into().ok()?,
+            children: Default::default(),
+        };
+        let rowdata = RowData::new(Rc::new(RefCell::new(node)));
+
+        Some(rowdata.upcast::<Object>())
+    }
+}


### PR DESCRIPTION
This intergrates @miek's `tree-model` branch with the previous generic UI code, allowing the `TreeListModel` and associated UI code to be shared between the traffic view and the device hierarchy view.