### PR TITLE
Use variable names in format strings where possible

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -202,7 +202,7 @@ impl Decoder {
             (_, PID::OUT)  => Direction::Out,
             (_, PID::PING) => Direction::Out,
             _ => return Err(IndexError(format!(
-                "PID {} does not indicate a direction", pid)))
+                "PID {pid} does not indicate a direction")))
         };
         let key = EndpointKey {
             dev_addr,
@@ -365,8 +365,7 @@ impl Decoder {
         let endpoint_id = self.current_endpoint_id()?;
         self.endpoint_data.get(endpoint_id).ok_or_else(||
             IndexError(format!(
-                "Decoder has no data for current endpoint ID {}",
-                endpoint_id)))
+                "Decoder has no data for current endpoint ID {endpoint_id}")))
     }
 
     fn current_endpoint_data_mut(&mut self)
@@ -375,8 +374,7 @@ impl Decoder {
         let endpoint_id = self.current_endpoint_id()?;
         self.endpoint_data.get_mut(endpoint_id).ok_or_else(||
             IndexError(format!(
-                "Decoder has no data for current endpoint ID {}",
-                endpoint_id)))
+                "Decoder has no data for current endpoint ID {endpoint_id}")))
     }
 
     fn current_device_data<'a>(&self, capture: &'a mut Capture)
@@ -734,7 +732,7 @@ impl Decoder {
         let ep_data = self.current_endpoint_data()?;
         let ep_transfer_id = ep_data.active.ok_or_else(||
             IndexError(format!(
-                "No active transfer on endpoint {}", endpoint_id)))?;
+                "No active transfer on endpoint {endpoint_id}")))?;
         self.add_endpoint_state(capture, endpoint_id, start)?;
         let mut entry = TransferIndexEntry::default();
         entry.set_endpoint_id(endpoint_id);
@@ -783,7 +781,7 @@ impl Decoder {
             let ep_data = self.endpoint_data
                 .get_mut(endpoint_id)
                 .ok_or_else(|| IndexError(
-                    format!("Endpoint {} has no associated data", i)))?;
+                    format!("Endpoint {i} has no associated data")))?;
             if let Some(ep_transfer_id) = ep_data.ended.take() {
                 // This transfer has ended and is not yet linked to an item.
                 let ep_traf = capture.endpoint_traffic(endpoint_id)?;

--- a/src/expander/mod.rs
+++ b/src/expander/mod.rs
@@ -55,7 +55,7 @@ impl ExpanderWrapper {
 
     pub fn set_connectors(&self, connectors: String) {
         self.imp().conn_label.borrow_mut().set_markup(
-                format!("<tt>{}</tt>", connectors).as_str());
+                format!("<tt>{connectors}</tt>").as_str());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ fn create_view<Item: 'static, Model, RowData>(capture: &Arc<Mutex<Capture>>)
             },
             Err(msg) => {
                 expander_wrapper.set_connectors("".to_string());
-                expander_wrapper.set_text(format!("Error: {}", msg));
+                expander_wrapper.set_text(format!("Error: {msg}"));
                 expander.set_visible(false);
             }
         };
@@ -286,10 +286,10 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
 
 fn display_error(result: Result<(), PacketryError>) {
     if let Err(e) = result {
-        let message = format!("{}", e);
+        let message = format!("{e}");
         WINDOW.with(|win_opt| {
             match win_opt.borrow().as_ref() {
-                None => println!("{}", message),
+                None => println!("{message}"),
                 Some(window) => {
                     let dialog = MessageDialog::new(
                         Some(window),

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -103,7 +103,7 @@ impl<Item> TreeNode<Item> where Item: Copy {
                 Ok(mut guard) => {
                     let cap = guard.deref_mut();
                     match func(cap, &item) {
-                        Err(e) => format!("Error: {:?}", e),
+                        Err(e) => format!("Error: {e:?}"),
                         Ok(string) => string
                     }
                 }
@@ -262,7 +262,7 @@ where Item: Copy,
         if position >= self.root.borrow().total_child_count {
             return None
         }
-        let node_or_err_msg = self.fetch(position).map_err(|e| format!("{:?}", e));
+        let node_or_err_msg = self.fetch(position).map_err(|e| format!("{e:?}"));
         let row_data = RowData::new(node_or_err_msg);
         Some(row_data.upcast::<Object>())
     }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -39,7 +39,7 @@ impl Default for PID {
 
 impl std::fmt::Display for PID {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -316,7 +316,7 @@ impl StandardRequest {
                     fields.value & 0xFF,
                     match (descriptor_type, fields.index) {
                         (DescriptorType::String, language) if language > 0 =>
-                            format!(", language 0x{:04x}", language),
+                            format!(", language 0x{language:04x}"),
                         (..) => format!(""),
                     }
                 )
@@ -451,7 +451,7 @@ impl DeviceDescriptor {
                       fmt_str_id(strings, self.product_str_id)),
         12 => format!("Serial string: {}",
                       fmt_str_id(strings, self.serial_str_id)),
-        i  => format!("Error: Invalid field ID {}", i)
+        i  => format!("Error: Invalid field ID {i}")
         }
     }
 
@@ -488,7 +488,7 @@ impl ConfigDescriptor {
                       fmt_str_id(strings, self.config_str_id)),
         6 => format!("Attributes: 0x{:02X}", self.attributes),
         7 => format!("Max power: {}mA", self.max_power as u16 * 2),
-        i => format!("Error: Invalid field ID {}", i)
+        i => format!("Error: Invalid field ID {i}")
         }
     }
 
@@ -526,7 +526,7 @@ impl InterfaceDescriptor {
         7 => format!("Protocol: 0x{:02X}", self.interface_protocol),
         8 => format!("Interface string: {}",
                       fmt_str_id(strings, self.interface_str_id)),
-        i => format!("Error: Invalid field ID {}", i)
+        i => format!("Error: Invalid field ID {i}")
         }
     }
 
@@ -555,7 +555,7 @@ impl EndpointDescriptor {
         4 => format!("Max packet size: {} bytes", {
             let size: u16 = self.max_packet_size; size }),
         5 => format!("Interval: 0x{:02X}", self.interval),
-        i => format!("Error: Invalid field ID {}", i)
+        i => format!("Error: Invalid field ID {i}")
         }
     }
 
@@ -720,11 +720,11 @@ impl ControlTransfer {
         match (self.fields.length, size) {
             (0, 0) => {}
             (len, _) if size == len as usize => {
-                parts.push(format!(", {} {} bytes", action, len));
+                parts.push(format!(", {action} {len} bytes"));
             },
             (len, _) => {
-                parts.push(format!(", {} {} of {} requested bytes",
-                                   action, size, len));
+                parts.push(
+                    format!(", {action} {size} of {len} requested bytes"));
             }
         };
         match (request_type, std_req, descriptor_type) {
@@ -749,8 +749,8 @@ fn fmt_str_id(strings: &VecMap<StringId, UTF16ByteVec>, id: StringId)
     match id.0 {
         0 => "(none)".to_string(),
         _ => match &strings.get(id) {
-            Some(utf16) => format!("#{} {}", id, utf16),
-            None => format!("#{} (not seen)", id)
+            Some(utf16) => format!("#{id} {utf16}"),
+            None => format!("#{id} (not seen)")
         }
     }
 }


### PR DESCRIPTION
Fixes new clippy errors introduced by Rust 1.67.