### PR TITLE
Clippy & CI fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,11 @@
 on:
   push:
   pull_request:
+  workflow_dispatch:
+
+  # Run automatically every monday
+  schedule:
+    - cron: 1 12 * * 1
 
 name: CI
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -114,7 +114,7 @@ impl TransferIndexEntry {
     }
 }
 
-#[derive(Copy, Clone, IntoPrimitive, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, IntoPrimitive, FromPrimitive, PartialEq, Eq)]
 #[repr(u8)]
 pub enum EndpointState {
     #[default]
@@ -735,7 +735,7 @@ impl ItemSource<TrafficItem> for Capture {
         Ok(match item {
             Packet(.., packet_id) => {
                 let packet = self.packet(*packet_id)?;
-                let pid = PID::from(*packet.get(0).ok_or(IndexError)?);
+                let pid = PID::from(*packet.first().ok_or(IndexError)?);
                 format!("{} packet{}",
                     pid,
                     match PacketFields::from_packet(&packet) {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -9,11 +9,11 @@ use CaptureError::IndexError;
 
 impl PID {
     fn from_packet(packet: &[u8]) -> Result<PID, CaptureError> {
-        Ok(PID::from(*packet.get(0).ok_or(IndexError)?))
+        Ok(PID::from(*packet.first().ok_or(IndexError)?))
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 enum DecodeStatus {
     Single,
     New,

--- a/src/file_vec.rs
+++ b/src/file_vec.rs
@@ -96,7 +96,7 @@ mod tests {
     use super::*;
     use bytemuck_derive::{Pod, Zeroable};
 
-    #[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable)]
+    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
     #[repr(C)]
     struct Foo {
         bar: u32,

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -79,6 +79,7 @@ impl<Item> TreeNode<Item> where Item: Copy {
 
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn field(&self,
              capture: &Arc<Mutex<Capture>>,
              func: Box<dyn

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -8,7 +8,7 @@ use derive_more::{From, Into, Display};
 use crate::vec_map::VecMap;
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Copy, Clone, Debug, IntoPrimitive, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, IntoPrimitive, FromPrimitive, PartialEq, Eq)]
 #[repr(u8)]
 pub enum PID {
     RSVD  = 0xF0,
@@ -43,57 +43,57 @@ impl std::fmt::Display for PID {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct DeviceAddr(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct DeviceField(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct StringId(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct ConfigNum(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct ConfigField(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct InterfaceNum(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct InterfaceField(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct InterfaceEpNum(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct EndpointNum(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct EndpointField(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct EndpointAddr(pub u8);
@@ -116,7 +116,7 @@ impl EndpointAddr {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Default,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default,
          Pod, Zeroable, From, Into, Display)]
 #[repr(transparent)]
 pub struct EndpointAttr(pub u8);
@@ -332,7 +332,7 @@ impl StandardRequest {
     }
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, Eq)]
 #[repr(u8)]
 pub enum DescriptorType {
     Device = 1,


### PR DESCRIPTION
This fixes a handful of Clippy warnings that were introduced by a new Rust version.

For most of them, I've implemented the suggested fix.
For the [type_complexity](https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity) warning, I tried to break out part of it as a new `type` but ran into a problem where it needed an unstable feature for inherent associated types, so I've just squelched that warning.

The other commit sets the workflow to run every week as we have on most of the other repos, so we can spot issues like this sooner. It should also allow for the workflow to be triggered manually.