### PR TITLE
Cache dependencies to speed up CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libgtk-4-dev build-essential
+          version: 0
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install stable components
         uses: actions-rs/toolchain@v1
@@ -24,11 +31,6 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install libgtk-4-dev build-essential
 
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
@@ -51,15 +53,17 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      - name: Install dependencies (Ubuntu)
-        run: |
-          sudo apt update
-          sudo apt install libgtk-4-dev build-essential
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libgtk-4-dev build-essential
+          version: 0
         if: startsWith(matrix.os, 'ubuntu-')
 
       - name: Install dependencies (macOS)
         run: brew install gtk4
         if: matrix.os == 'macos-latest'
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
This PR uses the [rust-cache](https://github.com/marketplace/actions/rust-cache) and [cache-apt-packages](https://github.com/marketplace/actions/cache-apt-packages) actions to speed up our CI workflow by preloading the Rust toolchain, the installed Debian packages for the Ubuntu runner, and all Rust dependencies built with Cargo. The actions used are already set up to use sensible caching policies for the items in question, so the cache should be invalidated as needed when dependency versions change.

Before ([build](https://github.com/greatscottgadgets/packetry/actions/runs/3709423685/usage) of #52):

![image](https://user-images.githubusercontent.com/673823/208010640-9108d4c5-1c69-4fce-86b5-3ce044639ad8.png)

After ([build of same change](https://github.com/martinling/packetry/actions/runs/3709779406/usage), appended to this PR):

![image](https://user-images.githubusercontent.com/673823/208010804-e4d8d130-c6ac-4b87-a5ad-50658b9253bd.png)
