### PR TITLE
More error handling improvements

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -838,8 +838,15 @@ pub fn stop_luna() -> Result<(), Error> {
 pub fn display_error(result: Result<(), Error>) {
     #[cfg(not(feature="test-ui-replay"))]
     if let Err(e) = result {
-        let backtrace = e.backtrace();
-        let message = format!("{e}\n\nBacktrace:\n\n{backtrace}");
+        use std::fmt::Write;
+        let mut message = format!("{e}");
+        for cause in e.chain().skip(1) {
+            write!(message, "\ncaused by: {cause} ({cause:?})").unwrap();
+        }
+        let backtrace = format!("{}", e.backtrace());
+        if backtrace != "disabled backtrace" {
+            write!(message, "\n\nBacktrace:\n{backtrace}").unwrap();
+        }
         gtk::glib::idle_add_once(move || {
             WINDOW.with(|win_opt| {
                 match win_opt.borrow().as_ref() {


### PR DESCRIPTION
A fix and some improvements following up on #82:
- Correctly handle the result of joining a capture worker thread, and displaying the message for a panic.
- Show the chain of causes behind an error.
- Don't attempt to show backtraces when not enabled.