### PR TITLE
Support multiple instances of the application

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use gtk::prelude::*;
+use gtk::gio::ApplicationFlags;
 
 use packetry::ui::{
     activate,
@@ -9,7 +10,7 @@ use packetry::ui::{
 fn main() {
     let application = gtk::Application::new(
         Some("com.greatscottgadgets.packetry"),
-        Default::default(),
+        ApplicationFlags::NON_UNIQUE
     );
     application.connect_activate(|app| display_error(activate(app)));
     application.run_with_args::<&str>(&[]);


### PR DESCRIPTION
This change stops GApplication from trying to have only a single shared instance of Packetry running at a time.