### PR TITLE
Use a BufReader for pcap file.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod tree_list_model;
 
 use std::cell::RefCell;
 use std::fs::File;
+use std::io::BufReader;
 use std::sync::{Arc, Mutex};
 
 use gtk::gio::ListModel;
@@ -186,8 +187,9 @@ fn run() -> Result<(), PacketryError> {
     let mut source_id: Option<gtk::glib::source::SourceId> = None;
 
     if args.len() > 1 {
-        let pcap_file = File::open(&args[1])?;
-        let pcap_reader = PcapReader::new(pcap_file)?;
+        let file = File::open(&args[1])?;
+        let reader = BufReader::new(file);
+        let pcap_reader = PcapReader::new(reader)?;
         let mut cap = capture.lock().ok().unwrap();
         for result in pcap_reader {
             let packet = result?.data;


### PR DESCRIPTION
PR #45 introduced a performance regression, because `PcapReader` doesn't internally buffer the `Read` implementation that it wraps. This fixes that by wrapping a `BufReader` around the `File`.