### PR TITLE
UI features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ humansize = "1.1.1"
 bisection = "0.1.0"
 derive_more = "0.99.17"
 rusb = "0.9.1"
+
+[features]
+step-decoder = []

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -423,7 +423,7 @@ pub struct Capture {
 
 impl Capture {
     pub fn new() -> Result<Self, CaptureError> {
-        Ok(Capture {
+        let mut capture = Capture {
             packet_data: FileVec::new()?,
             packet_index: HybridIndex::new(2)?,
             transaction_index: HybridIndex::new(1)?,
@@ -436,7 +436,12 @@ impl Capture {
             endpoint_states: FileVec::new()?,
             endpoint_state_index: HybridIndex::new(1)?,
             end_index: HybridIndex::new(1)?,
-        })
+        };
+        let default_addr = DeviceAddr(0);
+        let default_device = Device { address: default_addr };
+        let default_id = capture.devices.push(&default_device)?;
+        capture.device_data.set(default_id, DeviceData::default());
+        Ok(capture)
     }
 
     pub fn print_storage_summary(&self) {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -441,6 +441,15 @@ impl Capture {
         let default_device = Device { address: default_addr };
         let default_id = capture.devices.push(&default_device)?;
         capture.device_data.set(default_id, DeviceData::default());
+        for number in [INVALID_EP_NUM, FRAMING_EP_NUM] {
+            let mut endpoint = Endpoint::default();
+            endpoint.set_device_id(default_id);
+            endpoint.set_device_address(default_addr);
+            endpoint.set_number(EndpointNum(number));
+            endpoint.set_direction(Direction::Out);
+            let endpoint_id = capture.endpoints.push(&endpoint)?;
+            capture.endpoint_traffic.set(endpoint_id, EndpointTraffic::new()?);
+        }
         Ok(capture)
     }
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -152,6 +152,7 @@ pub struct EndpointTraffic {
     pub end_index: HybridIndex<EndpointTransferId, TrafficItemId>,
 }
 
+#[derive(Default)]
 pub struct DeviceData {
     pub device_descriptor: Option<DeviceDescriptor>,
     pub configurations: VecMap<ConfigNum, Configuration>,

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -152,6 +152,18 @@ pub struct EndpointTraffic {
     pub end_index: HybridIndex<EndpointTransferId, TrafficItemId>,
 }
 
+impl EndpointTraffic {
+    pub fn new() -> Result<Self, CaptureError> {
+        Ok(EndpointTraffic {
+            transaction_ids: HybridIndex::new(1)?,
+            transfer_index: HybridIndex::new(1)?,
+            data_index: HybridIndex::new(1)?,
+            total_data: 0,
+            end_index: HybridIndex::new(1)?,
+        })
+    }
+}
+
 #[derive(Default)]
 pub struct DeviceData {
     pub device_descriptor: Option<DeviceDescriptor>,

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1271,7 +1271,7 @@ mod tests {
                     let pcap_file = File::open(cap_path).unwrap();
                     let pcap_reader = PcapReader::new(pcap_file).unwrap();
                     let mut cap = Capture::new().unwrap();
-                    let mut decoder = Decoder::new(&mut cap).unwrap();
+                    let mut decoder = Decoder::default();
                     for result in pcap_reader {
                         let packet = result.unwrap().data;
                         decoder.handle_raw_packet(&mut cap, &packet).unwrap();

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -124,8 +124,11 @@ pub enum EndpointState {
     Ending = 3,
 }
 
-pub const INVALID_EP_NUM: u8 = 0x10;
-pub const FRAMING_EP_NUM: u8 = 0x11;
+pub const CONTROL_EP_NUM: EndpointNum = EndpointNum(0);
+pub const INVALID_EP_NUM: EndpointNum = EndpointNum(0x10);
+pub const FRAMING_EP_NUM: EndpointNum = EndpointNum(0x11);
+pub const INVALID_EP_ID: EndpointId = EndpointId::constant(0);
+pub const FRAMING_EP_ID: EndpointId = EndpointId::constant(1);
 
 #[derive(Copy, Clone, Debug)]
 pub enum EndpointType {
@@ -206,10 +209,10 @@ impl DeviceData {
         -> (EndpointType, Option<usize>)
     {
         use EndpointType::*;
-        match addr.0 {
+        match addr.number() {
             INVALID_EP_NUM => (Invalid, None),
             FRAMING_EP_NUM => (Framing, None),
-            0 => (
+            CONTROL_EP_NUM => (
                 Normal(usb::EndpointType::Control),
                 self.device_descriptor.map(|desc| {
                     desc.max_packet_size_0 as usize
@@ -445,7 +448,7 @@ impl Capture {
             let mut endpoint = Endpoint::default();
             endpoint.set_device_id(default_id);
             endpoint.set_device_address(default_addr);
-            endpoint.set_number(EndpointNum(number));
+            endpoint.set_number(number);
             endpoint.set_direction(Direction::Out);
             let endpoint_id = capture.endpoints.push(&endpoint)?;
             capture.endpoint_traffic.set(endpoint_id, EndpointTraffic::new()?);
@@ -1318,5 +1321,9 @@ pub mod prelude {
         TransactionId,
         TransferId,
         TransferIndexEntry,
+        INVALID_EP_NUM,
+        FRAMING_EP_NUM,
+        INVALID_EP_ID,
+        FRAMING_EP_ID,
     };
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -40,6 +40,22 @@ struct EndpointData {
     payload: Vec<u8>,
 }
 
+impl EndpointData {
+    fn new(device_id: DeviceId, address: EndpointAddr) -> EndpointData {
+        EndpointData {
+            address,
+            device_id,
+            active: None,
+            ended: None,
+            transaction_count: 0,
+            last: None,
+            last_success: false,
+            setup: None,
+            payload: Vec::new(),
+        }
+    }
+}
+
 #[derive(Default)]
 struct TransactionState {
     first: Option<PID>,
@@ -326,17 +342,9 @@ impl Decoder {
         endpoint.set_direction(direction);
         let endpoint_id = capture.endpoints.push(&endpoint)?;
         let address = EndpointAddr::from_parts(number, direction);
-        self.endpoint_data.set(endpoint_id, EndpointData {
-            address,
-            device_id,
-            active: None,
-            ended: None,
-            transaction_count: 0,
-            last: None,
-            last_success: false,
-            setup: None,
-            payload: Vec::new(),
-        });
+        self.endpoint_data.set(
+            endpoint_id,
+            EndpointData::new(device_id, address));
         capture.endpoint_traffic.set(endpoint_id, EndpointTraffic::new()?);
         let ep_state = EndpointState::Idle as u8;
         self.last_endpoint_state.push(ep_state);

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use crate::usb::{self, prelude::*};
-use crate::capture::{prelude::*, INVALID_EP_NUM, FRAMING_EP_NUM};
+use crate::capture::prelude::*;
 use crate::hybrid_index::Number;
 use crate::vec_map::{VecMap, Key};
 
@@ -190,17 +190,14 @@ impl Default for Decoder {
         let default_id = DeviceId::from(0);
         decoder.device_index.set(default_addr, default_id);
         for (ep_id, ep_num) in [
-            (Decoder::INVALID_EP_ID, INVALID_EP_NUM),
-            (Decoder::FRAMING_EP_ID, FRAMING_EP_NUM)]
+            (INVALID_EP_ID, INVALID_EP_NUM),
+            (FRAMING_EP_ID, FRAMING_EP_NUM)]
         {
             decoder.endpoint_data.set(
                 ep_id,
                 EndpointData::new(
                     default_id,
-                    EndpointAddr::from_parts(
-                        EndpointNum(ep_num),
-                        Direction::Out
-                    )
+                    EndpointAddr::from_parts(ep_num, Direction::Out)
                 )
             );
             let ep_state = EndpointState::Idle as u8;
@@ -211,9 +208,6 @@ impl Default for Decoder {
 }
 
 impl Decoder {
-    const INVALID_EP_ID: EndpointId = EndpointId::constant(0);
-    const FRAMING_EP_ID: EndpointId = EndpointId::constant(1);
-
     pub fn handle_raw_packet(&mut self, capture: &mut Capture, packet: &[u8])
         -> Result<(), CaptureError>
     {
@@ -293,10 +287,10 @@ impl Decoder {
         state.last = state.first;
         self.transaction_state.endpoint_id = Some(
             match PacketFields::from_packet(packet) {
-                PacketFields::SOF(_) => Decoder::FRAMING_EP_ID,
+                PacketFields::SOF(_) => FRAMING_EP_ID,
                 PacketFields::Token(token) =>
                     self.token_endpoint(capture, pid, &token)?,
-                _ => Decoder::INVALID_EP_ID,
+                _ => INVALID_EP_ID,
             }
         );
         Ok(())

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -304,13 +304,7 @@ impl Decoder {
         let device = Device { address };
         let device_id = capture.devices.push(&device)?;
         self.device_index.set(address, device_id);
-        capture.device_data.set(device_id, DeviceData {
-            device_descriptor: None,
-            configurations: VecMap::new(),
-            config_number: None,
-            endpoint_details: VecMap::new(),
-            strings: VecMap::new(),
-        });
+        capture.device_data.set(device_id, DeviceData::default());
         Ok(device_id)
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -189,12 +189,23 @@ impl Decoder {
         let default_addr = DeviceAddr(0);
         let default_id = DeviceId::from(0);
         decoder.device_index.set(default_addr, default_id);
-        let invalid_id = decoder.add_endpoint(
-            capture, default_addr, EndpointNum(INVALID_EP_NUM), Direction::Out)?;
-        let framing_id = decoder.add_endpoint(
-            capture, default_addr, EndpointNum(FRAMING_EP_NUM), Direction::Out)?;
-        assert!(invalid_id == Decoder::INVALID_EP_ID);
-        assert!(framing_id == Decoder::FRAMING_EP_ID);
+        for (ep_id, ep_num) in [
+            (Decoder::INVALID_EP_ID, INVALID_EP_NUM),
+            (Decoder::FRAMING_EP_ID, FRAMING_EP_NUM)]
+        {
+            decoder.endpoint_data.set(
+                ep_id,
+                EndpointData::new(
+                    default_id,
+                    EndpointAddr::from_parts(
+                        EndpointNum(ep_num),
+                        Direction::Out
+                    )
+                )
+            );
+            let ep_state = EndpointState::Idle as u8;
+            decoder.last_endpoint_state.push(ep_state);
+        }
         Ok(decoder)
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -176,8 +176,8 @@ pub struct Decoder {
     transaction_state: TransactionState,
 }
 
-impl Decoder {
-    pub fn new(capture: &mut Capture) -> Result<Self, CaptureError> {
+impl Default for Decoder {
+    fn default() -> Decoder {
         let mut decoder = Decoder {
             device_index: VecMap::new(),
             endpoint_index: VecMap::new(),
@@ -206,9 +206,11 @@ impl Decoder {
             let ep_state = EndpointState::Idle as u8;
             decoder.last_endpoint_state.push(ep_state);
         }
-        Ok(decoder)
+        decoder
     }
+}
 
+impl Decoder {
     const INVALID_EP_ID: EndpointId = EndpointId::constant(0);
     const FRAMING_EP_ID: EndpointId = EndpointId::constant(1);
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -2,7 +2,7 @@ use std::mem::size_of;
 
 use crate::usb::{self, prelude::*};
 use crate::capture::{prelude::*, INVALID_EP_NUM, FRAMING_EP_NUM};
-use crate::hybrid_index::{HybridIndex, Number};
+use crate::hybrid_index::Number;
 use crate::vec_map::{VecMap, Key};
 
 use CaptureError::IndexError;
@@ -337,13 +337,7 @@ impl Decoder {
             setup: None,
             payload: Vec::new(),
         });
-        capture.endpoint_traffic.set(endpoint_id, EndpointTraffic {
-            transaction_ids: HybridIndex::new(1)?,
-            transfer_index: HybridIndex::new(1)?,
-            data_index: HybridIndex::new(1)?,
-            total_data: 0,
-            end_index: HybridIndex::new(1)?,
-        });
+        capture.endpoint_traffic.set(endpoint_id, EndpointTraffic::new()?);
         let ep_state = EndpointState::Idle as u8;
         self.last_endpoint_state.push(ep_state);
         Ok(endpoint_id)

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -186,10 +186,13 @@ impl Decoder {
             last_item_endpoint: None,
             transaction_state: TransactionState::default(),
         };
+        let default_addr = DeviceAddr(0);
+        let default_id = DeviceId::from(0);
+        decoder.device_index.set(default_addr, default_id);
         let invalid_id = decoder.add_endpoint(
-            capture, DeviceAddr(0), EndpointNum(INVALID_EP_NUM), Direction::Out)?;
+            capture, default_addr, EndpointNum(INVALID_EP_NUM), Direction::Out)?;
         let framing_id = decoder.add_endpoint(
-            capture, DeviceAddr(0), EndpointNum(FRAMING_EP_NUM), Direction::Out)?;
+            capture, default_addr, EndpointNum(FRAMING_EP_NUM), Direction::Out)?;
         assert!(invalid_id == Decoder::INVALID_EP_ID);
         assert!(framing_id == Decoder::FRAMING_EP_ID);
         Ok(decoder)

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,9 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
         .title("Packetry")
         .build();
 
+    let header_bar = gtk::HeaderBar::new();
+
+    window.set_titlebar(Some(&header_bar));
     window.show();
     WINDOW.with(|win_opt| win_opt.replace(Some(window.clone())));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,21 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
 
     let header_bar = gtk::HeaderBar::new();
 
+    let open_button = gtk::Button::from_icon_name("document-open");
+    let save_button = gtk::Button::from_icon_name("document-save");
+    let capture_button = gtk::Button::from_icon_name("media-record");
+    let stop_button = gtk::Button::from_icon_name("media-playback-stop");
+
+    open_button.set_sensitive(false);
+    save_button.set_sensitive(false);
+    capture_button.set_sensitive(false);
+    stop_button.set_sensitive(false);
+
+    header_bar.pack_start(&open_button);
+    header_bar.pack_start(&save_button);
+    header_bar.pack_start(&capture_button);
+    header_bar.pack_start(&stop_button);
+
     window.set_titlebar(Some(&header_bar));
     window.show();
     WINDOW.with(|win_opt| win_opt.replace(Some(window.clone())));

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,10 +191,9 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
 
     let args: Vec<_> = std::env::args().collect();
     let capture = Arc::new(Mutex::new(Capture::new()?));
-    let app_capture = capture.clone();
 
     let (traffic_model, traffic_view) =
-        create_view::<TrafficItem, TrafficModel, TrafficRowData>(&app_capture);
+        create_view::<TrafficItem, TrafficModel, TrafficRowData>(&capture);
 
     let traffic_window = gtk::ScrolledWindow::builder()
         .hscrollbar_policy(gtk::PolicyType::Automatic)
@@ -205,7 +204,7 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
     traffic_window.set_child(Some(&traffic_view));
 
     let (device_model, device_view) =
-        create_view::<DeviceItem, DeviceModel, DeviceRowData>(&app_capture);
+        create_view::<DeviceItem, DeviceModel, DeviceRowData>(&capture);
 
     let device_window = gtk::ScrolledWindow::builder()
         .hscrollbar_policy(gtk::PolicyType::Automatic)

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,23 +287,26 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
 fn display_error(result: Result<(), PacketryError>) {
     if let Err(e) = result {
         let message = format!("{e}");
-        WINDOW.with(|win_opt| {
-            match win_opt.borrow().as_ref() {
-                None => println!("{message}"),
-                Some(window) => {
-                    let dialog = MessageDialog::new(
-                        Some(window),
-                        DialogFlags::MODAL,
-                        MessageType::Error,
-                        ButtonsType::Close,
-                        &message
-                    );
-                    dialog.set_transient_for(Some(window));
-                    dialog.set_modal(true);
-                    dialog.connect_response(move |dialog, _| dialog.destroy());
-                    dialog.show();
+        gtk::glib::idle_add_once(move || {
+            WINDOW.with(|win_opt| {
+                match win_opt.borrow().as_ref() {
+                    None => println!("{message}"),
+                    Some(window) => {
+                        let dialog = MessageDialog::new(
+                            Some(window),
+                            DialogFlags::MODAL,
+                            MessageType::Error,
+                            ButtonsType::Close,
+                            &message
+                        );
+                        dialog.set_transient_for(Some(window));
+                        dialog.set_modal(true);
+                        dialog.connect_response(
+                            move |dialog, _| dialog.destroy());
+                        dialog.show();
+                    }
                 }
-            }
+            });
         });
     }
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -757,13 +757,18 @@ fn fmt_str_id(strings: &VecMap<StringId, UTF16ByteVec>, id: StringId)
 
 pub struct UTF16Bytes<'b>(&'b [u8]);
 
+impl<'b> UTF16Bytes<'b> {
+    fn chars(&self) -> Vec<u16> {
+        self.0.chunks_exact(2)
+              .into_iter()
+              .map(|a| u16::from_le_bytes([a[0], a[1]]))
+              .collect()
+    }
+}
+
 impl std::fmt::Display for UTF16Bytes<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let chars: Vec<u16> =
-            self.0.chunks_exact(2)
-                  .into_iter()
-                  .map(|a| u16::from_le_bytes([a[0], a[1]]))
-                  .collect();
+        let chars = self.chars();
         match String::from_utf16(&chars) {
             Ok(string) => write!(f, "'{}'", string.escape_default()),
             Err(_) => write!(f,
@@ -774,6 +779,12 @@ impl std::fmt::Display for UTF16Bytes<'_> {
 }
 
 pub struct UTF16ByteVec(pub Vec<u8>);
+
+impl UTF16ByteVec {
+    pub fn chars(&self) -> Vec<u16> {
+        UTF16Bytes(self.0.as_slice()).chars()
+    }
+}
 
 impl std::fmt::Display for UTF16ByteVec {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {


### PR DESCRIPTION
This PR adds new UI features as follows:

1. Display product names in the device tree when known.
2. Run the decoder loop in its own thread.
3. Display a progress bar whilst loading a pcap file.
4. Add a header bar to the main window.
5. Clean up the construction of `Capture` and `Decoder` to make it simpler to reset to an empty capture.
6. Add open, save, capture and stop buttons to header bar.
7. Connect the capture and stop buttons to control LUNA capture.
8. Start a new empty `Capture` and reset UI when a new capture is started.
9. Connect the open button to start a file chooser and load a pcap file.
10. Connect the stop button to allow cancelling the ongoing loading of a pcap file.
11. Add a compile time optional feature that listens on a TCP port and blocks the decoder until a byte is received. This is useful for single-stepping the decoder and UI update for debugging purposes.

Closes #11.