### PR TITLE
Improve error reporting

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -23,8 +23,8 @@ pub enum CaptureError {
     RangeError(#[from] TryFromIntError),
     #[error("Descriptor missing")]
     DescriptorMissing,
-    #[error("Invalid index")]
-    IndexError,
+    #[error("Indexing error: {0}")]
+    IndexError(String),
 }
 
 use CaptureError::{DescriptorMissing, IndexError};
@@ -212,7 +212,8 @@ impl Configuration {
     {
         match self.interfaces.get(*number) {
             Some(iface) => Ok(iface),
-            _ => Err(IndexError)
+            _ => Err(IndexError(format!(
+                "Configuration has no interface {}", number)))
         }
     }
 }
@@ -223,7 +224,8 @@ impl Interface {
     {
         match self.endpoint_descriptors.get(*number) {
             Some(desc) => Ok(desc),
-            _ => Err(IndexError)
+            _ => Err(IndexError(format!(
+                "Interface has no endpoint descriptor {}", number)))
         }
     }
 }
@@ -455,7 +457,8 @@ impl Capture {
     pub fn endpoint_traffic(&mut self, endpoint_id: EndpointId)
         -> Result<&mut EndpointTraffic, CaptureError>
     {
-        self.endpoint_traffic.get_mut(endpoint_id).ok_or(IndexError)
+        self.endpoint_traffic.get_mut(endpoint_id).ok_or_else(||
+            IndexError(format!("Capture has no endpoint ID {}", endpoint_id)))
     }
 
     fn transfer_range(&mut self, entry: &TransferIndexEntry)
@@ -599,7 +602,8 @@ impl Capture {
                 SetupFields::from_data_packet(&data_packet)
             },
             _ => {
-                return Err(IndexError);
+                return Err(IndexError(String::from(
+                    "Control transfer did not start with SETUP packet")))
             }
         };
         let direction = fields.type_fields.direction();
@@ -627,13 +631,15 @@ impl Capture {
     pub fn device_data(&self, id: &DeviceId)
         -> Result<&DeviceData, CaptureError>
     {
-        self.device_data.get(*id).ok_or(IndexError)
+        self.device_data.get(*id).ok_or_else(||
+            IndexError(format!("Capture has no device with ID {}", id)))
     }
 
     pub fn device_data_mut(&mut self, id: &DeviceId)
         -> Result<&mut DeviceData, CaptureError>
     {
-        self.device_data.get_mut(*id).ok_or(IndexError)
+        self.device_data.get_mut(*id).ok_or_else(||
+            IndexError(format!("Capture has no device with ID {}", id)))
     }
 
     pub fn try_configuration(&self, dev: &DeviceId, conf: &ConfigNum)
@@ -706,7 +712,8 @@ impl ItemSource<TrafficItem> for Capture {
             Transaction(transfer_id, transaction_id) =>
                 Packet(*transfer_id, *transaction_id, {
                     self.transaction_index.get(*transaction_id)? + index}),
-            Packet(..) => return Err(IndexError)
+            Packet(..) => return Err(IndexError(String::from(
+                "Packets have no child items")))
         })
     }
 
@@ -747,7 +754,8 @@ impl ItemSource<TrafficItem> for Capture {
         let entry = self.transfer_index.get(transfer_id)?;
         let ep_transfer_id = entry.transfer_id();
         if !entry.is_start() {
-            return Err(IndexError)
+            return Err(IndexError(
+                String::from("Transfer entry for item_end is an end")))
         }
         let ep_traf = self.endpoint_traffic(entry.endpoint_id())?;
         if ep_transfer_id.value >= ep_traf.end_index.len() {
@@ -784,7 +792,11 @@ impl ItemSource<TrafficItem> for Capture {
         Ok(match item {
             Packet(.., packet_id) => {
                 let packet = self.packet(*packet_id)?;
-                let pid = PID::from(*packet.first().ok_or(IndexError)?);
+                let first_byte = *packet.first().ok_or_else(||
+                    IndexError(format!(
+                        "Packet {} is empty, cannot retrieve PID",
+                        packet_id)))?;
+                let pid = PID::from(first_byte);
                 format!("{} packet{}",
                     pid,
                     match PacketFields::from_packet(&packet) {
@@ -1037,7 +1049,8 @@ impl ItemSource<DeviceItem> for Capture {
             EndpointDescriptor(dev, conf, iface, ep) =>
                 EndpointDescriptorField(*dev, *conf, *iface, *ep,
                     EndpointField(index.try_into()?)),
-            _ => return Err(IndexError)
+            _ => return Err(IndexError(String::from(
+                "This device item type cannot have children")))
         })
     }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Sub};
 use std::ops::Range;
@@ -6,6 +7,22 @@ use std::ops::Range;
 pub struct Id<T> {
    _marker: PhantomData<T>,
    pub value: u64
+}
+
+impl<T> Display for Id<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>)
+        -> Result<(), std::fmt::Error>
+    {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl<T> Debug for Id<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>)
+        -> Result<(), std::fmt::Error>
+    {
+        write!(f, "Id({})", self.value)
+    }
 }
 
 pub trait HasLength {

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -5,16 +5,19 @@ use std::cell::RefCell;
 use crate::capture::{TrafficItem, DeviceItem};
 use crate::tree_list_model::{TreeNode};
 
+type ItemRc<Item> = Rc<RefCell<TreeNode<Item>>>;
+
 // The actual data structure that stores our values. This is not accessible
 // directly from the outside.
 #[derive(Default)]
 pub struct TrafficRowData {
-    pub(super) node: RefCell<Option<Rc<RefCell<TreeNode<TrafficItem>>>>>,
+    pub(super) node: RefCell<Option<Result<ItemRc<TrafficItem>, String>>>,
+
 }
 
 #[derive(Default)]
 pub struct DeviceRowData {
-    pub(super) node: RefCell<Option<Rc<RefCell<TreeNode<DeviceItem>>>>>,
+    pub(super) node: RefCell<Option<Result<ItemRc<DeviceItem>, String>>>,
 }
 
 // Basic declaration of our type for the GObject type system

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -25,32 +25,32 @@ glib::wrapper! {
 }
 
 pub trait GenericRowData<Item> where Item: Copy {
-    fn new(node: Rc<RefCell<TreeNode<Item>>>) -> Self;
-    fn node(&self) -> Rc<RefCell<TreeNode<Item>>>;
+    fn new(node: Result<Rc<RefCell<TreeNode<Item>>>, String>) -> Self;
+    fn node(&self) -> Result<Rc<RefCell<TreeNode<Item>>>, String>;
 }
 
 impl GenericRowData<TrafficItem> for TrafficRowData {
-    fn new(node: Rc<RefCell<TreeNode<TrafficItem>>>) -> TrafficRowData {
+    fn new(node: Result<Rc<RefCell<TreeNode<TrafficItem>>>, String>) -> TrafficRowData {
         let row: TrafficRowData =
             glib::Object::new(&[]).expect("Failed to create row data");
         row.imp().node.replace(Some(node));
         row
     }
 
-    fn node(&self) -> Rc<RefCell<TreeNode<TrafficItem>>> {
+    fn node(&self) -> Result<Rc<RefCell<TreeNode<TrafficItem>>>, String> {
         self.imp().node.borrow().as_ref().unwrap().clone()
     }
 }
 
 impl GenericRowData<DeviceItem> for DeviceRowData {
-    fn new(node: Rc<RefCell<TreeNode<DeviceItem>>>) -> DeviceRowData {
+    fn new(node: Result<Rc<RefCell<TreeNode<DeviceItem>>>, String>) -> DeviceRowData {
         let row: DeviceRowData =
             glib::Object::new(&[]).expect("Failed to create row data");
         row.imp().node.replace(Some(node));
         row
     }
 
-    fn node(&self) -> Rc<RefCell<TreeNode<DeviceItem>>> {
+    fn node(&self) -> Result<Rc<RefCell<TreeNode<DeviceItem>>>, String> {
         self.imp().node.borrow().as_ref().unwrap().clone()
     }
 }

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -207,20 +207,8 @@ where Item: Copy,
         Ok(Some((position, 0, added)))
     }
 
-    // The following methods correspond to the ListModel interface, and can be
-    // called by a GObject wrapper class to implement that interface.
-
-    pub fn n_items(&self) -> u32 {
-        self.root.borrow().total_child_count
-    }
-
-    pub fn item(&self, position: u32) -> Option<Object> {
-        // First check that the position is valid (must be within the root node's `total_child_count`).
+    fn fetch(&self, position: u32) -> Result<Rc<RefCell<TreeNode<Item>>>, ModelError> {
         let mut parent_ref = self.root.clone();
-        if position >= parent_ref.borrow().total_child_count {
-            return None
-        }
-
         let mut relative_position = position;
         'outer: loop {
             for (_, node_rc) in parent_ref.clone().borrow().children.iter() {
@@ -230,7 +218,7 @@ where Item: Copy,
                     break;
                 // If the position matches this node, return it.
                 } else if relative_position == node.item_index {
-                    return Some(RowData::new(node_rc.clone()).upcast::<Object>());
+                    return Ok(node_rc.clone());
                 // If the position is within this node's children, traverse down the tree and repeat.
                 } else if relative_position <= node.item_index + node.total_child_count {
                     parent_ref = node_rc.clone();
@@ -246,20 +234,36 @@ where Item: Copy,
         }
 
         // If we've broken out to this point, the node must be directly below `parent` - look it up.
-        let mut cap = self.capture.lock().ok()?;
+        let mut cap = self.capture.lock().or(Err(ModelError::LockError))?;
         let parent = parent_ref.borrow();
-        let item = cap.item(&parent.item, relative_position as u64).ok()?;
-        let child_count = cap.child_count(&item).ok()?;
+        let item = cap.item(&parent.item, relative_position as u64)?;
+        let child_count = cap.child_count(&item)?;
         let node = TreeNode {
             item: Some(item),
             parent: Some(Rc::downgrade(&parent_ref)),
             item_index: relative_position,
-            direct_child_count: child_count.try_into().ok()?,
-            total_child_count: child_count.try_into().ok()?,
+            direct_child_count: child_count.try_into()?,
+            total_child_count: child_count.try_into()?,
             children: Default::default(),
         };
-        let rowdata = RowData::new(Rc::new(RefCell::new(node)));
 
-        Some(rowdata.upcast::<Object>())
+        Ok(Rc::new(RefCell::new(node)))
+    }
+
+    // The following methods correspond to the ListModel interface, and can be
+    // called by a GObject wrapper class to implement that interface.
+
+    pub fn n_items(&self) -> u32 {
+        self.root.borrow().total_child_count
+    }
+
+    pub fn item(&self, position: u32) -> Option<Object> {
+        // First check that the position is valid (must be within the root node's `child_count`).
+        if position >= self.root.borrow().total_child_count {
+            return None
+        }
+        let node_or_err_msg = self.fetch(position).map_err(|e| format!("{:?}", e));
+        let row_data = RowData::new(node_or_err_msg);
+        Some(row_data.upcast::<Object>())
     }
 }


### PR DESCRIPTION
Two changes here:

1. We use `IndexError` as a catch-all for any lookup failure in `Capture`. Make it take a string argument to indicate the cause, and add suitable strings at all call sites.

2. When lookup for an individual tree node fails, display the error in the view rather than crashing.