### PR TITLE
Handle narrow window sizes better

### DIFF
--- a/src/expander/mod.rs
+++ b/src/expander/mod.rs
@@ -6,6 +6,7 @@ use gtk::{
     prelude::*,
     subclass::prelude::*,
     glib::{self, SignalHandlerId},
+    pango::EllipsizeMode,
     Expander,
     Label,
     Orientation,
@@ -22,7 +23,10 @@ impl ExpanderWrapper {
         let wrapper: ExpanderWrapper =
             glib::Object::new(&[])
                          .expect("Failed to create new expander wrapper");
-        wrapper.imp().text_label.replace(Label::new(None));
+        wrapper.imp().text_label.replace(
+            Label::builder()
+                .ellipsize(EllipsizeMode::End)
+                .build());
         wrapper.imp().conn_label.replace(Label::new(None));
         wrapper.imp().expander.replace(Expander::new(None));
         wrapper.append(&wrapper.imp().conn_label.borrow().clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn run() -> Result<(), PacketryError> {
         let scrolled_window = gtk::ScrolledWindow::builder()
             .hscrollbar_policy(gtk::PolicyType::Automatic) // Disable horizontal scrolling
             .min_content_height(480)
-            .min_content_width(640)
+            .min_content_width(240)
             .build();
 
         scrolled_window.set_child(Some(&listview));
@@ -147,7 +147,7 @@ fn run() -> Result<(), PacketryError> {
         let device_window = gtk::ScrolledWindow::builder()
             .hscrollbar_policy(gtk::PolicyType::Automatic)
             .min_content_height(480)
-            .min_content_width(240)
+            .min_content_width(100)
             .child(&device_tree)
             .build();
 


### PR DESCRIPTION
Reduce minimum size parameters for the two view panes, and set `pango::EllipsizeMode` so that text is truncated nicely as the window shrinks.

![image](https://user-images.githubusercontent.com/673823/197888123-c3c99fe7-9227-4aee-a375-338070cf3a73.png)