### PR TITLE
CI: Add pkg-config to brew dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu-')
 
       - name: Install dependencies (macOS)
-        run: brew install gtk4
+        run: brew install gtk4 pkg-config
         if: matrix.os == 'macos-latest'
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
We were not explicitly installing pkg-config before, but getting it accidentally, and now we don't.

Add it to the brew dependencies to fix the build.