### PR TITLE
Use the `anyhow` crate for error handling

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# Build PDF for docs
+formats:
+  - pdf
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,28 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arc-swap"
@@ -28,6 +46,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bisection"
@@ -307,6 +340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "gio"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1251ce8e8f9909600e127dcbe74ac50d8464e6685cf5953d37df7a741dbf9e9d"
 
 [[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
 name = "memmap2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -622,6 +676,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -857,6 +920,12 @@ dependencies = [
  "libc",
  "libusb1-sys",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "arc-swap"
@@ -634,6 +634,7 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 name = "packetry"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arc-swap",
  "bisection",
  "bitfield",
@@ -657,7 +658,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ arc-swap = "1.6.0"
 lrumap = "0.1.0"
 memmap2 = "0.5.8"
 page_size = "0.5.0"
-anyhow = "1.0.79"
+anyhow = { version = "1.0.79", features = ["backtrace"] }
 
 [dev-dependencies]
 serde = { version = "1.0.136", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ num_enum = "0.5.6"
 once_cell = "1.5"
 pcap-file = "2.0.0"
 tempfile = "3.3.0"
-thiserror = "1.0.30"
 bitfield = "0.13.2"
 num-format = "0.4.0"
 humansize = "1.1.1"
@@ -29,6 +28,7 @@ arc-swap = "1.6.0"
 lrumap = "0.1.0"
 memmap2 = "0.5.8"
 page_size = "0.5.0"
+anyhow = "1.0.79"
 
 [dev-dependencies]
 serde = { version = "1.0.136", features = ["derive"] }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -11,8 +11,10 @@ use {
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 
+use anyhow::Error;
+
 use crate::capture::{CaptureReader, TrafficItem, DeviceItem};
-use crate::tree_list_model::{TreeListModel, ItemNodeRc, ModelError};
+use crate::tree_list_model::{TreeListModel, ItemNodeRc};
 
 // Public part of the Model type.
 glib::wrapper! {
@@ -26,13 +28,13 @@ pub trait GenericModel<Item> where Self: Sized {
     fn new(capture: CaptureReader,
            #[cfg(any(feature="test-ui-replay", feature="record-ui-test"))]
            on_item_update: Rc<RefCell<dyn FnMut(u32, String)>>)
-        -> Result<Self, ModelError>;
+        -> Result<Self, Error>;
     fn set_expanded(&self,
                     node: &ItemNodeRc<Item>,
                     position: u32,
                     expanded: bool)
-        -> Result<(), ModelError>;
-    fn update(&self) -> Result<bool, ModelError>;
+        -> Result<(), Error>;
+    fn update(&self) -> Result<bool, Error>;
     fn summary(&self, item: &Item) -> String;
     fn connectors(&self, item: &Item) -> String;
 }
@@ -41,7 +43,7 @@ impl GenericModel<TrafficItem> for TrafficModel {
     fn new(capture: CaptureReader,
            #[cfg(any(feature="test-ui-replay", feature="record-ui-test"))]
            on_item_update: Rc<RefCell<dyn FnMut(u32, String)>>)
-        -> Result<Self, ModelError>
+        -> Result<Self, Error>
     {
         let model: TrafficModel =
             glib::Object::new(&[]).expect("Failed to create TrafficModel");
@@ -57,14 +59,14 @@ impl GenericModel<TrafficItem> for TrafficModel {
                     node: &ItemNodeRc<TrafficItem>,
                     position: u32,
                     expanded: bool)
-        -> Result<(), ModelError>
+        -> Result<(), Error>
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
         tree.set_expanded(self, node, position as u64, expanded)
     }
 
-    fn update(&self) -> Result<bool, ModelError> {
+    fn update(&self) -> Result<bool, Error> {
         let tree_opt = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
         tree.update(self)
@@ -87,7 +89,7 @@ impl GenericModel<DeviceItem> for DeviceModel {
     fn new(capture: CaptureReader,
            #[cfg(any(feature="test-ui-replay", feature="record-ui-test"))]
            on_item_update: Rc<RefCell<dyn FnMut(u32, String)>>)
-        -> Result<Self, ModelError>
+        -> Result<Self, Error>
     {
         let model: DeviceModel =
             glib::Object::new(&[]).expect("Failed to create DeviceModel");
@@ -103,14 +105,14 @@ impl GenericModel<DeviceItem> for DeviceModel {
                     node: &ItemNodeRc<DeviceItem>,
                     position: u32,
                     expanded: bool)
-        -> Result<(), ModelError>
+        -> Result<(), Error>
     {
         let tree_opt  = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
         tree.set_expanded(self, node, position as u64, expanded)
     }
 
-    fn update(&self) -> Result<bool, ModelError> {
+    fn update(&self) -> Result<bool, Error> {
         let tree_opt = self.imp().tree.borrow();
         let tree = tree_opt.as_ref().unwrap();
         tree.update(self)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -838,7 +838,8 @@ pub fn stop_luna() -> Result<(), Error> {
 pub fn display_error(result: Result<(), Error>) {
     #[cfg(not(feature="test-ui-replay"))]
     if let Err(e) = result {
-        let message = format!("{e}");
+        let backtrace = e.backtrace();
+        let message = format!("{e}\n\nBacktrace:\n\n{backtrace}");
         gtk::glib::idle_add_once(move || {
             WINDOW.with(|win_opt| {
                 match win_opt.borrow().as_ref() {


### PR DESCRIPTION
Use the [anyhow](https://docs.rs/anyhow/latest/anyhow/index.html) crate for error handling.

This crate provides:

- The `anyhow::Error` type, which wraps any other error type, and can thus replace the whole error type hierarchy we have currently including `PacketryError`, `CaptureError`, `StreamError`, `ModelError` etc.

- A `bail!` macro which can simplify sites where we just want to return an error with some text.

- A `Context` trait, implemented for `Option` and `Result`, which allows easily attaching context information when turning an existing `None` or `Err` value into an `anyhow::Error`. This neatly replaces some existing patterns and our `OnBug` trait.

As well as simplifying the code, this change enables us to display a backtrace for any error - this is implemented in the second commit. Backtraces are only captured if `RUST_BACKTRACE` or `RUST_LIB_BACKTRACE` are set.