### PR TITLE
Summary fixes

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1118,6 +1118,10 @@ impl ItemSource<TrafficItem> for Capture {
                                 "Incomplete control transfer on device {addr}")
                         }
                     },
+                    (Normal(Control), false) => {
+                        let addr = endpoint.device_address();
+                        format!("End of control transfer on device {addr}")
+                    },
                     (endpoint_type, starting) => {
                         let ep_transfer_id = entry.transfer_id();
                         let ep_traf = self.endpoint_traffic(endpoint_id)?;

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -743,7 +743,7 @@ impl ControlTransfer {
         };
         let size = self.data.len();
         let mut parts = vec![format!(
-            "{} for {}",
+            "{} {}",
             match request_type {
                 RequestType::Standard => std_req.description(&self.fields),
                 _ => format!(
@@ -758,16 +758,16 @@ impl ControlTransfer {
             },
             match self.fields.type_fields.recipient() {
                 Recipient::Device => format!(
-                    "device {}", self.address),
+                    "for device {}", self.address),
                 Recipient::Interface => format!(
-                    "interface {}.{}", self.address, self.fields.index as u8),
+                    "for interface {}.{}",
+                    self.address, self.fields.index as u8),
                 Recipient::Endpoint => {
                     let ep_addr = EndpointAddr(self.fields.index as u8);
-                    format!("endpoint {}.{} {}",
+                    format!("for endpoint {}.{} {}",
                             self.address, ep_addr.number(), ep_addr.direction())
                 }
-                _ => format!(
-                    "device {}, index {}", self.address, self.fields.index)
+                _ => format!("on device {}", self.address)
             }
         )];
         match (self.fields.length, size) {

--- a/tests/split-enum/reference.txt
+++ b/tests/split-enum/reference.txt
@@ -1790,7 +1790,7 @@ Polling 8 times for unidentified transfer on endpoint 12.1 IN
  IN transaction on 12.1, NAK
   IN packet on 12.1, CRC 1D
   NAK packet
-End of control transfer on endpoint 0.0 OUT
+End of control transfer on device 0
 Class request #3, index 2, value 4 for device 12, index 2
  SETUP transaction on 12.0 with 8 data bytes, ACK: [23, 03, 04, 00, 02, 00, 00, 00]
   SETUP packet on 12.0, CRC 0B

--- a/tests/split-enum/reference.txt
+++ b/tests/split-enum/reference.txt
@@ -1791,7 +1791,7 @@ Polling 8 times for unidentified transfer on endpoint 12.1 IN
   IN packet on 12.1, CRC 1D
   NAK packet
 End of control transfer on device 0
-Class request #3, index 2, value 4 for device 12, index 2
+Class request #3, index 2, value 4 on device 12
  SETUP transaction on 12.0 with 8 data bytes, ACK: [23, 03, 04, 00, 02, 00, 00, 00]
   SETUP packet on 12.0, CRC 0B
   DATA0 packet with CRC C5CE and 8 data bytes: [23, 03, 04, 00, 02, 00, 00, 00]
@@ -1805,7 +1805,7 @@ Unidentified transfer of 1 byte on endpoint 12.1 IN: [04]
   IN packet on 12.1, CRC 1D
   DATA1 packet with CRC 7C41 and 1 data bytes: [04]
   ACK packet
-Class request #0, index 2, value 0 for device 12, index 2, reading 4 bytes
+Class request #0, index 2, value 0 on device 12, reading 4 bytes
  SETUP transaction on 12.0 with 8 data bytes, ACK: [A3, 00, 00, 00, 02, 00, 04, 00]
   SETUP packet on 12.0, CRC 0B
   DATA0 packet with CRC E1F6 and 8 data bytes: [A3, 00, 00, 00, 02, 00, 04, 00]
@@ -1818,7 +1818,7 @@ Class request #0, index 2, value 0 for device 12, index 2, reading 4 bytes
   OUT packet on 12.0, CRC 0B
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Class request #1, index 2, value 20 for device 12, index 2
+Class request #1, index 2, value 20 on device 12
  SETUP transaction on 12.0 with 8 data bytes, ACK: [23, 01, 14, 00, 02, 00, 00, 00]
   SETUP packet on 12.0, CRC 0B
   DATA0 packet with CRC 95EF and 8 data bytes: [23, 01, 14, 00, 02, 00, 00, 00]
@@ -1827,7 +1827,7 @@ Class request #1, index 2, value 20 for device 12, index 2
   IN packet on 12.0, CRC 0B
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Class request #0, index 2, value 0 for device 12, index 2, reading 4 bytes
+Class request #0, index 2, value 0 on device 12, reading 4 bytes
  SETUP transaction on 12.0 with 8 data bytes, ACK: [A3, 00, 00, 00, 02, 00, 04, 00]
   SETUP packet on 12.0, CRC 0B
   DATA0 packet with CRC E1F6 and 8 data bytes: [A3, 00, 00, 00, 02, 00, 04, 00]


### PR DESCRIPTION
Tweak some item summaries:

- End items for control transfers included an unnecessary/inaccurate endpoint name in the summary e.g. `3.0 OUT`. Instead only specify the device address in the summary.

- Control transfers where the recipient is not a device, interface or endpoint, were identified as `for device X, index Y`, which is inaccurate and caused the index to be shown twice. Where the recipient field is `3` i.e. `Other`, just identify the request as being `on device X`.