### PR TITLE
CI: Work around bug in cache-apt-pkgs-action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libgtk-4-dev build-essential
-          version: 0
+          version: 2
 
       - uses: Swatinem/rust-cache@v2
 
@@ -56,7 +56,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libgtk-4-dev build-essential
-          version: 0
+          version: 2
         if: startsWith(matrix.os, 'ubuntu-')
 
       - name: Install dependencies (macOS)


### PR DESCRIPTION
Workaround for https://github.com/awalsh128/cache-apt-pkgs-action/issues/82.

This just bumps the cache version which is all we need to do; the broken release was already reverted.