### PR TITLE
Add support for saving capture to a pcap file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,8 +60,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
 dependencies = [
  "proc-macro2",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -69,6 +69,15 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "byteorder_slice"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b294e30387378958e8bf8f4242131b930ea615ff81e8cac2440cea0a6013190"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "cairo-rs"
@@ -123,12 +132,13 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "derive-into-owned"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576fce04d31d592013a5887ba8d9c3830adff329e5096d7e1eb5e8e61262ca62"
+checksum = "2c9d94d81e3819a7b06a8638f448bc6339371ca9b6076a99d4a43eece3c4c923"
 dependencies = [
- "quote 0.3.15",
- "syn 0.11.11",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -139,9 +149,9 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.15",
+ "quote",
  "rustc_version 0.4.0",
- "syn 1.0.86",
+ "syn",
 ]
 
 [[package]]
@@ -334,8 +344,8 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -447,8 +457,8 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -557,8 +567,8 @@ checksum = "0d992b768490d7fe0d8586d9b5745f6c49f557da6d81dc982b1d167ad4edbb21"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -615,11 +625,11 @@ dependencies = [
 
 [[package]]
 name = "pcap-file"
-version = "1.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad13fed1a83120159aea81b265074f21d753d157dd16b10cc3790ecba40a341"
+checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
 dependencies = [
- "byteorder",
+ "byteorder_slice",
  "derive-into-owned",
  "thiserror",
 ]
@@ -669,8 +679,8 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -681,7 +691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.15",
+ "quote",
  "version_check",
 ]
 
@@ -691,14 +701,8 @@ version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-xid",
 ]
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -799,33 +803,13 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.15",
- "unicode-xid 0.2.2",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -857,22 +841,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -889,12 +873,6 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ bytemuck_derive = "1.0.1"
 gtk = { version = "*", package = "gtk4" }
 num_enum = "0.5.6"
 once_cell = "1.5"
-pcap-file = "1.1.1"
+pcap-file = "2.0.0"
 tempfile = "3.3.0"
 thiserror = "1.0.30"
 bitfield = "0.13.2"

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1284,10 +1284,10 @@ mod tests {
                 out_path.push("output.txt");
                 {
                     let pcap_file = File::open(cap_path).unwrap();
-                    let pcap_reader = PcapReader::new(pcap_file).unwrap();
+                    let mut pcap_reader = PcapReader::new(pcap_file).unwrap();
                     let mut cap = Capture::new().unwrap();
                     let mut decoder = Decoder::default();
-                    for result in pcap_reader {
+                    while let Some(result) = pcap_reader.next_raw_packet() {
                         let packet = result.unwrap().data;
                         decoder.handle_raw_packet(&mut cap, &packet).unwrap();
                     }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -576,7 +576,7 @@ impl Capture {
         Ok(self.endpoint_states.get_range(range)?)
     }
 
-    fn packet(&mut self, id: PacketId)
+    pub fn packet(&mut self, id: PacketId)
         -> Result<Vec<u8>, CaptureError>
     {
         let range = self.packet_index.target_range(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,10 @@ mod row_data;
 mod expander;
 mod tree_list_model;
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufReader, BufWriter, Write};
 use std::mem::size_of;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, atomic::{AtomicBool, AtomicU64, Ordering}};
@@ -39,7 +40,11 @@ use gtk::{
     Orientation,
 };
 
-use pcap_file::{PcapError, pcap::{PcapReader, PcapHeader}};
+use pcap_file::{
+    PcapError,
+    DataLink,
+    pcap::{PcapReader, PcapWriter, PcapHeader, RawPcapPacket},
+};
 
 use backend::luna::{LunaDevice, LunaStop};
 use model::{GenericModel, TrafficModel, DeviceModel};
@@ -54,7 +59,9 @@ use capture::{
     ItemSource,
     TrafficItem,
     DeviceItem,
+    PacketId,
     fmt_size,
+    fmt_count,
 };
 
 mod decoder;
@@ -72,6 +79,12 @@ static STOP: AtomicBool = AtomicBool::new(false);
 
 static UPDATE_INTERVAL: Duration = Duration::from_millis(10);
 
+#[derive(Copy, Clone, PartialEq)]
+enum FileAction {
+    Load,
+    Save,
+}
+
 struct UserInterface {
     capture: Arc<Mutex<Capture>>,
     stop_handle: Option<LunaStop>,
@@ -80,10 +93,11 @@ struct UserInterface {
     traffic_model: Option<TrafficModel>,
     device_model: Option<DeviceModel>,
     endpoint_count: u16,
-    show_progress: bool,
+    show_progress: Option<FileAction>,
     progress_bar: ProgressBar,
     vbox: gtk::Box,
     open_button: Button,
+    save_button: Button,
     capture_button: Button,
     stop_button: Button,
 }
@@ -208,6 +222,8 @@ pub enum PacketryError {
 }
 
 fn activate(application: &Application) -> Result<(), PacketryError> {
+    use FileAction::*;
+
     let window = gtk::ApplicationWindow::builder()
         .default_width(320)
         .default_height(480)
@@ -225,7 +241,6 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
     open_button.set_sensitive(true);
     save_button.set_sensitive(false);
     capture_button.set_sensitive(true);
-    stop_button.set_sensitive(false);
 
     header_bar.pack_start(&open_button);
     header_bar.pack_start(&save_button);
@@ -277,7 +292,8 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
     window.set_child(Some(&vbox));
 
     capture_button.connect_clicked(|_| display_error(start_luna()));
-    open_button.connect_clicked(|_| display_error(open_file()));
+    open_button.connect_clicked(|_| display_error(choose_file(Load)));
+    save_button.connect_clicked(|_| display_error(choose_file(Save)));
 
     UI.with(|cell|
         cell.borrow_mut().replace(
@@ -289,10 +305,11 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
                 traffic_model: None,
                 device_model: None,
                 endpoint_count: 2,
-                show_progress: false,
+                show_progress: None,
                 progress_bar,
                 vbox,
                 open_button,
+                save_button,
                 capture_button,
                 stop_button,
             }
@@ -304,7 +321,7 @@ fn activate(application: &Application) -> Result<(), PacketryError> {
     if args.len() > 1 {
         let filename = args[1].clone();
         let path = PathBuf::from(filename);
-        start_pcap(path)?;
+        start_pcap(Load, path)?;
     }
 
     gtk::glib::timeout_add_once(
@@ -339,42 +356,48 @@ fn reset_capture() -> Result<(), PacketryError> {
         ui.endpoint_count = 2;
         ui.traffic_window.set_child(Some(&traffic_view));
         ui.device_window.set_child(Some(&device_view));
+        ui.stop_button.set_sensitive(false);
         Ok(())
     })
 }
 
 fn update_view() -> Result<(), PacketryError> {
+    use FileAction::*;
     with_ui(|ui| {
         use PacketryError::Lock;
         let mut more_updates = false;
-        if let Some(model) = &ui.traffic_model {
-            let old_count = model.n_items();
-            more_updates |= model.update()?;
-            let new_count = model.n_items();
-            // If any endpoints were added, we need to redraw the rows above
-            // to add the additional columns of the connecting lines.
-            if new_count > old_count {
-                let new_ep_count = ui.capture
-                    .lock()
-                    .or(Err(Lock))?
-                    .endpoints.len() as u16;
-                if new_ep_count > ui.endpoint_count {
-                    model.items_changed(0, old_count, old_count);
-                    ui.endpoint_count = new_ep_count;
+        if ui.show_progress != Some(Save) {
+            if let Some(model) = &ui.traffic_model {
+                let old_count = model.n_items();
+                more_updates |= model.update()?;
+                let new_count = model.n_items();
+                // If any endpoints were added, we need to redraw the rows above
+                // to add the additional columns of the connecting lines.
+                if new_count > old_count {
+                    let new_ep_count = ui.capture
+                        .lock()
+                        .or(Err(Lock))?
+                        .endpoints.len() as u16;
+                    if new_ep_count > ui.endpoint_count {
+                        model.items_changed(0, old_count, old_count);
+                        ui.endpoint_count = new_ep_count;
+                    }
                 }
             }
+            if let Some(model) = &ui.device_model {
+                more_updates |= model.update()?;
+            }
         }
-        if let Some(model) = &ui.device_model {
-            more_updates |= model.update()?;
-        }
-        if ui.show_progress {
-            let bytes_total = TOTAL.load(Ordering::Relaxed);
-            let bytes_read = CURRENT.load(Ordering::Relaxed);
-            let text = format!(
-                "Loaded {} / {}",
-                fmt_size(bytes_read),
-                fmt_size(bytes_total));
-            let fraction = (bytes_read as f64) / (bytes_total as f64);
+        if let Some(action) = &ui.show_progress {
+            let total = TOTAL.load(Ordering::Relaxed);
+            let current = CURRENT.load(Ordering::Relaxed);
+            let fraction = (current as f64) / (total as f64);
+            let text = match action {
+                Load => format!("Loaded {} / {}",
+                                fmt_size(current), fmt_size(total)),
+                Save => format!("Saved {} / {} packets",
+                                fmt_count(current), fmt_count(total)),
+            };
             ui.progress_bar.set_text(Some(&text));
             ui.progress_bar.set_fraction(fraction);
         }
@@ -388,22 +411,31 @@ fn update_view() -> Result<(), PacketryError> {
     })
 }
 
-fn open_file() -> Result<(), PacketryError> {
+fn choose_file(action: FileAction) -> Result<(), PacketryError> {
+    use FileAction::*;
     let chooser = WINDOW.with(|cell| {
         let borrow = cell.borrow();
         let window = borrow.as_ref();
-        gtk::FileChooserDialog::new(
-            Some("Open pcap file"),
-            window,
-            gtk::FileChooserAction::Open,
-            &[("Open", gtk::ResponseType::Accept)]
-        )
+        match action {
+            Load => gtk::FileChooserDialog::new(
+                Some("Open pcap file"),
+                window,
+                gtk::FileChooserAction::Open,
+                &[("Open", gtk::ResponseType::Accept)]
+            ),
+            Save => gtk::FileChooserDialog::new(
+                Some("Save pcap file"),
+                window,
+                gtk::FileChooserAction::Save,
+                &[("Save", gtk::ResponseType::Accept)]
+            ),
+        }
     });
     chooser.connect_response(move |dialog, response| {
         if response == gtk::ResponseType::Accept {
             if let Some(file) = dialog.file() {
                 if let Some(path) = file.path() {
-                    display_error(start_pcap(path));
+                    display_error(start_pcap(action, path));
                 }
             }
             dialog.destroy();
@@ -413,60 +445,105 @@ fn open_file() -> Result<(), PacketryError> {
     Ok(())
 }
 
-fn start_pcap(path: PathBuf) -> Result<(), PacketryError> {
-    reset_capture()?;
+fn start_pcap(action: FileAction, path: PathBuf) -> Result<(), PacketryError> {
+    use FileAction::*;
+    if action == Load {
+        reset_capture()?;
+    }
     with_ui(|ui| {
         ui.open_button.set_sensitive(false);
+        ui.save_button.set_sensitive(false);
         ui.capture_button.set_sensitive(false);
         ui.stop_button.set_sensitive(true);
         let signal_id = ui.stop_button.connect_clicked(|_|
             display_error(stop_pcap()));
         ui.vbox.append(&ui.progress_bar);
-        ui.show_progress = true;
+        ui.show_progress = Some(action);
         let capture = ui.capture.clone();
-        let read_pcap = move || {
-            let file = File::open(path)?;
-            let file_size = file.metadata()?.len();
-            TOTAL.store(file_size, Ordering::Relaxed);
-            let reader = BufReader::new(file);
-            let mut pcap = PcapReader::new(reader)?;
-            let mut bytes_read = size_of::<PcapHeader>() as u64;
-            let mut decoder = Decoder::default();
-            use PacketryError::Lock;
-            #[cfg(feature="step-decoder")]
-            let (mut client, _addr) =
-                TcpListener::bind("127.0.0.1:46563")?.accept()?;
-            while let Some(result) = pcap.next_raw_packet() {
-                #[cfg(feature="step-decoder")] {
-                    let mut buf = [0; 1];
-                    client.read(&mut buf).unwrap();
-                };
-                let packet = result?;
-                let mut cap = capture.lock().or(Err(Lock))?;
-                decoder.handle_raw_packet(&mut cap, &packet.data)?;
-                let size = 16 + packet.data.len();
-                bytes_read += size as u64;
-                CURRENT.store(bytes_read, Ordering::Relaxed);
-                if STOP.load(Ordering::Relaxed) {
-                    break;
+        use PacketryError::Lock;
+        let worker = move || match action {
+            Load => {
+                let file = File::open(path)?;
+                let file_size = file.metadata()?.len();
+                TOTAL.store(file_size, Ordering::Relaxed);
+                let reader = BufReader::new(file);
+                let mut pcap = PcapReader::new(reader)?;
+                let mut bytes_read = size_of::<PcapHeader>() as u64;
+                let mut decoder = Decoder::default();
+                #[cfg(feature="step-decoder")]
+                let (mut client, _addr) =
+                    TcpListener::bind("127.0.0.1:46563")?.accept()?;
+                while let Some(result) = pcap.next_raw_packet() {
+                    #[cfg(feature="step-decoder")] {
+                        let mut buf = [0; 1];
+                        client.read(&mut buf).unwrap();
+                    };
+                    let packet = result?;
+                    let mut cap = capture.lock().or(Err(Lock))?;
+                    decoder.handle_raw_packet(&mut cap, &packet.data)?;
+                    let size = 16 + packet.data.len();
+                    bytes_read += size as u64;
+                    CURRENT.store(bytes_read, Ordering::Relaxed);
+                    if STOP.load(Ordering::Relaxed) {
+                        break;
+                    }
                 }
-            }
-            let mut cap = capture.lock().or(Err(Lock))?;
-            cap.finish();
-            cap.print_storage_summary();
-            Ok(())
+                let mut cap = capture.lock().or(Err(Lock))?;
+                cap.finish();
+                cap.print_storage_summary();
+                Ok(())
+            },
+            Save => {
+                let packet_count = capture
+                    .lock()
+                    .or(Err(Lock))?
+                    .packet_index.len();
+                TOTAL.store(packet_count, Ordering::Relaxed);
+                CURRENT.store(0, Ordering::Relaxed);
+                let file = File::create(path)?;
+                let writer = BufWriter::new(file);
+                let header = PcapHeader {
+                    datalink: DataLink::USB_2_0,
+                    .. PcapHeader::default()
+                };
+                let mut pcap = PcapWriter::with_header(writer, header)?;
+                for i in 0..packet_count {
+                    let mut cap = capture.lock().or(Err(Lock))?;
+                    let packet_id = PacketId::from(i);
+                    let bytes = cap.packet(packet_id)?;
+                    let length: u32 = bytes
+                        .len()
+                        .try_into()
+                        .or_bug("Packet too large for pcap file")?;
+                    let packet = RawPcapPacket {
+                        ts_sec: 0,
+                        ts_frac: 0,
+                        incl_len: length,
+                        orig_len: length,
+                        data: Cow::from(bytes)
+                    };
+                    pcap.write_raw_packet(&packet)?;
+                    CURRENT.store(i + 1, Ordering::Relaxed);
+                    if STOP.load(Ordering::Relaxed) {
+                        break;
+                    }
+                }
+                pcap.into_writer().flush()?;
+                Ok(())
+            },
         };
         std::thread::spawn(move || {
-            display_error(read_pcap());
+            display_error(worker());
             gtk::glib::idle_add_once(|| {
                 STOP.store(false, Ordering::Relaxed);
                 display_error(
                     with_ui(|ui| {
-                        ui.show_progress = false;
+                        ui.show_progress = None;
                         ui.vbox.remove(&ui.progress_bar);
                         ui.stop_button.disconnect(signal_id);
                         ui.stop_button.set_sensitive(false);
                         ui.open_button.set_sensitive(true);
+                        ui.save_button.set_sensitive(true);
                         ui.capture_button.set_sensitive(true);
                         Ok(())
                     })
@@ -530,6 +607,7 @@ fn stop_luna() -> Result<(), PacketryError> {
         if let Some(stop_handle) = ui.stop_handle.take() {
             stop_handle.stop()?;
         }
+        ui.save_button.set_sensitive(true);
         Ok(())
     })
 }


### PR DESCRIPTION
This PR adds support for saving a capture to a pcap file.

This can take a while for large captures, so saving runs the background with a progress bar and can be interrupted, using the same UI mechanisms as for loading a pcap file.

Note some limitations:
  - This implementation saves all packets. The ability to select what to save will come in a future PR.
  - Since we have no timestamping yet, all timestamps in the pcap file are set to zero.