### PR TITLE
Update device tree during live update as well as traffic tree.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use gtk::{
 
 use pcap_file::{PcapError, pcap::PcapReader};
 
-use model::{GenericModel, TrafficModel};
+use model::{GenericModel, TrafficModel, DeviceModel};
 use row_data::GenericRowData;
 use expander::ExpanderWrapper;
 use tree_list_model::ModelError;
@@ -218,10 +218,18 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
 
             MODELS.with::<_, Result<(), PacketryError>>(|models| {
                 for model in models.borrow().iter() {
-                    let model = model.clone();
-                    if let Ok(tree_model) = model.downcast::<TrafficModel>() {
+                    if let Ok(tree_model) = model
+                        .clone()
+                        .downcast::<TrafficModel>()
+                    {
                         tree_model.update()?;
-                    };
+                    }
+                    else if let Ok(tree_model) = model
+                        .clone()
+                        .downcast::<DeviceModel>()
+                    {
+                        tree_model.update()?;
+                    }
                 }
                 Ok(())
             })?;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -21,24 +21,13 @@ glib::wrapper! {
     pub struct DeviceModel(ObjectSubclass<imp::DeviceModel>) @implements gio::ListModel;
 }
 
-impl TrafficModel {
-    pub fn update(&self) -> Result<(), ModelError> {
-        let mut tree_opt  = self.imp().tree.borrow_mut();
-        let tree = tree_opt.as_mut().unwrap();
-        if let Some((position, _, added)) = tree.update()? {
-            drop(tree_opt);
-            self.items_changed(position, 0, added);
-        }
-        Ok(())
-    }
-}
-
 pub trait GenericModel<Item> where Self: Sized {
     fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError>;
     fn set_expanded(&self,
                     node: &Rc<RefCell<TreeNode<Item>>>,
                     expanded: bool)
         -> Result<(), ModelError>;
+    fn update(&self) -> Result<(), ModelError>;
 }
 
 impl GenericModel<TrafficItem> for TrafficModel {
@@ -59,6 +48,16 @@ impl GenericModel<TrafficItem> for TrafficModel {
         let tree = tree_opt.as_ref().unwrap();
         tree.set_expanded(self, node, expanded)
     }
+
+    fn update(&self) -> Result<(), ModelError> {
+        let mut tree_opt  = self.imp().tree.borrow_mut();
+        let tree = tree_opt.as_mut().unwrap();
+        if let Some((position, _, added)) = tree.update()? {
+            drop(tree_opt);
+            self.items_changed(position, 0, added);
+        }
+        Ok(())
+    }
 }
 
 impl GenericModel<DeviceItem> for DeviceModel {
@@ -78,5 +77,15 @@ impl GenericModel<DeviceItem> for DeviceModel {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
         tree.set_expanded(self, node, expanded)
+    }
+
+    fn update(&self) -> Result<(), ModelError> {
+        let mut tree_opt  = self.imp().tree.borrow_mut();
+        let tree = tree_opt.as_mut().unwrap();
+        if let Some((position, _, added)) = tree.update()? {
+            drop(tree_opt);
+            self.items_changed(position, 0, added);
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
This fixes new devices not appearing in the device tree pane during live capture.