### PR TITLE
TreeListModel improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use gtk::{
 
 use pcap_file::{PcapError, pcap::PcapReader};
 
-use model::{GenericModel, TrafficModel};
+use model::{GenericModel, TrafficModel, DeviceModel};
 use row_data::GenericRowData;
 use expander::ExpanderWrapper;
 use tree_list_model::ModelError;
@@ -218,10 +218,18 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
 
             MODELS.with::<_, Result<(), PacketryError>>(|models| {
                 for model in models.borrow().iter() {
-                    let model = model.clone();
-                    if let Ok(tree_model) = model.downcast::<TrafficModel>() {
+                    if let Ok(tree_model) = model
+                        .clone()
+                        .downcast::<TrafficModel>()
+                    {
                         tree_model.update()?;
-                    };
+                    }
+                    else if let Ok(tree_model) = model
+                        .clone()
+                        .downcast::<DeviceModel>()
+                    {
+                        tree_model.update()?;
+                    }
                 }
                 Ok(())
             })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,10 +101,13 @@ fn create_view<Item: 'static, Model, RowData>(capture: &Arc<Mutex<Capture>>)
                 expander.set_expanded(node.expanded());
                 let model = model.clone();
                 let node_ref = node_ref.clone();
+                let list_item = list_item.clone();
                 let handler = expander.connect_expanded_notify(move |expander| {
+                    let position = list_item.position();
+                    let expanded = expander.is_expanded();
                     display_error(
-                        model.set_expanded(&node_ref, expander.is_expanded())
-                            .map_err(PacketryError::Model));
+                        model.set_expanded(&node_ref, position, expanded)
+                            .map_err(PacketryError::Model))
                 });
                 expander_wrapper.set_handler(handler);
             },

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -10,12 +10,12 @@ use crate::tree_list_model::TreeListModel;
 
 #[derive(Default)]
 pub struct TrafficModel {
-    pub(super) tree: RefCell<Option<TreeListModel<TrafficItem, TrafficRowData>>>,
+    pub(super) tree: RefCell<Option<TreeListModel<TrafficItem>>>,
 }
 
 #[derive(Default)]
 pub struct DeviceModel {
-    pub(super) tree: RefCell<Option<TreeListModel<DeviceItem, DeviceRowData>>>,
+    pub(super) tree: RefCell<Option<TreeListModel<DeviceItem>>>,
 }
 
 /// Basic declaration of our type for the GObject type system

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -5,7 +5,7 @@ use gtk::{gio, glib, prelude::*};
 
 use std::cell::RefCell;
 use crate::capture::{TrafficItem, DeviceItem};
-use crate::row_data::{TrafficRowData, DeviceRowData};
+use crate::row_data::{GenericRowData, TrafficRowData, DeviceRowData};
 use crate::tree_list_model::TreeListModel;
 
 #[derive(Default)]
@@ -42,7 +42,7 @@ impl ListModelImpl for TrafficModel {
 
     fn n_items(&self, _list_model: &Self::Type) -> u32 {
         match self.tree.borrow().as_ref() {
-            Some(tree) => tree.n_items(),
+            Some(tree) => tree.row_count(),
             None => 0
         }
     }
@@ -51,7 +51,15 @@ impl ListModelImpl for TrafficModel {
         -> Option<glib::Object>
     {
         match self.tree.borrow().as_ref() {
-            Some(tree) => tree.item(position),
+            Some(tree) => {
+                if position >= tree.row_count() {
+                    None
+                } else {
+                    let result = tree.fetch(position)
+                        .map_err(|e| format!("{:?}", e));
+                    Some(TrafficRowData::new(result).upcast::<glib::Object>())
+                }
+            }
             None => None
         }
     }
@@ -64,7 +72,7 @@ impl ListModelImpl for DeviceModel {
 
     fn n_items(&self, _list_model: &Self::Type) -> u32 {
         match self.tree.borrow().as_ref() {
-            Some(tree) => tree.n_items(),
+            Some(tree) => tree.row_count(),
             None => 0
         }
     }
@@ -73,7 +81,15 @@ impl ListModelImpl for DeviceModel {
         -> Option<glib::Object>
     {
         match self.tree.borrow().as_ref() {
-            Some(tree) => tree.item(position),
+            Some(tree) => {
+                if position >= tree.row_count() {
+                    None
+                } else {
+                    let result = tree.fetch(position)
+                        .map_err(|e| format!("{:?}", e));
+                    Some(DeviceRowData::new(result).upcast::<glib::Object>())
+                }
+            },
             None => None
         }
     }

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -10,12 +10,12 @@ use crate::tree_list_model::TreeListModel;
 
 #[derive(Default)]
 pub struct TrafficModel {
-    pub(super) tree: RefCell<Option<TreeListModel<TrafficItem, super::TrafficModel, TrafficRowData>>>,
+    pub(super) tree: RefCell<Option<TreeListModel<TrafficItem, TrafficRowData>>>,
 }
 
 #[derive(Default)]
 pub struct DeviceModel {
-    pub(super) tree: RefCell<Option<TreeListModel<DeviceItem, super::DeviceModel, DeviceRowData>>>,
+    pub(super) tree: RefCell<Option<TreeListModel<DeviceItem, DeviceRowData>>>,
 }
 
 /// Basic declaration of our type for the GObject type system

--- a/src/model/imp.rs
+++ b/src/model/imp.rs
@@ -8,6 +8,8 @@ use crate::capture::{TrafficItem, DeviceItem};
 use crate::row_data::{GenericRowData, TrafficRowData, DeviceRowData};
 use crate::tree_list_model::TreeListModel;
 
+use super::{clamp, MAX_ROWS};
+
 #[derive(Default)]
 pub struct TrafficModel {
     pub(super) tree: RefCell<Option<TreeListModel<TrafficItem>>>,
@@ -42,7 +44,7 @@ impl ListModelImpl for TrafficModel {
 
     fn n_items(&self, _list_model: &Self::Type) -> u32 {
         match self.tree.borrow().as_ref() {
-            Some(tree) => tree.row_count(),
+            Some(tree) => clamp(tree.row_count(), MAX_ROWS),
             None => 0
         }
     }
@@ -52,10 +54,10 @@ impl ListModelImpl for TrafficModel {
     {
         match self.tree.borrow().as_ref() {
             Some(tree) => {
-                if position >= tree.row_count() {
+                if position >= clamp(tree.row_count(), MAX_ROWS) {
                     None
                 } else {
-                    let result = tree.fetch(position)
+                    let result = tree.fetch(position as u64)
                         .map_err(|e| format!("{:?}", e));
                     Some(TrafficRowData::new(result).upcast::<glib::Object>())
                 }
@@ -72,7 +74,7 @@ impl ListModelImpl for DeviceModel {
 
     fn n_items(&self, _list_model: &Self::Type) -> u32 {
         match self.tree.borrow().as_ref() {
-            Some(tree) => tree.row_count(),
+            Some(tree) => clamp(tree.row_count(), MAX_ROWS),
             None => 0
         }
     }
@@ -82,10 +84,10 @@ impl ListModelImpl for DeviceModel {
     {
         match self.tree.borrow().as_ref() {
             Some(tree) => {
-                if position >= tree.row_count() {
+                if position >= clamp(tree.row_count(), MAX_ROWS) {
                     None
                 } else {
-                    let result = tree.fetch(position)
+                    let result = tree.fetch(position as u64)
                         .map_err(|e| format!("{:?}", e));
                     Some(DeviceRowData::new(result).upcast::<glib::Object>())
                 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,8 +2,6 @@
 
 mod imp;
 
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
 use gtk::prelude::ListModelExt;
@@ -11,7 +9,7 @@ use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 
 use crate::capture::{Capture, TrafficItem, DeviceItem};
-use crate::tree_list_model::{TreeListModel, TreeNode, ModelError};
+use crate::tree_list_model::{TreeListModel, ItemNodeRc, ModelError};
 
 // Public part of the Model type.
 glib::wrapper! {
@@ -24,7 +22,7 @@ glib::wrapper! {
 pub trait GenericModel<Item> where Self: Sized {
     fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError>;
     fn set_expanded(&self,
-                    node: &Rc<RefCell<TreeNode<Item>>>,
+                    node: &ItemNodeRc<Item>,
                     expanded: bool)
         -> Result<(), ModelError>;
     fn update(&self) -> Result<(), ModelError>;
@@ -40,7 +38,7 @@ impl GenericModel<TrafficItem> for TrafficModel {
     }
 
     fn set_expanded(&self,
-                    node: &Rc<RefCell<TreeNode<TrafficItem>>>,
+                    node: &ItemNodeRc<TrafficItem>,
                     expanded: bool)
         -> Result<(), ModelError>
     {
@@ -70,7 +68,7 @@ impl GenericModel<DeviceItem> for DeviceModel {
     }
 
     fn set_expanded(&self,
-                    node: &Rc<RefCell<TreeNode<DeviceItem>>>,
+                    node: &ItemNodeRc<DeviceItem>,
                     expanded: bool)
         -> Result<(), ModelError>
     {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,6 +2,7 @@
 
 mod imp;
 
+use std::cmp::min;
 use std::sync::{Arc, Mutex};
 
 use gtk::prelude::{IsA, ListModelExt};
@@ -20,14 +21,28 @@ glib::wrapper! {
 }
 
 trait ApplyUpdate {
-    fn apply_update(&self, position: u32, update: ModelUpdate);
+    fn apply_update(&self, position: u64, update: ModelUpdate);
+}
+
+const MAX_ROWS: u64 = u32::MAX as u64;
+
+fn clamp(value: u64, max: u64) -> u32 {
+    min(value, max) as u32
 }
 
 impl<T> ApplyUpdate for T where T: Sized + IsA<gio::ListModel> {
-    fn apply_update(&self, position: u32, update: ModelUpdate) {
-        let rows_removed = update.rows_removed + update.rows_changed;
-        let rows_added = update.rows_added + update.rows_changed;
-        self.items_changed(position, rows_removed, rows_added);
+    fn apply_update(&self, position: u64, update: ModelUpdate) {
+        let rows_addressable = MAX_ROWS - position as u64;
+        let rows_removed = clamp(
+            update.rows_removed + update.rows_changed,
+            rows_addressable);
+        let rows_added = clamp(
+            update.rows_added + update.rows_changed,
+            rows_addressable);
+        self.items_changed(
+            position as u32,
+            rows_removed as u32,
+            rows_added as u32);
     }
 }
 
@@ -60,8 +75,8 @@ impl GenericModel<TrafficItem> for TrafficModel {
             .borrow_mut()
             .as_mut()
             .unwrap()
-            .set_expanded(node, position, expanded)?;
-        self.apply_update(position + 1, update);
+            .set_expanded(node, position as u64, expanded)?;
+        self.apply_update(position as u64 + 1, update);
         Ok(())
     }
 
@@ -97,8 +112,8 @@ impl GenericModel<DeviceItem> for DeviceModel {
             .borrow_mut()
             .as_mut()
             .unwrap()
-            .set_expanded(node, position, expanded)?;
-        self.apply_update(position + 1, update);
+            .set_expanded(node, position as u64, expanded)?;
+        self.apply_update(position as u64 + 1, update);
         Ok(())
     }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -21,24 +21,13 @@ glib::wrapper! {
     pub struct DeviceModel(ObjectSubclass<imp::DeviceModel>) @implements gio::ListModel;
 }
 
-impl TrafficModel {
-    pub fn update(&self) -> Result<(), ModelError> {
-        let mut tree_opt  = self.imp().tree.borrow_mut();
-        let tree = tree_opt.as_mut().unwrap();
-        if let Some((position, _, added)) = tree.update()? {
-            drop(tree_opt);
-            self.items_changed(position, 0, added);
-        }
-        Ok(())
-    }
-}
-
 pub trait GenericModel<Item> where Self: Sized {
     fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError>;
     fn set_expanded(&self,
                     node: &Rc<RefCell<TreeNode<Item>>>,
                     expanded: bool)
         -> Result<(), ModelError>;
+    fn update(&self) -> Result<(), ModelError>;
 }
 
 impl GenericModel<TrafficItem> for TrafficModel {
@@ -59,6 +48,16 @@ impl GenericModel<TrafficItem> for TrafficModel {
         let tree = tree_opt.as_ref().unwrap();
         tree.set_expanded(self, node, expanded)
     }
+
+    fn update(&self) -> Result<(), ModelError> {
+        let mut tree_opt  = self.imp().tree.borrow_mut();
+        let tree = tree_opt.as_mut().unwrap();
+        if let Some((position, _, added)) = tree.update()? {
+            drop(tree_opt);
+            self.items_changed(position, 0, added);
+        }
+        Ok(())
+    }
 }
 
 impl GenericModel<DeviceItem> for DeviceModel {
@@ -78,5 +77,15 @@ impl GenericModel<DeviceItem> for DeviceModel {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
         tree.set_expanded(self, node, expanded)
+    }
+
+    fn update(&self) -> Result<(), ModelError> {
+        let mut tree_opt  = self.imp().tree.borrow_mut();
+        let tree = tree_opt.as_mut().unwrap();
+        if let Some((position, _, added)) = tree.update()? {
+            drop(tree_opt);
+            self.items_changed(position, 0, added);
+        }
+        Ok(())
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -46,7 +46,7 @@ impl GenericModel<TrafficItem> for TrafficModel {
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        let update = tree.set_expanded(self, node, position, expanded)?;
+        let update = tree.set_expanded(node, position, expanded)?;
         let rows_removed = update.rows_removed + update.rows_changed;
         let rows_added = update.rows_added + update.rows_changed;
         self.items_changed(position + 1, rows_removed, rows_added);
@@ -81,7 +81,7 @@ impl GenericModel<DeviceItem> for DeviceModel {
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        let update = tree.set_expanded(self, node, position, expanded)?;
+        let update = tree.set_expanded(node, position, expanded)?;
         let rows_removed = update.rows_removed + update.rows_changed;
         let rows_added = update.rows_added + update.rows_changed;
         self.items_changed(position + 1, rows_removed, rows_added);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -23,6 +23,7 @@ pub trait GenericModel<Item> where Self: Sized {
     fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError>;
     fn set_expanded(&self,
                     node: &ItemNodeRc<Item>,
+                    position: u32,
                     expanded: bool)
         -> Result<(), ModelError>;
     fn update(&self) -> Result<(), ModelError>;
@@ -39,12 +40,13 @@ impl GenericModel<TrafficItem> for TrafficModel {
 
     fn set_expanded(&self,
                     node: &ItemNodeRc<TrafficItem>,
+                    position: u32,
                     expanded: bool)
         -> Result<(), ModelError>
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        tree.set_expanded(self, node, expanded)
+        tree.set_expanded(self, node, position, expanded)
     }
 
     fn update(&self) -> Result<(), ModelError> {
@@ -69,12 +71,13 @@ impl GenericModel<DeviceItem> for DeviceModel {
 
     fn set_expanded(&self,
                     node: &ItemNodeRc<DeviceItem>,
+                    position: u32,
                     expanded: bool)
         -> Result<(), ModelError>
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        tree.set_expanded(self, node, expanded)
+        tree.set_expanded(self, node, position, expanded)
     }
 
     fn update(&self) -> Result<(), ModelError> {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -56,9 +56,10 @@ impl GenericModel<TrafficItem> for TrafficModel {
     fn update(&self) -> Result<(), ModelError> {
         let mut tree_opt  = self.imp().tree.borrow_mut();
         let tree = tree_opt.as_mut().unwrap();
-        if let Some((position, _, added)) = tree.update()? {
-            drop(tree_opt);
-            self.items_changed(position, 0, added);
+        if let Some((position, update)) = tree.update()? {
+            let rows_removed = update.rows_removed + update.rows_changed;
+            let rows_added = update.rows_added + update.rows_changed;
+            self.items_changed(position, rows_removed, rows_added);
         }
         Ok(())
     }
@@ -91,9 +92,10 @@ impl GenericModel<DeviceItem> for DeviceModel {
     fn update(&self) -> Result<(), ModelError> {
         let mut tree_opt  = self.imp().tree.borrow_mut();
         let tree = tree_opt.as_mut().unwrap();
-        if let Some((position, _, added)) = tree.update()? {
-            drop(tree_opt);
-            self.items_changed(position, 0, added);
+        if let Some((position, update)) = tree.update()? {
+            let rows_removed = update.rows_removed + update.rows_changed;
+            let rows_added = update.rows_added + update.rows_changed;
+            self.items_changed(position, rows_removed, rows_added);
         }
         Ok(())
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -46,7 +46,11 @@ impl GenericModel<TrafficItem> for TrafficModel {
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        tree.set_expanded(self, node, position, expanded)
+        let update = tree.set_expanded(self, node, position, expanded)?;
+        let rows_removed = update.rows_removed + update.rows_changed;
+        let rows_added = update.rows_added + update.rows_changed;
+        self.items_changed(position + 1, rows_removed, rows_added);
+        Ok(())
     }
 
     fn update(&self) -> Result<(), ModelError> {
@@ -77,7 +81,11 @@ impl GenericModel<DeviceItem> for DeviceModel {
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        tree.set_expanded(self, node, position, expanded)
+        let update = tree.set_expanded(self, node, position, expanded)?;
+        let rows_removed = update.rows_removed + update.rows_changed;
+        let rows_added = update.rows_added + update.rows_changed;
+        self.items_changed(position + 1, rows_removed, rows_added);
+        Ok(())
     }
 
     fn update(&self) -> Result<(), ModelError> {

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -1,23 +1,20 @@
 use gtk::glib::{self, subclass::prelude::*};
-use std::rc::Rc;
 use std::cell::RefCell;
 
 use crate::capture::{TrafficItem, DeviceItem};
-use crate::tree_list_model::{TreeNode};
-
-type ItemRc<Item> = Rc<RefCell<TreeNode<Item>>>;
+use crate::tree_list_model::ItemNodeRc;
 
 // The actual data structure that stores our values. This is not accessible
 // directly from the outside.
 #[derive(Default)]
 pub struct TrafficRowData {
-    pub(super) node: RefCell<Option<Result<ItemRc<TrafficItem>, String>>>,
+    pub(super) node: RefCell<Option<Result<ItemNodeRc<TrafficItem>, String>>>,
 
 }
 
 #[derive(Default)]
 pub struct DeviceRowData {
-    pub(super) node: RefCell<Option<Result<ItemRc<DeviceItem>, String>>>,
+    pub(super) node: RefCell<Option<Result<ItemNodeRc<DeviceItem>, String>>>,
 }
 
 // Basic declaration of our type for the GObject type system

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -6,14 +6,11 @@
 
 mod imp;
 
-use std::rc::Rc;
-use std::cell::RefCell;
-
 use gtk::glib;
 use gtk::subclass::prelude::*;
 
 use crate::capture::{TrafficItem, DeviceItem};
-use crate::tree_list_model::TreeNode;
+use crate::tree_list_model::ItemNodeRc;
 
 // Public part of the RowData type. This behaves like a normal gtk-rs-style GObject
 // binding
@@ -25,32 +22,32 @@ glib::wrapper! {
 }
 
 pub trait GenericRowData<Item> where Item: Copy {
-    fn new(node: Result<Rc<RefCell<TreeNode<Item>>>, String>) -> Self;
-    fn node(&self) -> Result<Rc<RefCell<TreeNode<Item>>>, String>;
+    fn new(node: Result<ItemNodeRc<Item>, String>) -> Self;
+    fn node(&self) -> Result<ItemNodeRc<Item>, String>;
 }
 
 impl GenericRowData<TrafficItem> for TrafficRowData {
-    fn new(node: Result<Rc<RefCell<TreeNode<TrafficItem>>>, String>) -> TrafficRowData {
+    fn new(node: Result<ItemNodeRc<TrafficItem>, String>) -> TrafficRowData {
         let row: TrafficRowData =
             glib::Object::new(&[]).expect("Failed to create row data");
         row.imp().node.replace(Some(node));
         row
     }
 
-    fn node(&self) -> Result<Rc<RefCell<TreeNode<TrafficItem>>>, String> {
+    fn node(&self) -> Result<ItemNodeRc<TrafficItem>, String> {
         self.imp().node.borrow().as_ref().unwrap().clone()
     }
 }
 
 impl GenericRowData<DeviceItem> for DeviceRowData {
-    fn new(node: Result<Rc<RefCell<TreeNode<DeviceItem>>>, String>) -> DeviceRowData {
+    fn new(node: Result<ItemNodeRc<DeviceItem>, String>) -> DeviceRowData {
         let row: DeviceRowData =
             glib::Object::new(&[]).expect("Failed to create row data");
         row.imp().node.replace(Some(node));
         row
     }
 
-    fn node(&self) -> Result<Rc<RefCell<TreeNode<DeviceItem>>>, String> {
+    fn node(&self) -> Result<ItemNodeRc<DeviceItem>, String> {
         self.imp().node.borrow().as_ref().unwrap().clone()
     }
 }

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -1,6 +1,5 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::num::TryFromIntError;
 use std::rc::{Rc, Weak};
 use std::sync::{Arc, Mutex};
 use std::ops::DerefMut;
@@ -13,8 +12,6 @@ use crate::capture::{Capture, CaptureError, ItemSource};
 pub enum ModelError {
     #[error(transparent)]
     CaptureError(#[from] CaptureError),
-    #[error(transparent)]
-    RangeError(#[from] TryFromIntError),
     #[error("Locking capture failed")]
     LockError,
     #[error("Node references a dropped parent")]
@@ -42,17 +39,17 @@ trait Node<Item> {
 
 struct Children<Item> {
     /// Number of direct children below this node.
-    direct_count: u32,
+    direct_count: u64,
 
     /// Total number nodes below this node, recursively.
-    total_count: u32,
+    total_count: u64,
 
     /// Expanded children of this item.
-    expanded: BTreeMap<u32, ItemNodeRc<Item>>,
+    expanded: BTreeMap<u64, ItemNodeRc<Item>>,
 }
 
 impl<Item> Children<Item> {
-    fn new(child_count: u32) -> Self {
+    fn new(child_count: u64) -> Self {
         Children {
             direct_count: child_count,
             total_count: child_count,
@@ -74,7 +71,7 @@ pub struct ItemNode<Item> {
     parent: Weak<RefCell<dyn Node<Item>>>,
 
     /// Index of this node below the parent Item.
-    item_index: u32,
+    item_index: u64,
 
     /// Children of this item.
     children: Children<Item>,
@@ -82,12 +79,12 @@ pub struct ItemNode<Item> {
 
 impl<Item> Children<Item> {
     /// Whether this child is expanded.
-    fn expanded(&self, index: u32) -> bool {
+    fn expanded(&self, index: u64) -> bool {
         self.expanded.contains_key(&index)
     }
 
     /// Iterate over the expanded children.
-    fn iter_expanded(&self) -> impl Iterator<Item=(&u32, &ItemNodeRc<Item>)> + '_ {
+    fn iter_expanded(&self) -> impl Iterator<Item=(&u64, &ItemNodeRc<Item>)> + '_ {
         self.expanded.iter()
     }
 
@@ -176,9 +173,9 @@ impl<Item> ItemNode<Item> where Item: Copy {
 }
 
 pub struct ModelUpdate {
-    pub rows_added: u32,
-    pub rows_removed: u32,
-    pub rows_changed: u32,
+    pub rows_added: u64,
+    pub rows_removed: u64,
+    pub rows_changed: u64,
 }
 
 pub struct TreeListModel<Item> {
@@ -193,22 +190,21 @@ where Item: 'static + Copy,
     pub fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError> {
         let mut cap = capture.lock().or(Err(ModelError::LockError))?;
         let item_count = cap.item_count(&None)?;
-        let child_count = u32::try_from(item_count)?;
         Ok(TreeListModel {
             capture: capture.clone(),
             root: Rc::new(RefCell::new(RootNode {
-                children: Children::new(child_count),
+                children: Children::new(item_count),
             })),
         })
     }
 
-    pub fn row_count(&self) -> u32 {
+    pub fn row_count(&self) -> u64 {
         self.root.borrow().children.total_count
     }
 
     pub fn set_expanded(&self,
                         node_ref: &ItemNodeRc<Item>,
-                        _position: u32,
+                        _position: u64,
                         expanded: bool)
         -> Result<ModelUpdate, ModelError>
     {
@@ -246,11 +242,11 @@ where Item: 'static + Copy,
         })
     }
 
-    pub fn update(&mut self) -> Result<Option<(u32, ModelUpdate)>, ModelError> {
+    pub fn update(&mut self) -> Result<Option<(u64, ModelUpdate)>, ModelError> {
         let mut cap = self.capture.lock().or(Err(ModelError::LockError))?;
 
         let mut root = self.root.borrow_mut();
-        let new_item_count = cap.item_count(&None)? as u32;
+        let new_item_count = cap.item_count(&None)?;
         let old_item_count = root.children.direct_count;
 
         if new_item_count == old_item_count {
@@ -270,7 +266,7 @@ where Item: 'static + Copy,
         Ok(Some((position, update)))
     }
 
-    pub fn fetch(&self, position: u32) -> Result<ItemNodeRc<Item>, ModelError> {
+    pub fn fetch(&self, position: u64) -> Result<ItemNodeRc<Item>, ModelError> {
         let mut parent_ref: Rc<RefCell<dyn Node<Item>>> = self.root.clone();
         let mut relative_position = position;
         'outer: loop {
@@ -304,13 +300,13 @@ where Item: 'static + Copy,
         // If we've broken out to this point, the node must be directly below `parent` - look it up.
         let mut cap = self.capture.lock().or(Err(ModelError::LockError))?;
         let parent = parent_ref.borrow();
-        let item = cap.item(&parent.item(), relative_position as u64)?;
+        let item = cap.item(&parent.item(), relative_position)?;
         let child_count = cap.child_count(&item)?;
         let node = ItemNode {
             item,
             parent: Rc::downgrade(&parent_ref),
             item_index: relative_position,
-            children: Children::new(child_count.try_into()?),
+            children: Children::new(child_count),
         };
 
         Ok(Rc::new(RefCell::new(node)))

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -210,6 +210,10 @@ where Item: 'static + Copy,
         })
     }
 
+    pub fn row_count(&self) -> u32 {
+        self.root.borrow().children.total_count
+    }
+
     pub fn set_expanded(&self,
                         node_ref: &ItemNodeRc<Item>,
                         _position: u32,
@@ -267,7 +271,7 @@ where Item: 'static + Copy,
         Ok(Some((position, 0, added)))
     }
 
-    fn fetch(&self, position: u32) -> Result<ItemNodeRc<Item>, ModelError> {
+    pub fn fetch(&self, position: u32) -> Result<ItemNodeRc<Item>, ModelError> {
         let mut parent_ref: Rc<RefCell<dyn Node<Item>>> = self.root.clone();
         let mut relative_position = position;
         'outer: loop {
@@ -311,23 +315,5 @@ where Item: 'static + Copy,
         };
 
         Ok(Rc::new(RefCell::new(node)))
-    }
-
-    // The following methods correspond to the ListModel interface, and can be
-    // called by a GObject wrapper class to implement that interface.
-
-    pub fn n_items(&self) -> u32 {
-        self.root.borrow().children.total_count
-    }
-
-    pub fn item(&self, position: u32) -> Option<Object> {
-        // First check that the position is valid (must be within the root
-        // node's total child count).
-        if position >= self.root.borrow().children.total_count {
-            return None
-        }
-        let node_or_err_msg = self.fetch(position).map_err(|e| format!("{:?}", e));
-        let row_data = RowData::new(node_or_err_msg);
-        Some(row_data.upcast::<Object>())
     }
 }

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -1,18 +1,13 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::marker::PhantomData;
 use std::num::TryFromIntError;
 use std::rc::{Rc, Weak};
 use std::sync::{Arc, Mutex};
 use std::ops::DerefMut;
 
-use gtk::prelude::{IsA, Cast};
-use gtk::glib::Object;
-
 use thiserror::Error;
 
 use crate::capture::{Capture, CaptureError, ItemSource};
-use crate::row_data::GenericRowData;
 
 #[derive(Error, Debug)]
 pub enum ModelError {
@@ -186,15 +181,13 @@ pub struct ModelUpdate {
     pub rows_changed: u32,
 }
 
-pub struct TreeListModel<Item, RowData> {
-    _marker: PhantomData<RowData>,
+pub struct TreeListModel<Item> {
     capture: Arc<Mutex<Capture>>,
     root: Rc<RefCell<RootNode<Item>>>,
 }
 
-impl<Item, RowData> TreeListModel<Item, RowData>
+impl<Item> TreeListModel<Item>
 where Item: 'static + Copy,
-      RowData: GenericRowData<Item> + IsA<Object> + Cast,
       Capture: ItemSource<Item>
 {
     pub fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError> {
@@ -202,7 +195,6 @@ where Item: 'static + Copy,
         let item_count = cap.item_count(&None)?;
         let child_count = u32::try_from(item_count)?;
         Ok(TreeListModel {
-            _marker: PhantomData,
             capture: capture.clone(),
             root: Rc::new(RefCell::new(RootNode {
                 children: Children::new(child_count),

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -214,7 +214,6 @@ where Item: 'static + Copy,
     }
 
     pub fn set_expanded(&self,
-                        _model: &Model,
                         node_ref: &ItemNodeRc<Item>,
                         _position: u32,
                         expanded: bool)

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -8,12 +8,10 @@ use std::ops::DerefMut;
 
 use gtk::prelude::{IsA, Cast};
 use gtk::glib::Object;
-use gtk::gio::prelude::ListModelExt;
 
 use thiserror::Error;
 
 use crate::capture::{Capture, CaptureError, ItemSource};
-use crate::model::GenericModel;
 use crate::row_data::GenericRowData;
 
 #[derive(Error, Debug)]
@@ -188,15 +186,14 @@ pub struct ModelUpdate {
     pub rows_changed: u32,
 }
 
-pub struct TreeListModel<Item, Model, RowData> {
-    _marker: PhantomData<(Model, RowData)>,
+pub struct TreeListModel<Item, RowData> {
+    _marker: PhantomData<RowData>,
     capture: Arc<Mutex<Capture>>,
     root: Rc<RefCell<RootNode<Item>>>,
 }
 
-impl<Item, Model, RowData> TreeListModel<Item, Model, RowData>
+impl<Item, RowData> TreeListModel<Item, RowData>
 where Item: 'static + Copy,
-      Model: GenericModel<Item> + ListModelExt,
       RowData: GenericRowData<Item> + IsA<Object> + Cast,
       Capture: ItemSource<Item>
 {

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -26,6 +26,8 @@ pub enum ModelError {
     LockError,
     #[error("Node references a dropped parent")]
     ParentDropped,
+    #[error("Node already in requested expansion state")]
+    AlreadyDone,
 }
 
 pub type ItemNodeRc<Item> = Rc<RefCell<ItemNode<Item>>>;
@@ -214,7 +216,7 @@ where Item: 'static + Copy,
     {
         let node = node_ref.borrow();
         if node.expanded() == expanded {
-            return Ok(());
+            return Err(ModelError::AlreadyDone);
         }
 
         // New rows will be added or removed after the current one.

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -246,7 +246,7 @@ where Item: 'static + Copy,
         })
     }
 
-    pub fn update(&mut self) -> Result<Option<(u32, u32, u32)>, ModelError> {
+    pub fn update(&mut self) -> Result<Option<(u32, ModelUpdate)>, ModelError> {
         let mut cap = self.capture.lock().or(Err(ModelError::LockError))?;
 
         let mut node_borrow = self.root.borrow_mut();
@@ -257,10 +257,14 @@ where Item: 'static + Copy,
         }
 
         let position = node_borrow.children.total_count;
-        let added = new_child_count - node_borrow.children.direct_count;
+        let update = ModelUpdate {
+            rows_added: new_child_count - node_borrow.children.direct_count,
+            rows_removed: 0,
+            rows_changed: 0,
+        };
         node_borrow.children.direct_count = new_child_count;
-        node_borrow.children.total_count += added;
-        Ok(Some((position, 0, added)))
+        node_borrow.children.total_count += update.rows_added;
+        Ok(Some((position, update)))
     }
 
     pub fn fetch(&self, position: u32) -> Result<ItemNodeRc<Item>, ModelError> {


### PR DESCRIPTION
This PR stacks on #50 and collects some improvements to the existing TreeListModel code. The key changes are:

1. Define separate types for the root node and item nodes, with a common `Node` trait, and a `Children` structure used by all three. This allows the same code to be used to access the children of either, and avoids needing to handle the root node case in contexts where we know we are dealing with an item node.
2. When the user expands or collapses an item, pass its absolute position, which we can retrieve from the `ListItem`, into `set_expanded`. This saves us needing to recalculate it from the tree and removes the need for the `relative_position` method.
3. Return an error if `set_expanded` is called to expand a node that is already expanded, or vice versa.
4. Decouple the `TreeListModel` implementation from its GTK wrapper:
    1. Rather than having `set_expanded` call into the `items_changed` method of the `ListModel`, have it return a `ModelUpdate` struct giving the row count changes, then handle the GTK-specific details in the wrapper. This allows us to remove the `Model` type parameter from the definition of `TreeListModel`. The live `update` method is also modified to return a `ModelUpdate`.
    2. Remove the `n_items` and `item` methods from `TreeListModel`, and have the wrapper call directly into `fetch` and a new `row_count` method. This allows us to remove the `RowData` type parameter also, making the `TreeListModel` implementation fully independent of the GTK API.
    3. Use `u64` indices in `TreeListModel`, putting the necessary adjustments for compatibility with GTK's `u32`  indices into the GTK wrapper instead.
5. Remove the `complete` methods, which are not currently used. These will be replaced with a new API in the next PR.

This PR is the first in a series of three which will eventually introduce the interleaved tree model. The second PR will reimplement `TreeListModel` with a region map, and ensure that all required UI updates occur during live capture. The third PR will introduce the interleaving.