### PR TITLE
Add support for devices to report available analysis speeds

### DIFF
--- a/src/backend/luna.rs
+++ b/src/backend/luna.rs
@@ -75,8 +75,7 @@ pub struct LunaStop {
 }
 
 impl LunaDevice {
-    pub fn scan() -> Result<Vec<Device<Context>>, Error> {
-        let context = Context::new()?;
+    pub fn scan(context: &mut Context) -> Result<Vec<Device<Context>>, Error> {
         let devices = context.devices()?;
         let mut result = Vec::with_capacity(devices.len());
         for device in devices.iter() {

--- a/src/backend/luna.rs
+++ b/src/backend/luna.rs
@@ -29,12 +29,14 @@ pub enum Speed {
     High = 0,
     Full = 1,
     Low  = 2,
+    Auto = 3,
 }
 
 impl Speed {
     pub fn description(&self) -> &'static str {
         use Speed::*;
         match self {
+            Auto => "Auto",
             High => "High (480Mbps)",
             Full => "Full (12Mbps)",
             Low => "Low (1.5Mbps)",

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -149,12 +149,24 @@ pub fn activate(application: &Application) -> Result<(), PacketryError> {
         .title("Packetry")
         .build();
 
-    let header_bar = gtk::HeaderBar::new();
+    let action_bar = gtk::ActionBar::new();
 
-    let open_button = gtk::Button::from_icon_name("document-open");
-    let save_button = gtk::Button::from_icon_name("document-save");
-    let capture_button = gtk::Button::from_icon_name("media-record");
-    let stop_button = gtk::Button::from_icon_name("media-playback-stop");
+    let open_button = gtk::Button::builder()
+        .icon_name("document-open")
+        .tooltip_text("Open")
+        .build();
+    let save_button = gtk::Button::builder()
+        .icon_name("document-save")
+        .tooltip_text("Save")
+        .build();
+    let capture_button = gtk::Button::builder()
+        .icon_name("media-record")
+        .tooltip_text("Capture")
+        .build();
+    let stop_button = gtk::Button::builder()
+        .icon_name("media-playback-stop")
+        .tooltip_text("Stop")
+        .build();
     let speed_dropdown = gtk::DropDown::from_strings(&[
         "High (480Mbps)",
         "Full (12Mbps)",
@@ -165,13 +177,14 @@ pub fn activate(application: &Application) -> Result<(), PacketryError> {
     save_button.set_sensitive(false);
     capture_button.set_sensitive(true);
 
-    header_bar.pack_start(&open_button);
-    header_bar.pack_start(&save_button);
-    header_bar.pack_start(&capture_button);
-    header_bar.pack_start(&stop_button);
-    header_bar.pack_start(&speed_dropdown);
+    action_bar.pack_start(&open_button);
+    action_bar.pack_start(&save_button);
+    action_bar.pack_start(&gtk::Separator::new(Orientation::Vertical));
+    action_bar.pack_start(&gtk::Label::new(Some("Speed:")));
+    action_bar.pack_start(&speed_dropdown);
+    action_bar.pack_start(&capture_button);
+    action_bar.pack_start(&stop_button);
 
-    window.set_titlebar(Some(&header_bar));
     #[cfg(not(feature="test-ui-replay"))]
     window.show();
     WINDOW.with(|win_opt| win_opt.replace(Some(window.clone())));
@@ -199,8 +212,6 @@ pub fn activate(application: &Application) -> Result<(), PacketryError> {
         .vexpand(true)
         .build();
 
-    let separator = gtk::Separator::new(Orientation::Horizontal);
-
     let progress_bar = gtk::ProgressBar::builder()
         .show_text(true)
         .text("")
@@ -211,8 +222,10 @@ pub fn activate(application: &Application) -> Result<(), PacketryError> {
         .orientation(Orientation::Vertical)
         .build();
 
+    vbox.append(&action_bar);
+    vbox.append(&gtk::Separator::new(Orientation::Horizontal));
     vbox.append(&paned);
-    vbox.append(&separator);
+    vbox.append(&gtk::Separator::new(Orientation::Horizontal));
 
     window.set_child(Some(&vbox));
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -175,12 +175,7 @@ impl DeviceSelector {
         self.dev_strings = Vec::with_capacity(self.devices.len());
         self.dev_speeds = Vec::with_capacity(self.devices.len());
         for device in self.devices.iter() {
-            let desc = device.usb_device.device_descriptor()?;
-            let handle = device.usb_device.open()?;
-            let manufacturer = handle.read_manufacturer_string_ascii(&desc)?;
-            let product = handle.read_product_string_ascii(&desc)?;
-            self.dev_strings.push(
-                format!("{} {}", manufacturer, product));
+            self.dev_strings.push(device.description.clone());
             self.dev_speeds.push(vec![
                 "High (480Mbps)",
                 "Full (12Mbps)",

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -117,7 +117,7 @@ pub enum PacketryError {
 }
 
 struct DeviceSelector {
-    usb_context: Context,
+    usb_context: Option<Context>,
     devices: Vec<Device<Context>>,
     dev_strings: Vec<String>,
     dev_speeds: Vec<Vec<&'static str>>,
@@ -129,7 +129,7 @@ struct DeviceSelector {
 impl DeviceSelector {
     fn new() -> Result<Self, PacketryError> {
         let mut selector = DeviceSelector {
-            usb_context: Context::new()?,
+            usb_context: Context::new().ok(),
             devices: vec![],
             dev_strings: vec![],
             dev_speeds: vec![],
@@ -167,7 +167,11 @@ impl DeviceSelector {
     }
 
     fn scan(&mut self) -> Result<bool, PacketryError> {
-        self.devices = LunaDevice::scan(&mut self.usb_context)?;
+        self.devices = if let Some(context) = self.usb_context.as_mut() {
+            LunaDevice::scan(context)?
+        } else {
+            vec![]
+        };
         self.dev_strings = Vec::with_capacity(self.devices.len());
         self.dev_speeds = Vec::with_capacity(self.devices.len());
         for device in self.devices.iter() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -176,11 +176,9 @@ impl DeviceSelector {
         self.dev_speeds = Vec::with_capacity(self.devices.len());
         for device in self.devices.iter() {
             self.dev_strings.push(device.description.clone());
-            self.dev_speeds.push(vec![
-                "High (480Mbps)",
-                "Full (12Mbps)",
-                "Low (1.5Mbps)"
-            ]);
+            self.dev_speeds.push(
+                device.speeds.iter().map(|x| x.description()).collect()
+            )
         }
         let no_speeds = vec![];
         let speed_strings = self.dev_speeds.get(0).unwrap_or(&no_speeds);
@@ -194,8 +192,8 @@ impl DeviceSelector {
     fn open(&self) -> Result<(LunaHandle, Speed), PacketryError> {
         let device_id = self.dev_dropdown.selected();
         let device = &self.devices[device_id as usize];
-        let speed_id = self.speed_dropdown.selected() as u8;
-        let speed = Speed::from(speed_id);
+        let speed_id = self.speed_dropdown.selected() as usize;
+        let speed = device.speeds[speed_id];
         let luna = device.open()?;
         Ok((luna, speed))
     }


### PR DESCRIPTION
Based on #73 

This starts off with some refactoring to return a struct with device information from the backend `scan` function, moves querying the device name/description to the backend and returns it in the new struct, adds available speeds to the struct, adds an 'Auto' option, and finally supports the new vendor request to query the available speeds (to be added in https://github.com/greatscottgadgets/luna/pull/202).