### PR TITLE
Update for Cynthion analyzer USB API changes

### DIFF
--- a/src/backend/cynthion.rs
+++ b/src/backend/cynthion.rs
@@ -82,8 +82,7 @@ impl State {
 
 /// A Cynthion device attached to the system.
 pub struct CynthionDevice {
-    device_info: DeviceInfo,
-    pub description: String,
+    pub device_info: DeviceInfo,
     pub speeds: Vec<Speed>,
 }
 
@@ -113,18 +112,10 @@ impl CynthionDevice {
                 if !(MIN_SUPPORTED..=NOT_SUPPORTED).contains(&version) {
                     continue;
                 }
-                let manufacturer = device_info
-                    .manufacturer_string()
-                    .unwrap_or("Unknown");
-                let product = device_info
-                    .product_string()
-                    .unwrap_or("Device");
-                let description = format!("{} {}", manufacturer, product);
                 let handle = CynthionHandle::new(&device_info)?;
                 let speeds = handle.speeds()?;
                 result.push(CynthionDevice{
                     device_info,
-                    description,
                     speeds,
                 })
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -146,7 +146,7 @@ impl DeviceSelector {
         for device in self.devices.iter() {
             self.dev_strings.push(device.description.clone());
             self.dev_speeds.push(
-                device.speeds.iter().map(|x| x.description()).collect()
+                device.speeds.iter().map(Speed::description).collect()
             )
         }
         let no_speeds = vec![];

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -139,7 +139,7 @@ impl DeviceSelector {
         self.speed_dropdown.set_sensitive(sensitive);
     }
 
-    fn scan(&mut self) -> Result<bool, Error> {
+    fn scan(&mut self) -> Result<(), Error> {
         self.devices = CynthionDevice::scan()?;
         self.dev_strings = Vec::with_capacity(self.devices.len());
         self.dev_speeds = Vec::with_capacity(self.devices.len());
@@ -153,9 +153,8 @@ impl DeviceSelector {
         let speed_strings = self.dev_speeds.first().unwrap_or(&no_speeds);
         self.replace_dropdown(&self.dev_dropdown, &self.dev_strings);
         self.replace_dropdown(&self.speed_dropdown, speed_strings);
-        let available = self.device_available();
-        self.set_sensitive(available);
-        Ok(available)
+        self.set_sensitive(self.device_available());
+        Ok(())
     }
 
     fn open(&self) -> Result<(CynthionHandle, Speed), Error> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -146,10 +146,24 @@ impl DeviceSelector {
             self.dev_dropdown.disconnect(handler);
         }
         self.devices = CynthionDevice::scan()?;
-        self.dev_strings = Vec::with_capacity(self.devices.len());
-        self.dev_speeds = Vec::with_capacity(self.devices.len());
+        let count = self.devices.len();
+        self.dev_strings = Vec::with_capacity(count);
+        self.dev_speeds = Vec::with_capacity(count);
         for device in self.devices.iter() {
-            self.dev_strings.push(device.description.clone());
+            self.dev_strings.push(
+                if count <= 1 {
+                    String::from("Cynthion")
+                } else {
+                    let info = &device.device_info;
+                    if let Some(serial) = info.serial_number() {
+                        format!("Cynthion #{}", serial)
+                    } else {
+                        format!("Cynthion (bus {}, device {})",
+                            info.bus_number(),
+                            info.device_address())
+                    }
+                }
+            );
             self.dev_speeds.push(
                 device.speeds.iter().map(Speed::description).collect()
             )

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -47,7 +47,13 @@ use pcap_file::{
     pcap::{PcapReader, PcapWriter, PcapHeader, RawPcapPacket},
 };
 
-use crate::backend::cynthion::{CynthionDevice, CynthionHandle, CynthionStop, Speed};
+use crate::backend::cynthion::{
+    CynthionDevice,
+    CynthionHandle,
+    CynthionStop,
+    CynthionUsability::*,
+    Speed};
+
 use crate::capture::{
     create_capture,
     CaptureReader,
@@ -132,13 +138,32 @@ impl DeviceSelector {
         Ok(selector)
     }
 
+    fn current_device(&self) -> Option<&CynthionDevice> {
+        if self.devices.is_empty() {
+            None
+        } else {
+            Some(&self.devices[self.dev_dropdown.selected() as usize])
+        }
+    }
+
     fn device_available(&self) -> bool {
-        !self.devices.is_empty()
+        match self.current_device() {
+            None => false,
+            Some(device) => match device.usability {
+                Usable(..) => true,
+                Unusable(..) => false,
+            }
+        }
     }
 
     fn set_sensitive(&mut self, sensitive: bool) {
-        self.dev_dropdown.set_sensitive(sensitive);
-        self.speed_dropdown.set_sensitive(sensitive);
+        if sensitive {
+            self.dev_dropdown.set_sensitive(!self.devices.is_empty());
+            self.speed_dropdown.set_sensitive(self.device_available());
+        } else {
+            self.dev_dropdown.set_sensitive(false);
+            self.speed_dropdown.set_sensitive(false);
+        }
     }
 
     fn scan(&mut self) -> Result<(), Error> {
@@ -164,15 +189,20 @@ impl DeviceSelector {
                     }
                 }
             );
-            self.dev_speeds.push(
-                device.speeds.iter().map(Speed::description).collect()
-            )
+            if let Usable(speeds) = &device.usability {
+                self.dev_speeds.push(
+                    speeds.iter().map(Speed::description).collect()
+                )
+            } else {
+                self.dev_speeds.push(vec![]);
+            }
         }
         let no_speeds = vec![];
         let speed_strings = self.dev_speeds.first().unwrap_or(&no_speeds);
         self.replace_dropdown(&self.dev_dropdown, &self.dev_strings);
         self.replace_dropdown(&self.speed_dropdown, speed_strings);
-        self.set_sensitive(self.device_available());
+        self.dev_dropdown.set_sensitive(!self.devices.is_empty());
+        self.speed_dropdown.set_sensitive(!speed_strings.is_empty());
         self.change_handler = Some(
             self.dev_dropdown.connect_selected_notify(
                 |_| display_error(device_selection_changed())));
@@ -189,10 +219,17 @@ impl DeviceSelector {
     fn open(&self) -> Result<(CynthionHandle, Speed), Error> {
         let device_id = self.dev_dropdown.selected();
         let device = &self.devices[device_id as usize];
-        let speed_id = self.speed_dropdown.selected() as usize;
-        let speed = device.speeds[speed_id];
-        let cynthion = device.open()?;
-        Ok((cynthion, speed))
+        match &device.usability {
+            Usable(speeds) => {
+                let speed_id = self.speed_dropdown.selected() as usize;
+                let speed = speeds[speed_id];
+                let cynthion = device.open()?;
+                Ok((cynthion, speed))
+            },
+            Unusable(reason) => {
+                bail!("Device not usable: {}", reason)
+            }
+        }
     }
 
     fn replace_dropdown<T: AsRef<str>>(
@@ -775,9 +812,8 @@ fn start_pcap(action: FileAction, path: PathBuf) -> Result<(), Error> {
                         ui.open_button.set_sensitive(true);
                         ui.save_button.set_sensitive(true);
                         ui.scan_button.set_sensitive(true);
-                        let available = ui.selector.device_available();
-                        ui.selector.set_sensitive(available);
-                        ui.capture_button.set_sensitive(available);
+                        ui.selector.set_sensitive(true);
+                        ui.capture_button.set_sensitive(ui.selector.device_available());
                         Ok(())
                     })
                 );
@@ -809,6 +845,7 @@ fn detect_hardware() -> Result<(), Error> {
 
 fn device_selection_changed() -> Result<(), Error> {
     with_ui(|ui| {
+        ui.capture_button.set_sensitive(ui.selector.device_available());
         ui.selector.update_speeds();
         Ok(())
     })
@@ -844,9 +881,8 @@ pub fn start_cynthion() -> Result<(), Error> {
                         ui.stop_button.disconnect(signal_id);
                         ui.stop_button.set_sensitive(false);
                         ui.open_button.set_sensitive(true);
-                        let available = ui.selector.device_available();
-                        ui.selector.set_sensitive(available);
-                        ui.capture_button.set_sensitive(available);
+                        ui.selector.set_sensitive(true);
+                        ui.capture_button.set_sensitive(ui.selector.device_available());
                         Ok(())
                     })
                 );

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -189,7 +189,7 @@ impl DeviceSelector {
                     }
                 }
             );
-            if let Usable(speeds) = &device.usability {
+            if let Usable(_, speeds) = &device.usability {
                 self.dev_speeds.push(
                     speeds.iter().map(Speed::description).collect()
                 )
@@ -220,7 +220,7 @@ impl DeviceSelector {
         let device_id = self.dev_dropdown.selected();
         let device = &self.devices[device_id as usize];
         match &device.usability {
-            Usable(speeds) => {
+            Usable(_, speeds) => {
                 let speed_id = self.speed_dropdown.selected() as usize;
                 let speed = speeds[speed_id];
                 let cynthion = device.open()?;


### PR DESCRIPTION
Depends on https://github.com/greatscottgadgets/cynthion/pull/87.

Updates how Packetry searches for and displays available Cynthion devices.

Changes are as follows:
1. Preliminary UI code cleanups.
2. Update available speeds when device selection is changed.
3. Name devices simply as `Cynthion`, unless duplicated, in which case disambiguate with serial number or bus/address.
4. Display all Cynthion devices found, including ones that cannot be used. For unusable devices, keep track of why.
5. Adjust methods to match https://github.com/greatscottgadgets/cynthion/pull/87

One detail I'm not sure of yet is how best to display the reasons for devices not being usable, but that doesn't have to be in this PR.