### PR TITLE
Extend transfer data indexing to control transfers

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -342,6 +342,7 @@ impl EndpointData {
                                         effect = PendingData(data);
                                     } else {
                                         self.payload.extend(data);
+                                        effect = IndexData(length, id);
                                     }
                                 }
                                 // Await status stage.

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -29,7 +29,7 @@ struct EndpointData {
     last_success: bool,
     setup: Option<SetupFields>,
     payload: Vec<u8>,
-    pending_payload: Option<Vec<u8>>,
+    pending_payload: Option<(Vec<u8>, EndpointTransactionId)>,
     total_data: u64,
 }
 
@@ -258,13 +258,19 @@ impl TransactionState {
     }
 }
 
+enum TransactionSideEffect {
+    NoEffect,
+    PendingData(Vec<u8>),
+    IndexData(usize, Option<EndpointTransactionId>)
+}
+
 impl EndpointData {
     fn transfer_status(&mut self,
                        dev_data: &DeviceData,
                        transaction: &mut TransactionState,
                        success: bool,
                        complete: bool)
-        -> Result<TransferStatus, CaptureError>
+        -> Result<(TransferStatus, TransactionSideEffect), CaptureError>
     {
         use TransactionStyle::*;
         let (ep_type, ep_max) = dev_data.endpoint_details(self.address);
@@ -274,8 +280,14 @@ impl EndpointData {
         };
         let next = transaction.start_pid()?;
         let pending_payload = self.pending_payload.take();
-        let payload = transaction.payload.take().or(pending_payload);
-        let length = payload.as_ref().map_or(0, |vec| vec.len()) as u64;
+        let (payload, id) = match transaction.payload.take() {
+            Some(payload) => (Some(payload), None),
+            None => match pending_payload {
+                Some((payload, id)) => (Some(payload), Some(id)),
+                None => (None, None)
+            }
+        };
+        let length = payload.as_ref().map_or(0, |vec| vec.len());
         let short = match (&payload, ep_max) {
             (Some(payload), Some(max)) => payload.len() < max,
             (..) => false,
@@ -286,7 +298,9 @@ impl EndpointData {
         use Direction::*;
         use TransferStatus::*;
         use StartComplete::*;
-        Ok(match (ep_type, &self.active, next) {
+        use TransactionSideEffect::*;
+        let mut effect = NoEffect;
+        let status = match (ep_type, &self.active, next) {
 
             // A SETUP transaction starts a new control transfer.
             // Store the setup fields to interpret the request.
@@ -321,10 +335,14 @@ impl EndpointData {
                         (In,  true, IN,    IN ) |
                         (Out, true, OUT,   OUT) => {
                             if success {
-                                if (split_sc, next) == (Some(Complete), OUT) {
-                                    self.pending_payload = payload;
-                                } else if let Some(data) = payload {
-                                    self.payload.extend(data);
+                                if let Some(data) = payload {
+                                    if (split_sc, next) ==
+                                        (Some(Start), OUT)
+                                    {
+                                        effect = PendingData(data);
+                                    } else {
+                                        self.payload.extend(data);
+                                    }
                                 }
                                 // Await status stage.
                                 Continue
@@ -370,14 +388,13 @@ impl EndpointData {
             // This can be either an actual transfer, or a polling
             // group used to collect NAKed transactions.
             (_, None, IN | OUT) => {
-                self.writer.data_index.push(self.total_data)?;
                 if success {
-                    if split_sc == Some(Complete) && next == OUT {
-                        self.pending_payload = payload;
-                    } else {
-                        self.total_data += length;
-                        self.writer.shared.total_data
-                            .store(self.total_data, Release);
+                    if let Some(data) = payload {
+                        if split_sc == Some(Start) && next == OUT {
+                            effect = PendingData(data);
+                        } else {
+                            effect = IndexData(length, id);
+                        }
                     }
                 }
                 if complete {
@@ -398,14 +415,13 @@ impl EndpointData {
             // IN or OUT may then be repeated.
             (_, Some(TransferState { first: IN,  ..}), IN) |
             (_, Some(TransferState { first: OUT, ..}), OUT) => {
-                self.writer.data_index.push(self.total_data)?;
                 if success {
-                    if split_sc == Some(Complete) && next == OUT {
-                        self.pending_payload = payload;
-                    } else if complete {
-                        self.total_data += length;
-                        self.writer.shared.total_data
-                            .store(self.total_data, Release);
+                    if let Some(data) = payload {
+                        if split_sc == Some(Start) && next == OUT {
+                            effect = PendingData(data);
+                        } else if complete {
+                            effect = IndexData(length, id);
+                        }
                     }
                 }
                 if complete {
@@ -450,7 +466,36 @@ impl EndpointData {
 
             // Any other case is not a valid part of a transfer.
             _ => Invalid
-        })
+        };
+        Ok((status, effect))
+    }
+
+    fn apply_effect(&mut self,
+                    transaction: &TransactionState,
+                    effect: TransactionSideEffect)
+        -> Result<(), CaptureError>
+    {
+        use TransactionSideEffect::*;
+        match effect {
+            NoEffect => {},
+            PendingData(data) => {
+                let ep_transaction_id = transaction.ep_transaction_id
+                    .ok_or_else(|| IndexError(String::from(
+                        "Pending data but no endpoint transaction ID set")))?;
+                self.pending_payload = Some((data, ep_transaction_id));
+            },
+            IndexData(length, ep_transaction_id) => {
+                let ep_transaction_id = ep_transaction_id
+                    .or(transaction.ep_transaction_id)
+                    .ok_or_else(|| IndexError(String::from(
+                        "Data to index but no endpoint transaction ID set")))?;
+                self.writer.data_transactions.push(ep_transaction_id)?;
+                self.writer.data_byte_counts.push(self.total_data)?;
+                self.total_data += length as u64;
+                self.writer.shared.total_data.store(self.total_data, Release);
+            }
+        };
+        Ok(())
     }
 }
 
@@ -828,9 +873,9 @@ impl Decoder {
         let endpoint_id = transaction.endpoint_id()?;
         let ep_data = &mut self.endpoint_data[endpoint_id];
         let dev_data = self.capture.device_data(ep_data.device_id)?;
-        match ep_data.transfer_status(
-            dev_data.as_ref(), transaction, success, complete)?
-        {
+        let (status, effect) = ep_data.transfer_status(
+            dev_data.as_ref(), transaction, success, complete)?;
+        match status {
             Single => {
                 self.transfer_start(transaction, true)?;
                 self.transfer_end(transaction)?;
@@ -853,6 +898,7 @@ impl Decoder {
                 self.transfer_end(transaction)?;
             }
         }
+        self.endpoint_data[endpoint_id].apply_effect(transaction, effect)?;
         Ok(())
     }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::mem::size_of;
-use std::ops::{Add, AddAssign, Sub};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::ops::Range;
 
 #[derive(Copy, Clone)]
@@ -81,6 +81,12 @@ impl<T> Sub<u64> for Id<T> {
 
    fn sub(self, other: u64) -> Self {
       Id::<T>::from(self.value - other)
+   }
+}
+
+impl<T> SubAssign<u64> for Id<T> {
+   fn sub_assign(&mut self, other: u64) {
+      self.value -= other
    }
 }
 

--- a/src/index_stream.rs
+++ b/src/index_stream.rs
@@ -96,6 +96,30 @@ where Position: Copy + From<u64> + Into<u64>,
         Ok(values)
     }
 
+    /// Get the range of values between the specified position and the next.
+    ///
+    /// The length of the data referenced by this index must be passed
+    /// as a parameter. If the specified position is the last in the
+    /// index, the range will be from the last value in the index to the
+    /// end of the referenced data.
+    pub fn target_range(&mut self, position: Position, target_length: u64)
+        -> Result<Range<Value>, StreamError>
+    {
+        let stop = position.into() + 2;
+        let range = if stop > self.len() {
+            let start = self.get(position)?;
+            let end = Value::from(target_length);
+            start..end
+        } else {
+            let range = position..Position::from(stop);
+            let vec = self.get_range(&range)?;
+            let start = vec[0];
+            let end = vec[1];
+            start..end
+        };
+        Ok(range)
+    }
+
     /// Leftmost position where a value would be ordered within this index.
     pub fn bisect_left(&mut self, value: &Value)
         -> Result<Position, StreamError>


### PR DESCRIPTION
This PR fixes delays in the UI when summarizing control transfers with large numbers of transactions (e.g. many NAKs). These delays occurred because the `CaptureReader::control_transfer` method had to iterate over all transactions in the transfer to retrieve the payload data.

For data transfers, we already had a per-endpoint `data_index` mapping endpoint transaction IDs to byte counts, allowing payload data to be located efficiently. However this scheme depends on the fact that we include only the successful transactions in a data transfer, assigning transactions that result in a NAK into a polling group instead. For control transfers we group NAKed transactions with the transfer, so the same indexing scheme cannot be applied.

This PR replaces the existing `data_index` with two indexes, `data_transactions` and `data_byte_counts`, which advance in lockstep each time there is a transaction with payload data. A given position within these two indexes defines an `EndpointDataEvent`. To retrieve data for a given transfer:

- The `data_transactions` index is bisected twice, to find the `EndpointDataEvent` range that corresponds to the starting and ending endpoint transaction IDs of the transfer.
- Total endpoint byte counts at the start and end of the transfer can be fetched from `data_byte_counts`; this gives the length of data in the transfer.
- Data is fetched by iterating over the identified range of endpoint transaction IDs in `data_transactions`, which include only those transactions with payload data.

This scheme is then extended to control transfers, specifically for the data stage of requests. The setup data can always be found in the first transaction of a control transfer. So far, we have not found a need for efficient retrieval of data from the status stage of a request.