### PR TITLE
Additional live update mechanisms

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -174,6 +174,7 @@ pub struct DeviceData {
     pub config_number: Option<ConfigNum>,
     pub endpoint_details: VecMap<EndpointAddr, (usb::EndpointType, usize)>,
     pub strings: VecMap<StringId, UTF16ByteVec>,
+    pub version: DeviceVersion,
 }
 
 impl DeviceData {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1103,7 +1103,10 @@ impl ItemSource<DeviceItem> for Capture {
             None =>
                 (self.completion, self.device_data.len() - 1),
             Some(Device(dev, _version)) =>
-                (Ongoing, self.device_data(dev)?.configurations.len()),
+                (Ongoing, {
+                    let configs = self.device_data(dev)?.configurations.len();
+                    if configs == 0 { 1 } else { configs }
+                }),
             Some(DeviceDescriptor(dev)) =>
                 match self.device_data(dev)?.device_descriptor {
                     Some(_) => (Complete, usb::DeviceDescriptor::NUM_FIELDS),

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -709,22 +709,24 @@ impl Capture {
     }
 }
 
+pub enum CompletionStatus {
+    Complete,
+    Ongoing
+}
+
 pub trait ItemSource<Item> {
-    type ItemId;
-    fn item(&mut self, parent: &Option<Item>, index: u64) -> Result<Item, CaptureError>;
-    fn child_item(&mut self, parent: &Item, index: u64) -> Result<Item, CaptureError>;
-    fn item_count(&mut self, parent: &Option<Item>) -> Result<u64, CaptureError>;
-    fn child_count(&mut self, parent: &Item) -> Result<u64, CaptureError>;
-    fn item_end(&mut self, item_id: Self::ItemId)
-        -> Result<Option<Self::ItemId>, CaptureError>;
+    fn item(&mut self, parent: Option<&Item>, index: u64)
+        -> Result<Item, CaptureError>;
+    fn child_item(&mut self, parent: &Item, index: u64)
+        -> Result<Item, CaptureError>;
+    fn item_children(&mut self, parent: Option<&Item>)
+        -> Result<(CompletionStatus, u64), CaptureError>;
     fn summary(&mut self, item: &Item) -> Result<String, CaptureError>;
     fn connectors(&mut self, item: &Item) -> Result<String, CaptureError>;
 }
 
 impl ItemSource<TrafficItem> for Capture {
-    type ItemId = TrafficItemId;
-
-    fn item(&mut self, parent: &Option<TrafficItem>, index: u64)
+    fn item(&mut self, parent: Option<&TrafficItem>, index: u64)
         -> Result<TrafficItem, CaptureError>
     {
         match parent {
@@ -759,52 +761,39 @@ impl ItemSource<TrafficItem> for Capture {
         })
     }
 
-    fn item_count(&mut self, parent: &Option<TrafficItem>)
-        -> Result<u64, CaptureError>
-    {
-        match parent {
-            None => Ok(self.item_index.len()),
-            Some(item) => self.child_count(item)
-        }
-    }
-
-    fn child_count(&mut self, parent: &TrafficItem)
-        -> Result<u64, CaptureError>
+    fn item_children(&mut self, parent: Option<&TrafficItem>)
+        -> Result<(CompletionStatus, u64), CaptureError>
     {
         use TrafficItem::*;
+        use CompletionStatus::*;
         Ok(match parent {
-            Transfer(transfer_id) => {
+            None => {
+                (Ongoing, self.item_index.len())
+            },
+            Some(Transfer(transfer_id)) => {
                 let entry = self.transfer_index.get(*transfer_id)?;
-                if entry.is_start() {
-                    self.transfer_range(&entry)?.len()
+                if !entry.is_start() {
+                    return Ok((Complete, 0));
+                }
+                let transaction_count = self.transfer_range(&entry)?.len();
+                let ep_traf = self.endpoint_traffic(entry.endpoint_id())?;
+                if entry.transfer_id().value >= ep_traf.end_index.len() {
+                    (Ongoing, transaction_count)
                 } else {
-                    0
+                    (Complete, transaction_count)
                 }
             },
-            Transaction(_, transaction_id) => {
-                self.transaction_index.target_range(
-                    *transaction_id, self.packet_index.len())?.len()
+            Some(Transaction(_, transaction_id)) => {
+                let packet_count = self.transaction_index.target_range(
+                    *transaction_id, self.packet_index.len())?.len();
+                if transaction_id.value < self.transaction_index.len() - 1 {
+                    (Complete, packet_count)
+                } else {
+                    (Ongoing, packet_count)
+                }
             },
-            Packet(..) => 0,
+            Some(Packet(..)) => (Complete, 0),
         })
-    }
-
-    fn item_end(&mut self, item_id: TrafficItemId)
-        -> Result<Option<TrafficItemId>, CaptureError>
-    {
-        let transfer_id = self.item_index.get(item_id)?;
-        let entry = self.transfer_index.get(transfer_id)?;
-        let ep_transfer_id = entry.transfer_id();
-        if !entry.is_start() {
-            return Err(IndexError(
-                String::from("Transfer entry for item_end is an end")))
-        }
-        let ep_traf = self.endpoint_traffic(entry.endpoint_id())?;
-        if ep_transfer_id.value >= ep_traf.end_index.len() {
-            return Ok(None)
-        }
-        let end_item_id = ep_traf.end_index.get(ep_transfer_id)?;
-        Ok(Some(end_item_id))
     }
 
     fn summary(&mut self, item: &TrafficItem)
@@ -1022,9 +1011,7 @@ impl ItemSource<TrafficItem> for Capture {
 }
 
 impl ItemSource<DeviceItem> for Capture {
-    type ItemId = DeviceId;
-
-    fn item(&mut self, parent: &Option<DeviceItem>, index: u64)
+    fn item(&mut self, parent: Option<&DeviceItem>, index: u64)
         -> Result<DeviceItem, CaptureError>
     {
         match parent {
@@ -1070,53 +1057,45 @@ impl ItemSource<DeviceItem> for Capture {
         })
     }
 
-    fn item_count(&mut self, parent: &Option<DeviceItem>)
-        -> Result<u64, CaptureError>
-    {
-        Ok(match parent {
-            None => (self.device_data.len() - 1) as u64,
-            Some(item) => self.child_count(item)?,
-        })
-    }
-
-    fn child_count(&mut self, parent: &DeviceItem)
-        -> Result<u64, CaptureError>
+    fn item_children(&mut self, parent: Option<&DeviceItem>)
+        -> Result<(CompletionStatus, u64), CaptureError>
     {
         use DeviceItem::*;
-        Ok((match parent {
-            Device(dev) =>
-                self.device_data(dev)?.configurations.len(),
-            DeviceDescriptor(dev) =>
+        use CompletionStatus::*;
+        let (completion, children) = match parent {
+            None =>
+                (Ongoing, self.device_data.len() - 1),
+            Some(Device(dev)) =>
+                (Ongoing, self.device_data(dev)?.configurations.len()),
+            Some(DeviceDescriptor(dev)) =>
                 match self.device_data(dev)?.device_descriptor {
-                    Some(_) => usb::DeviceDescriptor::NUM_FIELDS,
-                    None => 0,
+                    Some(_) => (Complete, usb::DeviceDescriptor::NUM_FIELDS),
+                    None => (Ongoing, 0),
                 },
-            Configuration(dev, conf) =>
+            Some(Configuration(dev, conf)) =>
                 match self.try_configuration(dev, conf) {
-                    Some(conf) => 1 + conf.interfaces.len(),
-                    None => 0
+                    Some(conf) => (Ongoing, 1 + conf.interfaces.len()),
+                    None => (Ongoing, 0)
                 },
-            ConfigurationDescriptor(dev, conf) =>
+            Some(ConfigurationDescriptor(dev, conf)) =>
                 match self.try_configuration(dev, conf) {
-                    Some(_) => usb::ConfigDescriptor::NUM_FIELDS,
-                    None => 0
+                    Some(_) => (Complete, usb::ConfigDescriptor::NUM_FIELDS),
+                    None => (Ongoing, 0)
                 },
-            Interface(dev, conf, iface) =>
+            Some(Interface(dev, conf, iface)) =>
                 match self.try_configuration(dev, conf) {
                     Some(conf) =>
-                        1 + conf.interface(iface)?.endpoint_descriptors.len(),
-                    None => 0
+                        (Complete,
+                         1 + conf.interface(iface)?.endpoint_descriptors.len()),
+                    None => (Ongoing, 0)
                 },
-            InterfaceDescriptor(..) => usb::InterfaceDescriptor::NUM_FIELDS,
-            EndpointDescriptor(..) => usb::EndpointDescriptor::NUM_FIELDS,
-            _ => 0
-        }) as u64)
-    }
-
-    fn item_end(&mut self, _item_id: DeviceId)
-        -> Result<Option<DeviceId>, CaptureError>
-    {
-        Ok(None)
+            Some(InterfaceDescriptor(..)) =>
+                (Complete, usb::InterfaceDescriptor::NUM_FIELDS),
+            Some(EndpointDescriptor(..)) =>
+                (Complete, usb::EndpointDescriptor::NUM_FIELDS),
+            _ => (Complete, 0)
+        };
+        Ok((completion, children as u64))
     }
 
     fn summary(&mut self, item: &DeviceItem)
@@ -1217,7 +1196,7 @@ mod tests {
         }
         writer.write(summary.as_bytes()).unwrap();
         writer.write(b"\n").unwrap();
-        let num_children = cap.child_count(item).unwrap();
+        let (_completion, num_children) = cap.item_children(Some(item)).unwrap();
         for child_id in 0..num_children {
             let child = cap.child_item(item, child_id).unwrap();
             write_item(cap, &child, depth + 1, writer);
@@ -1250,7 +1229,7 @@ mod tests {
                     let mut out_writer = BufWriter::new(out_file);
                     let num_items = cap.item_index.len();
                     for item_id in 0 .. num_items {
-                        let item = cap.item(&None, item_id).unwrap();
+                        let item = cap.item(None, item_id).unwrap();
                         write_item(&mut cap, &item, 0, &mut out_writer);
                     }
                 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -288,12 +288,6 @@ impl Transaction {
             (..)            => false
         }
     }
-
-    fn complete(&self) -> bool {
-        use PID::*;
-        // TODO: iso transactions end on a DATAx
-        matches!(self.end_pid, ACK | NAK | NYET | STALL | ERR)
-    }
 }
 
 pub fn fmt_count(count: u64) -> String {
@@ -723,7 +717,6 @@ pub trait ItemSource<Item> {
     fn child_count(&mut self, parent: &Item) -> Result<u64, CaptureError>;
     fn item_end(&mut self, item_id: Self::ItemId)
         -> Result<Option<Self::ItemId>, CaptureError>;
-    fn complete(&mut self, item: &Item) -> Result<bool, CaptureError>;
     fn summary(&mut self, item: &Item) -> Result<String, CaptureError>;
     fn connectors(&mut self, item: &Item) -> Result<String, CaptureError>;
 }
@@ -812,26 +805,6 @@ impl ItemSource<TrafficItem> for Capture {
         }
         let end_item_id = ep_traf.end_index.get(ep_transfer_id)?;
         Ok(Some(end_item_id))
-    }
-
-    fn complete(&mut self, item: &TrafficItem)
-        -> Result<bool, CaptureError>
-    {
-        use TrafficItem::*;
-        Ok(match item {
-            Packet(..) => {
-                true
-            },
-            // TODO: switch to using `item_end` after interleaving merge.
-            Transaction(_, transaction_id) => {
-                let transaction = self.transaction(*transaction_id)?;
-                transaction.complete()
-            },
-            // TODO: switch to using `item_end` after interleaving merge.
-            Transfer(..) => {
-                false
-            }
-        })
     }
 
     fn summary(&mut self, item: &TrafficItem)
@@ -1144,12 +1117,6 @@ impl ItemSource<DeviceItem> for Capture {
         -> Result<Option<DeviceId>, CaptureError>
     {
         Ok(None)
-    }
-
-    fn complete(&mut self, _item: &DeviceItem)
-        -> Result<bool, CaptureError>
-    {
-        Ok(false)
     }
 
     fn summary(&mut self, item: &DeviceItem)

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -58,9 +58,9 @@ impl EndpointData {
 
 #[derive(Default)]
 struct TransactionState {
+    id: Option<TransactionId>,
     first: Option<PID>,
     last: Option<PID>,
-    start: Option<PacketId>,
     count: u64,
     endpoint_id: Option<EndpointId>,
     setup: Option<SetupFields>,
@@ -277,11 +277,11 @@ impl Decoder {
     fn transaction_start(&mut self, capture: &mut Capture, packet_id: PacketId, packet: &[u8])
         -> Result<(), CaptureError>
     {
-        self.add_transaction(capture)?;
+        self.transaction_end(capture)?;
         self.transaction_state = TransactionState::default();
         let pid = PID::from_packet(packet)?;
         let state = &mut self.transaction_state;
-        state.start = Some(packet_id);
+        state.id = Some(capture.transaction_index.push(packet_id)?);
         state.count = 1;
         state.first = Some(pid);
         state.last = state.first;
@@ -305,22 +305,9 @@ impl Decoder {
     fn transaction_end(&mut self, capture: &mut Capture)
         -> Result<(), CaptureError>
     {
-        self.add_transaction(capture)?;
-        self.transaction_state = TransactionState::default();
-        Ok(())
-    }
-
-    fn add_transaction(&mut self, capture: &mut Capture)
-        -> Result<(), CaptureError>
-    {
-        if self.transaction_state.count == 0 { return Ok(()) }
-        let start_packet_id =
-            self.transaction_state.start.ok_or_else(||
-                IndexError(String::from(
-                    "Transaction state has no start PID")))?;
-        let transaction_id =
-            capture.transaction_index.push(start_packet_id)?;
-        self.transfer_update(capture, transaction_id)?;
+        if let Some(transaction_id) = self.transaction_state.id.take() {
+            self.transfer_update(capture, transaction_id)?;
+        }
         Ok(())
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -413,6 +413,7 @@ impl Decoder {
                     let descriptor = DeviceDescriptor::from_bytes(payload);
                     let dev_data = self.current_device_data_mut(capture)?;
                     dev_data.device_descriptor = Some(descriptor);
+                    dev_data.version += 1;
                 }
             },
             (Recipient::Device, DescriptorType::Configuration) => {
@@ -426,6 +427,7 @@ impl Decoder {
                             config.descriptor.config_value);
                         configurations.set(config_num, config);
                         dev_data.update_endpoint_details();
+                        dev_data.version += 1;
                     }
                 }
             },
@@ -437,6 +439,7 @@ impl Decoder {
                     let string_id =
                         StringId::from((fields.value & 0xFF) as u8);
                     strings.set(string_id, string);
+                    dev_data.version += 1;
                 }
             },
             _ => {}
@@ -450,6 +453,7 @@ impl Decoder {
         let dev_data = self.current_device_data_mut(capture)?;
         dev_data.config_number = Some(ConfigNum(fields.value.try_into()?));
         dev_data.update_endpoint_details();
+        dev_data.version += 1;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,10 +175,10 @@ fn create_view<Item: 'static, Model, RowData>(capture: &Arc<Mutex<Capture>>)
         }
 
         let expander = expander_wrapper.expander();
-        let handler = expander_wrapper
-            .take_handler()
-            .or_bug("ExpanderWrapper handler was not set")?;
-        expander.disconnect(handler);
+        if let Some(handler) = expander_wrapper.take_handler() {
+            expander.disconnect(handler);
+        }
+
         Ok(())
     };
     factory.connect_bind(move |_, item| display_error(bind(item)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,10 +138,13 @@ fn create_view<Item: 'static, Model, RowData>(capture: &Arc<Mutex<Capture>>)
                 expander.set_expanded(node.expanded());
                 let model = bind_model.clone();
                 let node_ref = node_ref.clone();
+                let list_item = list_item.clone();
                 let handler = expander.connect_expanded_notify(move |expander| {
+                    let position = list_item.position();
+                    let expanded = expander.is_expanded();
                     display_error(
-                        model.set_expanded(&node_ref, expander.is_expanded())
-                            .map_err(PacketryError::Model));
+                        model.set_expanded(&node_ref, position, expanded)
+                            .map_err(PacketryError::Model))
                 });
                 expander_wrapper.set_handler(handler);
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,7 @@ fn create_view<Item: 'static, Model, RowData>(capture: &Arc<Mutex<Capture>>)
                             .map_err(PacketryError::Model))
                 });
                 expander_wrapper.set_handler(handler);
+                node.attach_widget(&expander_wrapper);
             },
             Err(msg) => {
                 expander_wrapper.set_connectors("".to_string());
@@ -157,11 +158,22 @@ fn create_view<Item: 'static, Model, RowData>(capture: &Arc<Mutex<Capture>>)
         Ok(())
     };
     let unbind = move |list_item: &ListItem| {
+        let row = list_item
+            .item()
+            .or_bug("ListItem has no item")?
+            .downcast::<RowData>()
+            .or_bug("Item is not RowData")?;
+
         let expander_wrapper = list_item
             .child()
             .or_bug("ListItem has no child widget")?
             .downcast::<ExpanderWrapper>()
             .or_bug("Child widget is not an ExpanderWrapper")?;
+
+        if let Ok(node_ref) = row.node() {
+            node_ref.borrow().remove_widget(&expander_wrapper);
+        }
+
         let expander = expander_wrapper.expander();
         let handler = expander_wrapper
             .take_handler()

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,8 +2,6 @@
 
 mod imp;
 
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
 use gtk::prelude::ListModelExt;
@@ -11,7 +9,7 @@ use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 
 use crate::capture::{Capture, TrafficItem, DeviceItem};
-use crate::tree_list_model::{TreeListModel, TreeNode, ModelError};
+use crate::tree_list_model::{TreeListModel, ItemNodeRc, ModelError};
 
 // Public part of the Model type.
 glib::wrapper! {
@@ -24,7 +22,7 @@ glib::wrapper! {
 pub trait GenericModel<Item> where Self: Sized {
     fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError>;
     fn set_expanded(&self,
-                    node: &Rc<RefCell<TreeNode<Item>>>,
+                    node: &ItemNodeRc<Item>,
                     expanded: bool)
         -> Result<(), ModelError>;
     fn update(&self) -> Result<(), ModelError>;
@@ -40,7 +38,7 @@ impl GenericModel<TrafficItem> for TrafficModel {
     }
 
     fn set_expanded(&self,
-                    node: &Rc<RefCell<TreeNode<TrafficItem>>>,
+                    node: &ItemNodeRc<TrafficItem>,
                     expanded: bool)
         -> Result<(), ModelError>
     {
@@ -70,7 +68,7 @@ impl GenericModel<DeviceItem> for DeviceModel {
     }
 
     fn set_expanded(&self,
-                    node: &Rc<RefCell<TreeNode<DeviceItem>>>,
+                    node: &ItemNodeRc<DeviceItem>,
                     expanded: bool)
         -> Result<(), ModelError>
     {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -4,7 +4,6 @@ mod imp;
 
 use std::sync::{Arc, Mutex};
 
-use gtk::prelude::ListModelExt;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 
@@ -50,11 +49,7 @@ impl GenericModel<TrafficItem> for TrafficModel {
     fn update(&self) -> Result<(), ModelError> {
         let tree_opt = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        if let Some((position, _, added)) = tree.update()? {
-            drop(tree_opt);
-            self.items_changed(position, 0, added);
-        }
-        Ok(())
+        tree.update(self)
     }
 }
 
@@ -80,10 +75,6 @@ impl GenericModel<DeviceItem> for DeviceModel {
     fn update(&self) -> Result<(), ModelError> {
         let tree_opt = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        if let Some((position, _, added)) = tree.update()? {
-            drop(tree_opt);
-            self.items_changed(position, 0, added);
-        }
-        Ok(())
+        tree.update(self)
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -48,8 +48,8 @@ impl GenericModel<TrafficItem> for TrafficModel {
     }
 
     fn update(&self) -> Result<(), ModelError> {
-        let mut tree_opt  = self.imp().tree.borrow_mut();
-        let tree = tree_opt.as_mut().unwrap();
+        let tree_opt = self.imp().tree.borrow();
+        let tree = tree_opt.as_ref().unwrap();
         if let Some((position, _, added)) = tree.update()? {
             drop(tree_opt);
             self.items_changed(position, 0, added);
@@ -78,8 +78,8 @@ impl GenericModel<DeviceItem> for DeviceModel {
     }
 
     fn update(&self) -> Result<(), ModelError> {
-        let mut tree_opt  = self.imp().tree.borrow_mut();
-        let tree = tree_opt.as_mut().unwrap();
+        let tree_opt = self.imp().tree.borrow();
+        let tree = tree_opt.as_ref().unwrap();
         if let Some((position, _, added)) = tree.update()? {
             drop(tree_opt);
             self.items_changed(position, 0, added);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -22,6 +22,7 @@ pub trait GenericModel<Item> where Self: Sized {
     fn new(capture: Arc<Mutex<Capture>>) -> Result<Self, ModelError>;
     fn set_expanded(&self,
                     node: &ItemNodeRc<Item>,
+                    position: u32,
                     expanded: bool)
         -> Result<(), ModelError>;
     fn update(&self) -> Result<(), ModelError>;
@@ -38,12 +39,13 @@ impl GenericModel<TrafficItem> for TrafficModel {
 
     fn set_expanded(&self,
                     node: &ItemNodeRc<TrafficItem>,
+                    position: u32,
                     expanded: bool)
         -> Result<(), ModelError>
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        tree.set_expanded(self, node, expanded)
+        tree.set_expanded(self, node, position, expanded)
     }
 
     fn update(&self) -> Result<(), ModelError> {
@@ -64,12 +66,13 @@ impl GenericModel<DeviceItem> for DeviceModel {
 
     fn set_expanded(&self,
                     node: &ItemNodeRc<DeviceItem>,
+                    position: u32,
                     expanded: bool)
         -> Result<(), ModelError>
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
-        tree.set_expanded(self, node, expanded)
+        tree.set_expanded(self, node, position, expanded)
     }
 
     fn update(&self) -> Result<(), ModelError> {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -25,7 +25,7 @@ pub trait GenericModel<Item> where Self: Sized {
                     position: u32,
                     expanded: bool)
         -> Result<(), ModelError>;
-    fn update(&self) -> Result<(), ModelError>;
+    fn update(&self) -> Result<bool, ModelError>;
 }
 
 impl GenericModel<TrafficItem> for TrafficModel {
@@ -48,7 +48,7 @@ impl GenericModel<TrafficItem> for TrafficModel {
         tree.set_expanded(self, node, position, expanded)
     }
 
-    fn update(&self) -> Result<(), ModelError> {
+    fn update(&self) -> Result<bool, ModelError> {
         let tree_opt = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
         tree.update(self)
@@ -75,7 +75,7 @@ impl GenericModel<DeviceItem> for DeviceModel {
         tree.set_expanded(self, node, position, expanded)
     }
 
-    fn update(&self) -> Result<(), ModelError> {
+    fn update(&self) -> Result<bool, ModelError> {
         let tree_opt = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
         tree.update(self)

--- a/src/row_data/imp.rs
+++ b/src/row_data/imp.rs
@@ -1,23 +1,20 @@
 use gtk::glib::{self, subclass::prelude::*};
-use std::rc::Rc;
 use std::cell::RefCell;
 
 use crate::capture::{TrafficItem, DeviceItem};
-use crate::tree_list_model::{TreeNode};
-
-type ItemRc<Item> = Rc<RefCell<TreeNode<Item>>>;
+use crate::tree_list_model::ItemNodeRc;
 
 // The actual data structure that stores our values. This is not accessible
 // directly from the outside.
 #[derive(Default)]
 pub struct TrafficRowData {
-    pub(super) node: RefCell<Option<Result<ItemRc<TrafficItem>, String>>>,
+    pub(super) node: RefCell<Option<Result<ItemNodeRc<TrafficItem>, String>>>,
 
 }
 
 #[derive(Default)]
 pub struct DeviceRowData {
-    pub(super) node: RefCell<Option<Result<ItemRc<DeviceItem>, String>>>,
+    pub(super) node: RefCell<Option<Result<ItemNodeRc<DeviceItem>, String>>>,
 }
 
 // Basic declaration of our type for the GObject type system

--- a/src/row_data/mod.rs
+++ b/src/row_data/mod.rs
@@ -6,14 +6,11 @@
 
 mod imp;
 
-use std::rc::Rc;
-use std::cell::RefCell;
-
 use gtk::glib;
 use gtk::subclass::prelude::*;
 
 use crate::capture::{TrafficItem, DeviceItem};
-use crate::tree_list_model::TreeNode;
+use crate::tree_list_model::ItemNodeRc;
 
 // Public part of the RowData type. This behaves like a normal gtk-rs-style GObject
 // binding
@@ -25,32 +22,32 @@ glib::wrapper! {
 }
 
 pub trait GenericRowData<Item> where Item: Copy {
-    fn new(node: Result<Rc<RefCell<TreeNode<Item>>>, String>) -> Self;
-    fn node(&self) -> Result<Rc<RefCell<TreeNode<Item>>>, String>;
+    fn new(node: Result<ItemNodeRc<Item>, String>) -> Self;
+    fn node(&self) -> Result<ItemNodeRc<Item>, String>;
 }
 
 impl GenericRowData<TrafficItem> for TrafficRowData {
-    fn new(node: Result<Rc<RefCell<TreeNode<TrafficItem>>>, String>) -> TrafficRowData {
+    fn new(node: Result<ItemNodeRc<TrafficItem>, String>) -> TrafficRowData {
         let row: TrafficRowData =
             glib::Object::new(&[]).expect("Failed to create row data");
         row.imp().node.replace(Some(node));
         row
     }
 
-    fn node(&self) -> Result<Rc<RefCell<TreeNode<TrafficItem>>>, String> {
+    fn node(&self) -> Result<ItemNodeRc<TrafficItem>, String> {
         self.imp().node.borrow().as_ref().unwrap().clone()
     }
 }
 
 impl GenericRowData<DeviceItem> for DeviceRowData {
-    fn new(node: Result<Rc<RefCell<TreeNode<DeviceItem>>>, String>) -> DeviceRowData {
+    fn new(node: Result<ItemNodeRc<DeviceItem>, String>) -> DeviceRowData {
         let row: DeviceRowData =
             glib::Object::new(&[]).expect("Failed to create row data");
         row.imp().node.replace(Some(node));
         row
     }
 
-    fn node(&self) -> Result<Rc<RefCell<TreeNode<DeviceItem>>>, String> {
+    fn node(&self) -> Result<ItemNodeRc<DeviceItem>, String> {
         self.imp().node.borrow().as_ref().unwrap().clone()
     }
 }

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -25,67 +25,161 @@ pub enum ModelError {
     RangeError(#[from] TryFromIntError),
     #[error("Locking capture failed")]
     LockError,
-    #[error("Parent not set (attempting to expand the root node?)")]
-    ParentNotSet,
     #[error("Node references a dropped parent")]
     ParentDropped,
 }
 
-pub struct TreeNode<Item> {
+pub type ItemNodeRc<Item> = Rc<RefCell<ItemNode<Item>>>;
+type AnyNodeRc<Item> = Rc<RefCell<dyn Node<Item>>>;
+
+trait Node<Item> {
+    /// Item at this node, or None if the root.
+    fn item(&self) -> Option<Item>;
+
+    /// Parent of this node, or None if the root.
+    fn parent(&self) -> Result<Option<AnyNodeRc<Item>>, ModelError>;
+
+    /// Position of this node in a list, relative to its parent node.
+    fn relative_position(&self) -> Result<u32, ModelError>;
+
+    /// Access the children of this node.
+    fn children(&self) -> &Children<Item>;
+
+    /// Mutably access the children of this node.
+    fn children_mut(&mut self) -> &mut Children<Item>;
+}
+
+struct Children<Item> {
+    /// Number of direct children below this node.
+    direct_count: u32,
+
+    /// Total number of displayed rows below this node, recursively.
+    total_count: u32,
+
+    /// Expanded children of this item.
+    expanded: BTreeMap<u32, ItemNodeRc<Item>>,
+}
+
+impl<Item> Children<Item> {
+    fn new(child_count: u32) -> Self {
+        Children {
+            direct_count: child_count,
+            total_count: child_count,
+            expanded: BTreeMap::new()
+        }
+    }
+}
+
+struct RootNode<Item> {
+    /// Top level children.
+    children: Children<Item>,
+}
+
+pub struct ItemNode<Item> {
     /// The item at this tree node.
-    item: Option<Item>,
+    item: Item,
 
     /// Parent of this node in the tree.
-    parent: Option<Weak<RefCell<TreeNode<Item>>>>,
+    parent: Weak<RefCell<dyn Node<Item>>>,
 
     /// Index of this node below the parent Item.
     item_index: u32,
 
-    /// Number of direct children below this node.
-    direct_child_count: u32,
-
-    /// Total number nodes below this node, recursively.
-    total_child_count: u32,
-
-    /// List of expanded child nodes directly below this node.
-    children: BTreeMap<u32, Rc<RefCell<TreeNode<Item>>>>,
+    /// Children of this item.
+    children: Children<Item>,
 }
 
-impl<Item> TreeNode<Item> where Item: Copy {
+impl<Item> Children<Item> {
+    /// Whether this child is expanded.
+    fn expanded(&self, index: u32) -> bool {
+        self.expanded.contains_key(&index)
+    }
+
+    /// Iterate over the expanded children.
+    fn iter_expanded(&self) -> impl Iterator<Item=(&u32, &ItemNodeRc<Item>)> + '_ {
+        self.expanded.iter()
+    }
+
+    /// Set whether this child of the owning node is expanded.
+    fn set_expanded(&mut self, child_rc: &ItemNodeRc<Item>, expanded: bool) {
+        let child = child_rc.borrow();
+        if expanded {
+            self.expanded.insert(child.item_index, child_rc.clone());
+        } else {
+            self.expanded.remove(&child.item_index);
+        }
+    }
+}
+
+impl<Item> Node<Item> for RootNode<Item> {
+    fn item(&self) -> Option<Item> {
+        None
+    }
+
+    fn parent(&self) -> Result<Option<AnyNodeRc<Item>>, ModelError> {
+        Ok(None)
+    }
+
+    fn relative_position(&self) -> Result<u32, ModelError> {
+        Ok(0)
+    }
+
+    fn children(&self) -> &Children<Item> {
+        &self.children
+    }
+
+    fn children_mut(&mut self) -> &mut Children<Item> {
+        &mut self.children
+    }
+}
+
+impl<Item> Node<Item> for ItemNode<Item> where Item: Copy {
+    fn item(&self) -> Option<Item> {
+        Some(self.item)
+    }
+
+    fn parent(&self) -> Result<Option<AnyNodeRc<Item>>, ModelError> {
+        Ok(Some(self.parent.upgrade().ok_or(ModelError::ParentDropped)?))
+    }
+
+    fn relative_position(&self) -> Result<u32, ModelError> {
+        let parent = self.parent.upgrade()
+            .ok_or(ModelError::ParentDropped)?;
+        // Sum up the child counts of any expanded nodes before this one,
+        // and add to `item_index`.
+        let position = parent
+            .borrow()
+            .children()
+            .iter_expanded()
+            .take_while(|(&key, _)| key < self.item_index)
+            .map(|(_, node)| node.borrow().children.total_count)
+            .sum::<u32>() + self.item_index;
+        Ok(position)
+    }
+
+    fn children(&self) -> &Children<Item> {
+        &self.children
+    }
+
+    fn children_mut(&mut self) -> &mut Children<Item> {
+        &mut self.children
+    }
+}
+
+impl<Item> ItemNode<Item> where Item: Copy {
     pub fn expanded(&self) -> bool {
-        match self.parent.as_ref() {
-            Some(parent_weak) => match parent_weak.upgrade() {
-                Some(parent_ref) => {
-                    let parent = parent_ref.borrow();
-                    parent.children.contains_key(&self.item_index)
-                },
-                // Parent is dropped, so node cannot be expanded.
-                None => false
-            },
-            // This is the root, which is never expanded.
+        match self.parent.upgrade() {
+            Some(parent_ref) => parent_ref
+                .borrow()
+                .children()
+                .expanded(self.item_index),
+            // Parent is dropped, so node cannot be expanded.
             None => false
         }
     }
 
     pub fn expandable(&self) -> bool {
-        self.total_child_count != 0
-    }
-
-    /// Position of this node in a list, relative to its parent node.
-    pub fn relative_position(&self) -> Result<u32, ModelError> {
-        match self.parent.as_ref() {
-            Some(parent_weak) => {
-                let parent_ref = parent_weak.upgrade().ok_or(ModelError::ParentDropped)?;
-                let parent = parent_ref.borrow();
-                // Sum up the `child_count`s of any expanded nodes before this one, and add to `item_index`.
-                Ok(parent.children.iter()
-                    .take_while(|(&key, _)| key < self.item_index)
-                    .map(|(_, node)| node.borrow().total_child_count)
-                    .sum::<u32>() + self.item_index)
-            },
-            None => Ok(0),
-        }
-
+        self.children.total_count != 0
     }
 
     #[allow(clippy::type_complexity)]
@@ -96,16 +190,13 @@ impl<Item> TreeNode<Item> where Item: Copy {
                     -> Result<String, CaptureError>>)
         -> String
     {
-        match self.item {
-            None => "Error: node has no item".to_string(),
-            Some(item) => match capture.lock() {
-                Err(_) => "Error: failed to lock capture".to_string(),
-                Ok(mut guard) => {
-                    let cap = guard.deref_mut();
-                    match func(cap, &item) {
-                        Err(e) => format!("Error: {e:?}"),
-                        Ok(string) => string
-                    }
+        match capture.lock() {
+            Err(_) => "Error: failed to lock capture".to_string(),
+            Ok(mut guard) => {
+                let cap = guard.deref_mut();
+                match func(cap, &self.item) {
+                    Err(e) => format!("Error: {e:?}"),
+                    Ok(string) => string
                 }
             }
         }
@@ -115,11 +206,11 @@ impl<Item> TreeNode<Item> where Item: Copy {
 pub struct TreeListModel<Item, Model, RowData> {
     _marker: PhantomData<(Model, RowData)>,
     capture: Arc<Mutex<Capture>>,
-    root: Rc<RefCell<TreeNode<Item>>>,
+    root: Rc<RefCell<RootNode<Item>>>,
 }
 
 impl<Item, Model, RowData> TreeListModel<Item, Model, RowData>
-where Item: Copy,
+where Item: 'static + Copy,
       Model: GenericModel<Item> + ListModelExt,
       RowData: GenericRowData<Item> + IsA<Object> + Cast,
       Capture: ItemSource<Item>
@@ -131,20 +222,15 @@ where Item: Copy,
         Ok(TreeListModel {
             _marker: PhantomData,
             capture: capture.clone(),
-            root: Rc::new(RefCell::new(TreeNode {
-                item: None,
-                parent: None,
-                item_index: 0,
-                direct_child_count: child_count,
-                total_child_count: child_count,
-                children: Default::default(),
+            root: Rc::new(RefCell::new(RootNode {
+                children: Children::new(child_count),
             })),
         })
     }
 
     pub fn set_expanded(&self,
                         model: &Model,
-                        node_ref: &Rc<RefCell<TreeNode<Item>>>,
+                        node_ref: &ItemNodeRc<Item>,
                         expanded: bool)
         -> Result<(), ModelError>
     {
@@ -153,38 +239,34 @@ where Item: Copy,
             return Ok(());
         }
 
-        let node_parent_ref = node.parent
-            .as_ref().ok_or(ModelError::ParentNotSet)?
-            .upgrade().ok_or(ModelError::ParentDropped)?;
-        let mut node_parent = node_parent_ref.borrow_mut();
+        node.parent
+            .upgrade()
+            .ok_or(ModelError::ParentDropped)?
+            .borrow_mut()
+            .children_mut()
+            .set_expanded(node_ref, expanded);
 
-        // Add this node to the parent's list of expanded child nodes.
-        if expanded {
-            node_parent.children.insert(node.item_index, node_ref.clone());
-        } else {
-            node_parent.children.remove(&node.item_index);
-        }
-
-        drop(node_parent);
-
-        // Traverse back up the tree, modifying `total_child_count` for expanded/collapsed entries.
+        // Traverse back up the tree, modifying `children.total_count` for
+        // expanded/collapsed entries.
         let mut position = node.relative_position()?;
-        let mut current_node = node_ref.clone();
-        while let Some(parent_weak) = current_node.clone().borrow().parent.as_ref() {
-            let parent = parent_weak.upgrade().ok_or(ModelError::ParentDropped)?;
+        let mut current_node: AnyNodeRc<Item> = node_ref.clone();
+        while let Some(parent_ref) = current_node.clone().borrow().parent()? {
+            let mut parent = parent_ref.borrow_mut();
+            let children = parent.children_mut();
             if expanded {
-                parent.borrow_mut().total_child_count += node.total_child_count;
+                children.total_count += node.children.total_count;
             } else {
-                parent.borrow_mut().total_child_count -= node.total_child_count;
+                children.total_count -= node.children.total_count;
             }
-            current_node = parent;
+            drop(parent);
+            current_node = parent_ref;
             position += current_node.borrow().relative_position()? + 1;
         }
 
         if expanded {
-            model.items_changed(position, 0, node.total_child_count);
+            model.items_changed(position, 0, node.children.total_count);
         } else {
-            model.items_changed(position, node.total_child_count, 0);
+            model.items_changed(position, node.children.total_count, 0);
         }
 
         Ok(())
@@ -196,22 +278,27 @@ where Item: Copy,
         let mut node_borrow = self.root.borrow_mut();
 
         let new_child_count = cap.item_count(&None)? as u32;
-        if node_borrow.direct_child_count == new_child_count {
+        if node_borrow.children.direct_count == new_child_count {
             return Ok(None);
         }
 
-        let position = node_borrow.total_child_count;
-        let added = new_child_count - node_borrow.direct_child_count;
-        node_borrow.direct_child_count = new_child_count;
-        node_borrow.total_child_count += added;
+        let position = node_borrow.children.total_count;
+        let added = new_child_count - node_borrow.children.direct_count;
+        node_borrow.children.direct_count = new_child_count;
+        node_borrow.children.total_count += added;
         Ok(Some((position, 0, added)))
     }
 
-    fn fetch(&self, position: u32) -> Result<Rc<RefCell<TreeNode<Item>>>, ModelError> {
-        let mut parent_ref = self.root.clone();
+    fn fetch(&self, position: u32) -> Result<ItemNodeRc<Item>, ModelError> {
+        let mut parent_ref: Rc<RefCell<dyn Node<Item>>> = self.root.clone();
         let mut relative_position = position;
         'outer: loop {
-            for (_, node_rc) in parent_ref.clone().borrow().children.iter() {
+            for (_, node_rc) in parent_ref
+                .clone()
+                .borrow()
+                .children()
+                .iter_expanded()
+            {
                 let node = node_rc.borrow();
                 // If the position is before this node, break out of the loop to look it up.
                 if relative_position < node.item_index {
@@ -220,14 +307,14 @@ where Item: Copy,
                 } else if relative_position == node.item_index {
                     return Ok(node_rc.clone());
                 // If the position is within this node's children, traverse down the tree and repeat.
-                } else if relative_position <= node.item_index + node.total_child_count {
+                } else if relative_position <= node.item_index + node.children.total_count {
                     parent_ref = node_rc.clone();
                     relative_position -= node.item_index + 1;
                     continue 'outer;
                 // Otherwise, if the position is after this node,
                 // adjust the relative position for the node's children above.
                 } else {
-                    relative_position -= node.total_child_count;
+                    relative_position -= node.children.total_count;
                 }
             }
             break;
@@ -236,15 +323,13 @@ where Item: Copy,
         // If we've broken out to this point, the node must be directly below `parent` - look it up.
         let mut cap = self.capture.lock().or(Err(ModelError::LockError))?;
         let parent = parent_ref.borrow();
-        let item = cap.item(&parent.item, relative_position as u64)?;
+        let item = cap.item(&parent.item(), relative_position as u64)?;
         let child_count = cap.child_count(&item)?;
-        let node = TreeNode {
-            item: Some(item),
-            parent: Some(Rc::downgrade(&parent_ref)),
+        let node = ItemNode {
+            item,
+            parent: Rc::downgrade(&parent_ref),
             item_index: relative_position,
-            direct_child_count: child_count.try_into()?,
-            total_child_count: child_count.try_into()?,
-            children: Default::default(),
+            children: Children::new(child_count.try_into()?),
         };
 
         Ok(Rc::new(RefCell::new(node)))
@@ -254,12 +339,13 @@ where Item: Copy,
     // called by a GObject wrapper class to implement that interface.
 
     pub fn n_items(&self) -> u32 {
-        self.root.borrow().total_child_count
+        self.root.borrow().children.total_count
     }
 
     pub fn item(&self, position: u32) -> Option<Object> {
-        // First check that the position is valid (must be within the root node's `child_count`).
-        if position >= self.root.borrow().total_child_count {
+        // First check that the position is valid (must be within the root
+        // node's total child count).
+        if position >= self.root.borrow().children.total_count {
             return None
         }
         let node_or_err_msg = self.fetch(position).map_err(|e| format!("{e:?}"));

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -291,18 +291,19 @@ where Item: 'static + Copy,
     pub fn update(&mut self) -> Result<Option<(u32, u32, u32)>, ModelError> {
         let mut cap = self.capture.lock().or(Err(ModelError::LockError))?;
 
-        let mut node_borrow = self.root.borrow_mut();
+        let mut root = self.root.borrow_mut();
+        let new_item_count = cap.item_count(&None)? as u32;
+        let old_item_count = root.children.direct_count;
 
-        let new_child_count = cap.item_count(&None)? as u32;
-        if node_borrow.children.direct_count == new_child_count {
+        if new_item_count == old_item_count {
             return Ok(None);
         }
 
-        let position = node_borrow.children.total_count;
-        let added = new_child_count - node_borrow.children.direct_count;
-        node_borrow.children.direct_count = new_child_count;
-        node_borrow.children.total_count += added;
-        Ok(Some((position, 0, added)))
+        let position = root.children.total_count;
+        let items_added = new_item_count - old_item_count;
+        root.children.direct_count = new_item_count;
+        root.children.total_count += items_added;
+        Ok(Some((position, 0, items_added)))
     }
 
     fn fetch(&self, position: u32) -> Result<ItemNodeRc<Item>, ModelError> {

--- a/src/tree_list_model.rs
+++ b/src/tree_list_model.rs
@@ -288,7 +288,7 @@ where Item: 'static + Copy,
         Ok(())
     }
 
-    pub fn update(&mut self) -> Result<Option<(u32, u32, u32)>, ModelError> {
+    pub fn update(&self) -> Result<Option<(u32, u32, u32)>, ModelError> {
         let mut cap = self.capture.lock().or(Err(ModelError::LockError))?;
 
         let mut root = self.root.borrow_mut();

--- a/tests/emf2022-badge/reference.txt
+++ b/tests/emf2022-badge/reference.txt
@@ -1,4 +1,4 @@
-277 SOF groups
+278 SOF groups
  6 SOF packets
   SOF packet with frame number 597, CRC 07
   SOF packet with frame number 598, CRC 0F
@@ -3770,6 +3770,15 @@
   SOF packet with frame number 342, CRC 00
   SOF packet with frame number 343, CRC 1F
   SOF packet with frame number 344, CRC 1E
+ 8 SOF packets
+  SOF packet with frame number 345, CRC 01
+  SOF packet with frame number 346, CRC 09
+  SOF packet with frame number 347, CRC 16
+  SOF packet with frame number 348, CRC 19
+  SOF packet with frame number 349, CRC 06
+  SOF packet with frame number 350, CRC 0E
+  SOF packet with frame number 351, CRC 11
+  SOF packet with frame number 352, CRC 1D
 Getting device descriptor #0 for device 0, reading 18 of 64 requested bytes
  SETUP transaction, ACK
   SETUP packet on 0.0, CRC 02
@@ -5108,14 +5117,6 @@ Polling 263 times for interrupt transfer on endpoint 2.3 IN
  IN transaction, NAK
   IN packet on 2.3, CRC 06
   NAK packet
- IN transaction, SOF
+ IN transaction, NAK
   IN packet on 2.3, CRC 06
   NAK packet
-  SOF packet with frame number 345, CRC 01
-  SOF packet with frame number 346, CRC 09
-  SOF packet with frame number 347, CRC 16
-  SOF packet with frame number 348, CRC 19
-  SOF packet with frame number 349, CRC 06
-  SOF packet with frame number 350, CRC 0E
-  SOF packet with frame number 351, CRC 11
-  SOF packet with frame number 352, CRC 1D

--- a/tests/hackrf-connect/reference.txt
+++ b/tests/hackrf-connect/reference.txt
@@ -1,4 +1,4 @@
-6 SOF groups
+7 SOF groups
  13 SOF packets
   SOF packet with frame number 228, CRC 09
   SOF packet with frame number 228, CRC 09
@@ -801,6 +801,16 @@
   SOF packet with frame number 382, CRC 1F
   SOF packet with frame number 382, CRC 1F
   SOF packet with frame number 382, CRC 1F
+ 9 SOF packets
+  SOF packet with frame number 382, CRC 1F
+  SOF packet with frame number 382, CRC 1F
+  SOF packet with frame number 382, CRC 1F
+  SOF packet with frame number 383, CRC 00
+  SOF packet with frame number 383, CRC 00
+  SOF packet with frame number 383, CRC 00
+  SOF packet with frame number 383, CRC 00
+  SOF packet with frame number 383, CRC 00
+  SOF packet with frame number 383, CRC 00
 Getting device descriptor #0 for device 0, reading 18 of 64 requested bytes
  SETUP transaction, ACK
   SETUP packet on 0.0, CRC 02
@@ -948,16 +958,7 @@ Getting string descriptor #3, language 0x0409 for device 29, reading 24 of 255 r
   IN packet on 29.0, CRC 08
   DATA1 packet with CRC CE28 and 24 data bytes: [18, 03, 54, 00, 72, 00, 61, 00, 6E, 00, 73, 00, 63, 00, 65, 00, 69, 00, 76, 00, 65, 00, 72, 00]
   ACK packet
- OUT transaction with no data, SOF
+ OUT transaction with no data, ACK
   OUT packet on 29.0, CRC 08
   DATA1 packet with CRC 0000 and no data
   ACK packet
-  SOF packet with frame number 382, CRC 1F
-  SOF packet with frame number 382, CRC 1F
-  SOF packet with frame number 382, CRC 1F
-  SOF packet with frame number 383, CRC 00
-  SOF packet with frame number 383, CRC 00
-  SOF packet with frame number 383, CRC 00
-  SOF packet with frame number 383, CRC 00
-  SOF packet with frame number 383, CRC 00
-  SOF packet with frame number 383, CRC 00

--- a/tests/hackrf-dfu-enum/reference.txt
+++ b/tests/hackrf-dfu-enum/reference.txt
@@ -1,4 +1,4 @@
-11 SOF groups
+12 SOF groups
  8 SOF packets
   SOF packet with frame number 186, CRC 00
   SOF packet with frame number 186, CRC 00
@@ -29,6 +29,38 @@
   SOF packet with frame number 188, CRC 10
  1 SOF packets
   SOF packet with frame number 189, CRC 0F
+ 31 SOF packets
+  SOF packet with frame number 189, CRC 0F
+  SOF packet with frame number 189, CRC 0F
+  SOF packet with frame number 189, CRC 0F
+  SOF packet with frame number 189, CRC 0F
+  SOF packet with frame number 189, CRC 0F
+  SOF packet with frame number 189, CRC 0F
+  SOF packet with frame number 189, CRC 0F
+  SOF packet with frame number 190, CRC 07
+  SOF packet with frame number 190, CRC 07
+  SOF packet with frame number 190, CRC 07
+  SOF packet with frame number 190, CRC 07
+  SOF packet with frame number 190, CRC 07
+  SOF packet with frame number 190, CRC 07
+  SOF packet with frame number 190, CRC 07
+  SOF packet with frame number 190, CRC 07
+  SOF packet with frame number 191, CRC 18
+  SOF packet with frame number 191, CRC 18
+  SOF packet with frame number 191, CRC 18
+  SOF packet with frame number 191, CRC 18
+  SOF packet with frame number 191, CRC 18
+  SOF packet with frame number 191, CRC 18
+  SOF packet with frame number 191, CRC 18
+  SOF packet with frame number 191, CRC 18
+  SOF packet with frame number 192, CRC 1F
+  SOF packet with frame number 192, CRC 1F
+  SOF packet with frame number 192, CRC 1F
+  SOF packet with frame number 192, CRC 1F
+  SOF packet with frame number 192, CRC 1F
+  SOF packet with frame number 192, CRC 1F
+  SOF packet with frame number 192, CRC 1F
+  SOF packet with frame number 192, CRC 1F
 Getting device descriptor #0 for device 11, reading 18 bytes
  SETUP transaction, ACK
   SETUP packet on 11.0, CRC 04
@@ -221,38 +253,7 @@ Getting string descriptor #4, language 0x0409 for device 11, reading 8 of 255 re
  PING transaction, ACK
   PING packet on 11.0, CRC 04
   ACK packet
- OUT transaction with no data, SOF
+ OUT transaction with no data, ACK
   OUT packet on 11.0, CRC 04
   DATA1 packet with CRC 0000 and no data
   ACK packet
-  SOF packet with frame number 189, CRC 0F
-  SOF packet with frame number 189, CRC 0F
-  SOF packet with frame number 189, CRC 0F
-  SOF packet with frame number 189, CRC 0F
-  SOF packet with frame number 189, CRC 0F
-  SOF packet with frame number 189, CRC 0F
-  SOF packet with frame number 189, CRC 0F
-  SOF packet with frame number 190, CRC 07
-  SOF packet with frame number 190, CRC 07
-  SOF packet with frame number 190, CRC 07
-  SOF packet with frame number 190, CRC 07
-  SOF packet with frame number 190, CRC 07
-  SOF packet with frame number 190, CRC 07
-  SOF packet with frame number 190, CRC 07
-  SOF packet with frame number 190, CRC 07
-  SOF packet with frame number 191, CRC 18
-  SOF packet with frame number 191, CRC 18
-  SOF packet with frame number 191, CRC 18
-  SOF packet with frame number 191, CRC 18
-  SOF packet with frame number 191, CRC 18
-  SOF packet with frame number 191, CRC 18
-  SOF packet with frame number 191, CRC 18
-  SOF packet with frame number 191, CRC 18
-  SOF packet with frame number 192, CRC 1F
-  SOF packet with frame number 192, CRC 1F
-  SOF packet with frame number 192, CRC 1F
-  SOF packet with frame number 192, CRC 1F
-  SOF packet with frame number 192, CRC 1F
-  SOF packet with frame number 192, CRC 1F
-  SOF packet with frame number 192, CRC 1F
-  SOF packet with frame number 192, CRC 1F


### PR DESCRIPTION
This PR focuses on mechanisms for updating the UI as new packets are added to a running capture. With these changes:

- Transfer descriptions are updated as transfers make progress.
- New transactions and packets are appended to parents that are expanded in the traffic view.
- New information is added to the device hierarchy tree as it becomes available.

This PR is part of the the planned sequence documented in #54. The next PR will focus on decoder changes to improve the display of partial transactions and transfers, and will add support for SPLIT transactions. This PR lays the groundwork, by establishing the necessary UI update mechanisms for the effects to be seen.

Note that to see the effects of individual packets on the view, captures can be replayed packet-by-packet by running Packetry with the `step-decoder` feature enabled at compile time (introduced in #51). This will cause Packetry to listen on TCP port 46563, and block waiting for any byte to be received on that port before decoding each packet. You can then use e.g. `nc localhost 46563` and press enter to trigger each packet.