### PR TITLE
Switch from pcap to pcap-file to avoid libpcap/wpcap dependency.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install libgtk-4-dev libpcap-dev build-essential
+          sudo apt install libgtk-4-dev build-essential
 
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
@@ -54,11 +54,11 @@ jobs:
       - name: Install dependencies (Ubuntu)
         run: |
           sudo apt update
-          sudo apt install libgtk-4-dev libpcap-dev build-essential
+          sudo apt install libgtk-4-dev build-essential
         if: startsWith(matrix.os, 'ubuntu-')
 
       - name: Install dependencies (macOS)
-        run: brew install gtk4 libpcap
+        run: brew install gtk4
         if: matrix.os == 'macos-latest'
 
       - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,9 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cairo-rs"
@@ -125,6 +122,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "derive-into-owned"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576fce04d31d592013a5887ba8d9c3830adff329e5096d7e1eb5e8e61262ca62"
+dependencies = [
+ "quote 0.3.15",
+ "syn 0.11.11",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,30 +139,9 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.15",
  "rustc_version 0.4.0",
- "syn",
-]
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -348,8 +334,8 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -461,8 +447,8 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -518,16 +504,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
-name = "libloading"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
 name = "libusb1-sys"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,12 +514,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -587,8 +557,8 @@ checksum = "0d992b768490d7fe0d8586d9b5745f6c49f557da6d81dc982b1d167ad4edbb21"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -612,7 +582,7 @@ dependencies = [
  "num-format",
  "num_enum",
  "once_cell",
- "pcap",
+ "pcap-file",
  "rusb",
  "tempfile",
  "thiserror",
@@ -644,17 +614,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "pcap"
-version = "0.9.1"
+name = "pcap-file"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742d671d505d54e83924cc200e08442111f0ace8ebee3b9dc31cd9710cb301cb"
+checksum = "6ad13fed1a83120159aea81b265074f21d753d157dd16b10cc3790ecba40a341"
 dependencies = [
- "errno",
- "libc",
- "libloading",
- "regex",
- "widestring",
- "winapi",
+ "byteorder",
+ "derive-into-owned",
+ "thiserror",
 ]
 
 [[package]]
@@ -702,8 +669,8 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
  "version_check",
 ]
 
@@ -714,7 +681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.15",
  "version_check",
 ]
 
@@ -724,8 +691,14 @@ version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.2",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -744,23 +717,6 @@ checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "regex"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -843,13 +799,33 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
- "quote",
- "unicode-xid",
+ "quote 1.0.15",
+ "unicode-xid 0.2.2",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -895,8 +871,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -913,6 +889,12 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
@@ -937,12 +919,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "widestring"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ bytemuck_derive = "1.0.1"
 gtk = { version = "*", package = "gtk4" }
 num_enum = "0.5.6"
 once_cell = "1.5"
-pcap = "0.9.1"
+pcap-file = "1.1.1"
 tempfile = "3.3.0"
 thiserror = "1.0.30"
 bitfield = "0.13.2"

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1192,6 +1192,7 @@ mod tests {
     use std::fs::File;
     use std::io::{BufReader, BufWriter, BufRead, Write};
     use crate::decoder::Decoder;
+    use pcap_file::pcap::PcapReader;
 
     fn write_item(cap: &mut Capture, item: &TrafficItem, depth: u8,
                   writer: &mut dyn Write)
@@ -1223,10 +1224,12 @@ mod tests {
                 ref_path.push("reference.txt");
                 out_path.push("output.txt");
                 {
-                    let mut pcap = pcap::Capture::from_file(cap_path).unwrap();
+                    let pcap_file = File::open(cap_path).unwrap();
+                    let pcap_reader = PcapReader::new(pcap_file).unwrap();
                     let mut cap = Capture::new().unwrap();
                     let mut decoder = Decoder::new(&mut cap).unwrap();
-                    while let Ok(packet) = pcap.next() {
+                    for result in pcap_reader {
+                        let packet = result.unwrap().data;
                         decoder.handle_raw_packet(&mut cap, &packet).unwrap();
                     }
                     let out_file = File::create(out_path.clone()).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod expander;
 mod tree_list_model;
 
 use std::cell::RefCell;
+use std::fs::File;
 use std::sync::{Arc, Mutex};
 
 use gtk::gio::ListModel;
@@ -20,6 +21,8 @@ use gtk::{
     SingleSelection,
     Orientation,
 };
+
+use pcap_file::{PcapError, pcap::PcapReader};
 
 use model::GenericModel;
 use row_data::GenericRowData;
@@ -112,7 +115,9 @@ pub enum PacketryError {
     #[error(transparent)]
     CaptureError(#[from] CaptureError),
     #[error(transparent)]
-    PcapError(#[from] pcap::Error),
+    IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    PcapError(#[from] PcapError),
 }
 
 fn run() -> Result<(), PacketryError> {
@@ -171,9 +176,11 @@ fn run() -> Result<(), PacketryError> {
     let mut source_id: Option<gtk::glib::source::SourceId> = None;
 
     if args.len() > 1 {
-        let mut pcap = pcap::Capture::from_file(&args[1])?;
+        let pcap_file = File::open(&args[1])?;
+        let pcap_reader = PcapReader::new(pcap_file)?;
         let mut cap = capture.lock().ok().unwrap();
-        while let Ok(packet) = pcap.next() {
+        for result in pcap_reader {
+            let packet = result?.data;
             decoder.handle_raw_packet(&mut cap, &packet).unwrap();
         }
     } else {


### PR DESCRIPTION
Currently we use the [pcap](https://crates.io/crates/pcap) crate to read pcap files, which uses the `libpcap` library internally.

We only need the capability to read (and at some point write) pcap files, but that crate also provides the rest of the API, including its functionality for sniffing network devices. Satisfying the build dependencies requires some extra steps for users, particularly on Windows, where the `pcap` crate needs to link against [Npcap](https://npcap.com/)'s `wpcap` library.

Since we only need the file format capabilities, this PR switches to using the [pcap-file](https://crates.io/crates/pcap-file) crate, which provides a native Rust implementation of the file format without those external dependencies.

This PR is against current `main` but there is a version on my `pcap-file-rebase` branch which applies on top of #41 and #43.