### PR TITLE
Lock-free stream implementation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['macos-latest', 'ubuntu-22.04']
-        rust: ['stable']
+        rust: ['stable', '1.57']
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +296,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gio"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,9 +547,9 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "libc"
-version = "0.2.118"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libusb1-sys"
@@ -544,6 +561,21 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "lrumap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1251ce8e8f9909600e127dcbe74ac50d8464e6685cf5953d37df7a741dbf9e9d"
+
+[[package]]
+name = "memmap2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -602,6 +634,7 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 name = "packetry"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "bisection",
  "bitfield",
  "bufreaderwriter",
@@ -611,10 +644,14 @@ dependencies = [
  "gtk4",
  "humansize",
  "itertools",
+ "lrumap",
+ "memmap2",
  "num-format",
  "num_enum",
  "once_cell",
  "pcap-file",
+ "rand",
+ "rand_xorshift",
  "rusb",
  "serde",
  "serde_json",
@@ -686,6 +723,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +778,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -952,6 +1034,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,7 @@ dependencies = [
  "num-format",
  "num_enum",
  "once_cell",
+ "page_size",
  "pcap-file",
  "rand",
  "rand_xorshift",
@@ -657,6 +658,16 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+]
+
+[[package]]
+name = "page_size"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7663cbd190cfd818d08efa8497f6cd383076688c49a391ef7c0d03cd12b561"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ itertools = { version = "0.10.5", optional = true }
 arc-swap = "1.6.0"
 lrumap = "0.1.0"
 memmap2 = "0.5.8"
+page_size = "0.5.0"
 
 [dev-dependencies]
 serde = { version = "1.0.136", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,16 @@ rusb = "0.9.1"
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.85", optional = true }
 itertools = { version = "0.10.5", optional = true }
+arc-swap = "1.6.0"
+lrumap = "0.1.0"
+memmap2 = "0.5.8"
 
 [dev-dependencies]
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.85"
 itertools = "0.10.5"
+rand = "0.8.5"
+rand_xorshift = "0.3.0"
 
 [features]
 step-decoder = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "packetry"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.57"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Packetry is currently in active development and not yet ready for initial releas
 
 Packetry is written in [Rust](https://rust-lang.org/), with its GUI using [GTK 4](https://gtk.org) via the [gtk-rs](https://gtk-rs.org/) bindings.
 
-To build it, you need a working Rust development environment.
+To build it, you need a working Rust development environment. The minimum supported Rust version is 1.57.
 
 You must also have the GTK 4 headers installed and discoverable via `pkg-config`, as this is required for Rust to build the gtk-rs crates.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,8 @@ pub mod ui;
 mod usb;
 mod vec_map;
 
+#[cfg(test)]
+mod stream;
+
 #[cfg(any(feature="test-ui-replay", feature="record-ui-test"))]
 pub mod record_ui;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,475 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cmp::min;
+use std::fs::File;
+use std::io::Write;
+use std::ops::{Deref, Range};
+use std::ptr::copy_nonoverlapping;
+use std::slice;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering::{Acquire, Release}};
+
+use arc_swap::ArcSwap;
+use lrumap::LruBTreeMap;
+use memmap2::{Mmap, MmapOptions};
+use tempfile::tempfile;
+use thiserror::Error;
+
+/// Private data shared by the writer and multiple readers.
+struct Shared {
+    /// Available length of the stream, including data in both file and buffer.
+    length: AtomicU64,
+    /// File handle used by readers to create mappings.
+    file: File,
+    /// Buffer currently in use for newly appended data.
+    current_buffer: ArcSwap<Buffer>,
+}
+
+/// Unique handle for append-only write access to a stream.
+pub struct StreamWriter {
+    /// Shared data.
+    shared: Arc<Shared>,
+    /// Total length of the stream.
+    length: u64,
+    /// Pointer to start of the buffer currently in use.
+    buf: *mut u8,
+    /// Pointer to current position in the current buffer.
+    ptr: *mut u8,
+    /// File handle used to append to the stream.
+    file: File,
+    /// Spare buffer to be potentially used when current buffer is full.
+    spare_buffer: Option<Arc<Buffer>>,
+}
+
+/// Cloneable handle for read-only random access to a stream.
+pub struct StreamReader {
+    /// Shared data.
+    shared: Arc<Shared>,
+    /// Cache of existing mappings into the file.
+    mappings: LruBTreeMap<u64, Arc<Mmap>>,
+}
+
+/// Data that is part of a stream and currently in memory.
+struct Buffer {
+    /// Block to which this data belongs.
+    block_base: u64,
+    /// Raw pointer to space allocated to hold the data.
+    ptr: *mut u8,
+}
+
+/// A read-only handle to any data that is part of a stream.
+enum Data {
+    /// Data in the file, accessed through a mapping.
+    Mapped(Arc<Mmap>, Range<usize>),
+    /// Data in memory, accessed within a buffer.
+    Buffered(Arc<Buffer>, Range<usize>),
+}
+
+/// Error type returned by stream operations.
+#[derive(Debug, Error)]
+pub enum StreamError {
+    /// Failed to create temporary file to store the stream.
+    #[error("failed creating temporary file: {0}")]
+    TempFile(std::io::Error),
+    /// Failed to clone file handle to the stream file.
+    #[error("failed cloning file handle: {0}")]
+    CloneFile(std::io::Error),
+    /// Failed to write to the end of the stream file.
+    #[error("failed writing to stream file: {0}")]
+    WriteFile(std::io::Error),
+    /// Failed to create a memory mapping into part of the stream file.
+    #[error("failed mapping stream file: {0}")]
+    MapFile(std::io::Error),
+    /// Failed to allocate a buffer.
+    #[error("failed to allocate buffer")]
+    Alloc(),
+    /// Attempted to read past the end of the stream.
+    #[error("attemped to read past end of stream: {0}")]
+    ReadPastEnd(String),
+}
+
+// Use 2MB block size, which provides reasonable efficiency
+// tradeoffs and is a multiple of all relevant page sizes.
+const BLOCK_SIZE: usize = 0x200000;
+const BLOCK_MASK: usize = BLOCK_SIZE - 1;
+const BLOCK_SIZE_U64: u64 = BLOCK_SIZE as u64;
+const BLOCK_MASK_U64: u64 = BLOCK_MASK as u64;
+
+// Layout used to allocate block-sized, block-aligned chunks of memory.
+const BLOCK_LAYOUT: Layout = unsafe {
+    // Safety: align is non-zero, a power of 2, and does not overflow isize.
+    Layout::from_size_align_unchecked(BLOCK_SIZE, BLOCK_SIZE)
+};
+
+// Number of most recent file mappings retained by each reader.
+const MAP_CACHE_PER_READER: usize = 4;
+
+/// Construct a new stream.
+///
+/// Returns a unique writer and a cloneable reader.
+///
+pub fn stream() -> Result<(StreamWriter, StreamReader), StreamError> {
+    let buffer = Arc::new(Buffer::new(0)?);
+    let shared = Arc::new(Shared {
+        length: AtomicU64::from(0),
+        file: tempfile().map_err(StreamError::TempFile)?,
+        current_buffer: ArcSwap::new(buffer.clone()),
+    });
+    let writer = StreamWriter {
+        shared: shared.clone(),
+        length: 0,
+        buf: buffer.ptr,
+        ptr: buffer.ptr,
+        file: shared.file.try_clone().map_err(StreamError::CloneFile)?,
+        spare_buffer: None,
+    };
+    let reader = StreamReader {
+        shared,
+        mappings: LruBTreeMap::new(MAP_CACHE_PER_READER),
+    };
+    Ok((writer, reader))
+}
+
+impl StreamWriter {
+    /// Get the current length of the stream, in bytes.
+    pub fn len(&self) -> u64 {
+        self.length
+    }
+
+    /// Append data to the end of the stream.
+    ///
+    /// Returns the new stream length.
+    ///
+    pub fn append(&mut self, mut data: &[u8]) -> Result<u64, StreamError> {
+        let length = data.len();
+        let buffered = (self.length & BLOCK_MASK_U64) as usize;
+        if buffered + length <= BLOCK_SIZE {
+            // All the data will fit in the existing buffer.
+            unsafe { self.write_to_buffer(data, length) };
+            if self.length & BLOCK_MASK_U64 == 0 {
+                // Buffer is now full, and can be written to file.
+                unsafe { self.write_buffer_to_file()? };
+            }
+        } else {
+            // The data will fill the existing buffer.
+            if buffered > 0 {
+                // The buffer is partly used. Fill it and write it out.
+                let length = BLOCK_SIZE - buffered;
+                unsafe { self.write_to_buffer(data, length) };
+                // Buffer is now full, and can be written to file.
+                unsafe { self.write_buffer_to_file()? };
+                data = &data[length..];
+            }
+            // The buffer is curently empty, so we are free to write whole
+            // blocks of data directly to the file, bypassing the buffer.
+            let direct = data.len() & !BLOCK_MASK;
+            if direct > 0 {
+                unsafe { self.write_to_file(&data[..direct])? };
+                data = &data[direct..];
+                self.length += direct as u64;
+            }
+            let length = data.len();
+            if length > 0 {
+                // There is data remaining which will fit in the next buffer.
+                unsafe { self.write_to_buffer(data, length) };
+            }
+        }
+        // Update shared length value, and return new length.
+        self.shared.length.store(self.length, Release);
+        Ok(self.length)
+    }
+
+    /// Helper method for writing data to buffer.
+    ///
+    /// The data must be guaranteed to fit within the remaining space.
+    ///
+    #[inline(always)]
+    unsafe fn write_to_buffer(&mut self, data: &[u8], length: usize) {
+        copy_nonoverlapping(data.as_ptr(), self.ptr, length);
+        self.ptr = self.ptr.add(length);
+        self.length += length as u64;
+    }
+
+    /// Helper method for writing buffer to file.
+    ///
+    /// The buffer must be guaranteed to be full.
+    #[inline(always)]
+    unsafe fn write_buffer_to_file(&mut self) -> Result<(), StreamError> {
+        let buf = slice::from_raw_parts(self.buf, BLOCK_SIZE);
+        self.write_to_file(buf)
+    }
+
+    /// Helper method for writing data to file.
+    ///
+    /// The data must be guaranteed to be a multiple of the block size.
+    ///
+    unsafe fn write_to_file(&mut self, data: &[u8]) -> Result<(), StreamError> {
+
+        // Write the data to file.
+        self.file.write(data).map_err(StreamError::WriteFile)?;
+
+        // We must change the stream's current buffer to one for the new block.
+        let block_base = self.length;
+
+        // Look for a usable spare buffer.
+        let next_buffer = match self.spare_buffer.take() {
+            Some(mut arc) => {
+                if let Some(buffer) = Arc::get_mut(&mut arc) {
+                    // We are holding the only reference to this buffer,
+                    // so we can update its block base and reuse it.
+                    buffer.block_base = block_base;
+                    arc
+                } else {
+                    // This buffer is still in use. Allocate a new one.
+                    Arc::new(Buffer::new(block_base)?)
+                }
+            },
+            // There is no spare buffer. Allocate a new one.
+            None => Arc::new(Buffer::new(block_base)?)
+        };
+
+        // Set our pointers appropriately.
+        self.buf = next_buffer.ptr;
+        self.ptr = self.buf;
+
+        // Swap in the next write buffer.
+        let prev_buffer = self.shared.current_buffer.swap(next_buffer);
+
+        // Store the previous buffer as the new spare.
+        self.spare_buffer = Some(prev_buffer);
+
+        Ok(())
+    }
+}
+
+impl StreamReader {
+    /// Get the current length of the stream, in bytes.
+    pub fn len(&self) -> u64 {
+        self.shared.length.load(Acquire)
+    }
+
+    /// Access data in the stream.
+    ///
+    /// Returns a reference to a slice of data, which may have less than the
+    /// requested length. The method may be called again to access further data.
+    ///
+    pub fn access(&mut self, range: &Range<u64>)
+        -> Result<impl Deref<Target=[u8]>, StreamError>
+    {
+        use Data::*;
+
+        // First guarantee that the requested data exists, somewhere.
+        let available_length = self.shared.length.load(Acquire);
+        if range.end > available_length {
+            return Err(StreamError::ReadPastEnd(format!(
+                "requested read of range {:?}, but stream length is {}",
+                range, available_length)));
+        }
+
+        // Identify the block and the range required from within it.
+        let block_base = range.start & !BLOCK_MASK_U64;
+        let length = range.end - range.start;
+        let start = range.start & BLOCK_MASK_U64;
+        let end = min(start + length, BLOCK_SIZE_U64);
+        let range_in_block = (start as usize)..(end as usize);
+
+        // Take our own reference to the current buffer.
+        let buffer = self.shared.current_buffer.load();
+
+        // Check if the required block is the one represented by this buffer.
+        if buffer.block_base == block_base {
+            // Return a handle to access the data in this buffer.
+            Ok(Buffered(buffer.clone(), range_in_block))
+        } else {
+            // The requested block was already written to the file.
+            // Look for an existing mapping of the block.
+            let existing_mmap = self.mappings.get(&block_base);
+
+            // If there is no existing mapping, create one.
+            let mmap = match existing_mmap {
+                Some(mmap) => Arc::clone(mmap),
+                None => {
+                    // The block was already written to the file and will not
+                    // be modified by the writer, so it is safe to map it.
+                    let mmap_result = unsafe {
+                        MmapOptions::new()
+                            .offset(block_base)
+                            .len(BLOCK_SIZE)
+                            .map(&self.shared.file)
+                    };
+                    let new_mmap =
+                        Arc::new(mmap_result.map_err(StreamError::MapFile)?);
+                    self.mappings.push(block_base, Arc::clone(&new_mmap));
+                    new_mmap
+                }
+            };
+
+            // Return a handle to access the data through this mapping.
+            Ok(Mapped(mmap, range_in_block))
+        }
+    }
+}
+
+impl Buffer {
+    /// Create a new buffer for the specified block.
+    fn new(block_base: u64) -> Result<Buffer, StreamError> {
+        Ok(Buffer {
+            block_base,
+            // Calling System.alloc safely requires the layout to be known to
+            // have non-zero size. If the allocation fails we return an error.
+            // Otherwise, our Drop impl guarantees the allocation is freed.
+            ptr: unsafe {
+                let ptr = System.alloc(BLOCK_LAYOUT);
+                if ptr.is_null() {
+                    return Err(StreamError::Alloc());
+                }
+                ptr
+            }
+        })
+    }
+}
+
+// Dropping a Buffer must free the allocated block.
+impl Drop for Buffer {
+    fn drop(&mut self) {
+        unsafe {
+            // This pointer was created in Buffer::new() and is known to point
+            // to an allocation made by this allocator with the same layout.
+            System.dealloc(self.ptr, BLOCK_LAYOUT)
+        }
+    }
+}
+
+// Tell the compiler that it's safe to send and share our types between
+// threads despite the *mut u8 fields, due to the way we manage the data.
+unsafe impl Send for StreamWriter {}
+unsafe impl Sync for StreamWriter {}
+unsafe impl Send for Buffer {}
+unsafe impl Sync for Buffer {}
+
+// Data can be dereferenced by readers to access the stream data.
+impl Deref for Data {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        use Data::*;
+        match self {
+            Mapped(mmap, range) => &mmap[range.clone()],
+            // This variant is constructed only by StreamReader::access, which
+            // is responsible for ensuring that the range contains valid data.
+            Buffered(buffer, range) => unsafe {
+                let start = buffer.ptr.add(range.start);
+                let length = range.end - range.start;
+                slice::from_raw_parts(start, length)
+            }
+        }
+    }
+}
+
+// StreamReader can be cloned to set up multiple readers.
+impl Clone for StreamReader {
+    fn clone(&self) -> StreamReader {
+        StreamReader {
+            shared: self.shared.clone(),
+            mappings: LruBTreeMap::new(MAP_CACHE_PER_READER),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+    use std::time::Duration;
+    use std::thread::{spawn, sleep};
+    use rand_xorshift::XorShiftRng;
+    use rand::{Rng, SeedableRng};
+
+    #[test]
+    fn test_stream() {
+        // Create a reader-writer pair.
+        let (mut writer, reader) = stream().unwrap();
+
+        // Build a reference array with ~8MB of random data.
+        let mut prng = XorShiftRng::seed_from_u64(42);
+        let reference = Arc::new({
+            let mut data = vec![0u8; 8012345];
+            prng.fill(data.as_mut_slice());
+            data
+        });
+
+        // Spawn 10 reader threads which will each continually try to access
+        // random chunks of the stream, and verify data against the reference.
+        let mut readers = Vec::new();
+        let stop = Arc::new(AtomicBool::from(false));
+        for i in 0..10 {
+            let mut reader = reader.clone();
+            let reference = reference.clone();
+            let stop = stop.clone();
+            readers.push(spawn(move || {
+                // Give each thread its own PRNG.
+                let mut prng = XorShiftRng::seed_from_u64(i);
+
+                // Read randomly until stopped.
+                while !stop.load(Relaxed) {
+                    // Get the current length of the stream.
+                    let limit = reader.len();
+
+                    // Generate a random range to request.
+                    if limit < 2 { continue }
+                    let req_start = prng.gen_range(0..(limit - 1));
+                    let req_end = prng.gen_range((req_start + 1)..limit);
+                    let req_range = req_start..req_end;
+
+                    // Access the generated range.
+                    let data = reader.access(&req_range).unwrap();
+
+                    // Check against the reference.
+                    let ref_start = req_start as usize;
+                    let ref_end = ref_start + data.len();
+                    let expected = &reference[ref_start..ref_end];
+                    for (i, (a, b)) in data
+                         .iter()
+                         .zip(expected.iter())
+                         .enumerate()
+                    {
+                        if a != b {
+                            let req_range = req_start..req_end;
+                            let ref_length = ref_end - ref_start;
+                            panic!("Mismatch in data \
+                                   at byte {i} of {ref_length}: \
+                                   got {a}, expected {b}. \
+                                   Requested range was {req_range:?}")
+                        }
+                    }
+                }
+            }));
+        }
+
+        // Make random small writes until all data has been written.
+        let mut start = 0usize;
+        while start < reference.len() {
+            // Choose a random length to write.
+            let end = start + min(
+                prng.gen_range(1..12345),
+                reference.len() - start
+            );
+
+            // Wait briefly between writes.
+            sleep(Duration::from_millis(1));
+
+            // Append the data to the stream and check the return value.
+            let new_length = writer.append(&reference[start..end]).unwrap();
+            assert!(new_length == end as u64);
+
+            start = end;
+        }
+
+        assert!(writer.len() == reference.len() as u64);
+
+        // Stop the readers.
+        stop.store(true, Relaxed);
+        for thread in readers {
+            thread.join().unwrap();
+        }
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -14,6 +14,9 @@ use memmap2::{Mmap, MmapOptions};
 use tempfile::tempfile;
 use thiserror::Error;
 
+/// Minimum block size, defined by largest minimum page size on target systems.
+pub const MIN_BLOCK: usize = 0x4000; // 16KB (Apple M1/M2)
+
 /// Private data shared by the writer and multiple readers.
 struct Shared<const S: usize> {
     /// Available length of the stream, including data in both file and buffer.
@@ -25,7 +28,7 @@ struct Shared<const S: usize> {
 }
 
 /// Unique handle for append-only write access to a stream.
-pub struct StreamWriter<const S: usize> {
+pub struct StreamWriter<const S: usize = MIN_BLOCK> {
     /// Shared data.
     shared: Arc<Shared<S>>,
     /// Total length of the stream.
@@ -41,7 +44,7 @@ pub struct StreamWriter<const S: usize> {
 }
 
 /// Cloneable handle for read-only random access to a stream.
-pub struct StreamReader<const S: usize> {
+pub struct StreamReader<const S: usize = MIN_BLOCK> {
     /// Shared data.
     shared: Arc<Shared<S>>,
     /// Cache of existing mappings into the file.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -15,19 +15,19 @@ use tempfile::tempfile;
 use thiserror::Error;
 
 /// Private data shared by the writer and multiple readers.
-struct Shared {
+struct Shared<const S: usize> {
     /// Available length of the stream, including data in both file and buffer.
     length: AtomicU64,
     /// File handle used by readers to create mappings.
     file: File,
     /// Buffer currently in use for newly appended data.
-    current_buffer: ArcSwap<Buffer>,
+    current_buffer: ArcSwap<Buffer<S>>,
 }
 
 /// Unique handle for append-only write access to a stream.
-pub struct StreamWriter {
+pub struct StreamWriter<const S: usize> {
     /// Shared data.
-    shared: Arc<Shared>,
+    shared: Arc<Shared<S>>,
     /// Total length of the stream.
     length: u64,
     /// Pointer to start of the buffer currently in use.
@@ -37,19 +37,19 @@ pub struct StreamWriter {
     /// File handle used to append to the stream.
     file: File,
     /// Spare buffer to be potentially used when current buffer is full.
-    spare_buffer: Option<Arc<Buffer>>,
+    spare_buffer: Option<Arc<Buffer<S>>>,
 }
 
 /// Cloneable handle for read-only random access to a stream.
-pub struct StreamReader {
+pub struct StreamReader<const S: usize> {
     /// Shared data.
-    shared: Arc<Shared>,
+    shared: Arc<Shared<S>>,
     /// Cache of existing mappings into the file.
     mappings: LruBTreeMap<u64, Arc<Mmap>>,
 }
 
 /// Data that is part of a stream and currently in memory.
-struct Buffer {
+struct Buffer<const S: usize> {
     /// Block to which this data belongs.
     block_base: u64,
     /// Raw pointer to space allocated to hold the data.
@@ -57,11 +57,11 @@ struct Buffer {
 }
 
 /// A read-only handle to any data that is part of a stream.
-enum Data {
+enum Data<const S: usize> {
     /// Data in the file, accessed through a mapping.
     Mapped(Arc<Mmap>, Range<usize>),
     /// Data in memory, accessed within a buffer.
-    Buffered(Arc<Buffer>, Range<usize>),
+    Buffered(Arc<Buffer<S>>, Range<usize>),
 }
 
 /// Error type returned by stream operations.
@@ -87,27 +87,16 @@ pub enum StreamError {
     ReadPastEnd(String),
 }
 
-// Use 2MB block size, which provides reasonable efficiency
-// tradeoffs and is a multiple of all relevant page sizes.
-const BLOCK_SIZE: usize = 0x200000;
-const BLOCK_MASK: usize = BLOCK_SIZE - 1;
-const BLOCK_SIZE_U64: u64 = BLOCK_SIZE as u64;
-const BLOCK_MASK_U64: u64 = BLOCK_MASK as u64;
-
-// Layout used to allocate block-sized, block-aligned chunks of memory.
-const BLOCK_LAYOUT: Layout = unsafe {
-    // Safety: align is non-zero, a power of 2, and does not overflow isize.
-    Layout::from_size_align_unchecked(BLOCK_SIZE, BLOCK_SIZE)
-};
-
 // Number of most recent file mappings retained by each reader.
 const MAP_CACHE_PER_READER: usize = 4;
+
+type StreamPair<const S: usize> = (StreamWriter<S>, StreamReader<S>);
 
 /// Construct a new stream.
 ///
 /// Returns a unique writer and a cloneable reader.
 ///
-pub fn stream() -> Result<(StreamWriter, StreamReader), StreamError> {
+pub fn stream<const S: usize>() -> Result<StreamPair<S>, StreamError> {
     let buffer = Arc::new(Buffer::new(0)?);
     let shared = Arc::new(Shared {
         length: AtomicU64::from(0),
@@ -129,7 +118,7 @@ pub fn stream() -> Result<(StreamWriter, StreamReader), StreamError> {
     Ok((writer, reader))
 }
 
-impl StreamWriter {
+impl<const BLOCK_SIZE: usize> StreamWriter<BLOCK_SIZE> {
     /// Get the current length of the stream, in bytes.
     pub fn len(&self) -> u64 {
         self.length
@@ -141,11 +130,11 @@ impl StreamWriter {
     ///
     pub fn append(&mut self, mut data: &[u8]) -> Result<u64, StreamError> {
         let length = data.len();
-        let buffered = (self.length & BLOCK_MASK_U64) as usize;
-        if buffered + length <= BLOCK_SIZE {
+        let buffered = self.length as usize & Self::block_mask();
+        if buffered + length <= Self::block_size() {
             // All the data will fit in the existing buffer.
             unsafe { self.write_to_buffer(data, length) };
-            if self.length & BLOCK_MASK_U64 == 0 {
+            if self.length as usize & Self::block_mask() == 0 {
                 // Buffer is now full, and can be written to file.
                 unsafe { self.write_buffer_to_file()? };
             }
@@ -153,7 +142,7 @@ impl StreamWriter {
             // The data will fill the existing buffer.
             if buffered > 0 {
                 // The buffer is partly used. Fill it and write it out.
-                let length = BLOCK_SIZE - buffered;
+                let length = Self::block_size() - buffered;
                 unsafe { self.write_to_buffer(data, length) };
                 // Buffer is now full, and can be written to file.
                 unsafe { self.write_buffer_to_file()? };
@@ -161,7 +150,7 @@ impl StreamWriter {
             }
             // The buffer is curently empty, so we are free to write whole
             // blocks of data directly to the file, bypassing the buffer.
-            let direct = data.len() & !BLOCK_MASK;
+            let direct = data.len() & !Self::block_mask();
             if direct > 0 {
                 unsafe { self.write_to_file(&data[..direct])? };
                 data = &data[direct..];
@@ -194,7 +183,7 @@ impl StreamWriter {
     /// The buffer must be guaranteed to be full.
     #[inline(always)]
     unsafe fn write_buffer_to_file(&mut self) -> Result<(), StreamError> {
-        let buf = slice::from_raw_parts(self.buf, BLOCK_SIZE);
+        let buf = slice::from_raw_parts(self.buf, Self::block_size());
         self.write_to_file(buf)
     }
 
@@ -239,9 +228,19 @@ impl StreamWriter {
 
         Ok(())
     }
+
+    /// Block size in bytes.
+    pub const fn block_size() -> usize {
+        BLOCK_SIZE
+    }
+
+    /// Bitmask for bits defining an offset within a block.
+    pub const fn block_mask() -> usize {
+        BLOCK_SIZE - 1
+    }
 }
 
-impl StreamReader {
+impl<const BLOCK_SIZE: usize> StreamReader<BLOCK_SIZE> {
     /// Get the current length of the stream, in bytes.
     pub fn len(&self) -> u64 {
         self.shared.length.load(Acquire)
@@ -266,10 +265,10 @@ impl StreamReader {
         }
 
         // Identify the block and the range required from within it.
-        let block_base = range.start & !BLOCK_MASK_U64;
+        let block_base = range.start & !(Self::block_mask() as u64);
         let length = range.end - range.start;
-        let start = range.start & BLOCK_MASK_U64;
-        let end = min(start + length, BLOCK_SIZE_U64);
+        let start = range.start & (Self::block_mask() as u64);
+        let end = min(start + length, Self::block_size() as u64);
         let range_in_block = (start as usize)..(end as usize);
 
         // Take our own reference to the current buffer.
@@ -293,7 +292,7 @@ impl StreamReader {
                     let mmap_result = unsafe {
                         MmapOptions::new()
                             .offset(block_base)
-                            .len(BLOCK_SIZE)
+                            .len(Self::block_size())
                             .map(&self.shared.file)
                     };
                     let new_mmap =
@@ -307,18 +306,28 @@ impl StreamReader {
             Ok(Mapped(mmap, range_in_block))
         }
     }
+
+    /// Block size in bytes.
+    pub const fn block_size() -> usize {
+        BLOCK_SIZE
+    }
+
+    /// Bitmask for bits defining an offset within a block.
+    pub const fn block_mask() -> usize {
+        BLOCK_SIZE - 1
+    }
 }
 
-impl Buffer {
+impl<const BLOCK_SIZE: usize> Buffer<BLOCK_SIZE> {
     /// Create a new buffer for the specified block.
-    fn new(block_base: u64) -> Result<Buffer, StreamError> {
+    fn new(block_base: u64) -> Result<Self, StreamError>{
         Ok(Buffer {
             block_base,
             // Calling System.alloc safely requires the layout to be known to
             // have non-zero size. If the allocation fails we return an error.
             // Otherwise, our Drop impl guarantees the allocation is freed.
             ptr: unsafe {
-                let ptr = System.alloc(BLOCK_LAYOUT);
+                let ptr = System.alloc(Self::block_layout());
                 if ptr.is_null() {
                     return Err(StreamError::Alloc());
                 }
@@ -326,28 +335,46 @@ impl Buffer {
             }
         })
     }
+
+    /// Layout for allocating block-sized, block-aligned chunks of memory.
+    const fn block_layout() -> Layout {
+        match Layout::from_size_align(BLOCK_SIZE, BLOCK_SIZE) {
+            Ok(layout) => layout,
+            Err(_) => panic!("{}",
+                if BLOCK_SIZE == 0 {
+                    "Stream block size must not be zero"
+                } else if !BLOCK_SIZE.is_power_of_two() {
+                    "Stream block size must be a power of two"
+                } else if BLOCK_SIZE > (isize::MAX as usize) {
+                    "Stream block size must be within isize::MAX"
+                } else {
+                    "Unexpected layout error"
+                }
+            )
+        }
+    }
 }
 
 // Dropping a Buffer must free the allocated block.
-impl Drop for Buffer {
+impl<const S: usize> Drop for Buffer<S> {
     fn drop(&mut self) {
         unsafe {
             // This pointer was created in Buffer::new() and is known to point
             // to an allocation made by this allocator with the same layout.
-            System.dealloc(self.ptr, BLOCK_LAYOUT)
+            System.dealloc(self.ptr, Self::block_layout())
         }
     }
 }
 
 // Tell the compiler that it's safe to send and share our types between
 // threads despite the *mut u8 fields, due to the way we manage the data.
-unsafe impl Send for StreamWriter {}
-unsafe impl Sync for StreamWriter {}
-unsafe impl Send for Buffer {}
-unsafe impl Sync for Buffer {}
+unsafe impl<const S: usize> Send for StreamWriter<S> {}
+unsafe impl<const S: usize> Sync for StreamWriter<S> {}
+unsafe impl<const S: usize> Send for Buffer<S> {}
+unsafe impl<const S: usize> Sync for Buffer<S> {}
 
 // Data can be dereferenced by readers to access the stream data.
-impl Deref for Data {
+impl<const S: usize> Deref for Data<S> {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
@@ -366,8 +393,8 @@ impl Deref for Data {
 }
 
 // StreamReader can be cloned to set up multiple readers.
-impl Clone for StreamReader {
-    fn clone(&self) -> StreamReader {
+impl<const S: usize> Clone for StreamReader<S> {
+    fn clone(&self) -> StreamReader<S> {
         StreamReader {
             shared: self.shared.clone(),
             mappings: LruBTreeMap::new(MAP_CACHE_PER_READER),
@@ -386,8 +413,10 @@ mod tests {
 
     #[test]
     fn test_stream() {
+        const BLOCK_SIZE: usize = 0x4000;
+
         // Create a reader-writer pair.
-        let (mut writer, reader) = stream().unwrap();
+        let (mut writer, reader) = stream::<BLOCK_SIZE>().unwrap();
 
         // Build a reference array with ~8MB of random data.
         let mut prng = XorShiftRng::seed_from_u64(42);


### PR DESCRIPTION
This PR adds a new lock-free implementation of the basic underlying data structure required by Packetry: an append-only data stream, backed by a file, for which we require fast random access to any part of the data whilst it continues to grow.

Packetry's current implementation, in the `FileVec` and `HybridIndex` types, uses file I/O which adds significant overhead. Both reading and writing require exclusive access to a stream object, which is currently managed by a single `Mutex` protecting the whole `Capture` database. This creates contention between the decoder and UI threads.

The new implementation creates two objects for each stream: a unique `StreamWriter`, and a clonable `StreamReader`. The writer and any number of readers may operate concurrently without blocking each other.

- `StreamReader` creates memory-mapped regions on demand to access the file in blocks of a configurable size, which must be a multiple of the system page size. Each reader maintains a fixed-size cache of mappings for its most recently used blocks, using the [LruBTreeMap](https://docs.rs/lrumap/0.1.0/lrumap/struct.LruBTreeMap.html) type.

- `StreamWriter` operates much like a conventional buffered writer, but uses interchangeable write buffers whose lifetimes are managed by `Arc`. To read stream data not yet written to the file, readers clone the `Arc` of the current write buffer, which they can then retain access to after the writer moves on to using another buffer.

Atomically switching from one write buffer to another is achieved using the [ArcSwap](https://docs.rs/arc-swap/latest/arc_swap/) type.