### PR TITLE
Add hardware-in-the-loop test using Cynthion analyzer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,16 @@ step-decoder = []
 record-ui-test = ["serde", "serde_json"]
 test-ui-replay = ["serde", "serde_json"]
 debug-region-map = []
+test-cynthion = []
 
 [[test]]
 name = "test_replay"
 path = "src/test_replay.rs"
 harness = false
 required-features = ["test-ui-replay"]
+
+[[test]]
+name = "test_cynthion"
+path = "src/test_cynthion.rs"
+harness = false
+required-features = ["test-cynthion"]

--- a/src/backend/cynthion.rs
+++ b/src/backend/cynthion.rs
@@ -87,12 +87,21 @@ bitfield! {
     #[derive(Copy, Clone)]
     struct TestConfig(u8);
     bool, connect, set_connect: 0;
+    u8, from into Speed, speed, set_speed: 2, 1;
 }
 
 impl TestConfig {
-    fn new(connect: bool) -> TestConfig {
+    fn new(speed: Option<Speed>) -> TestConfig {
         let mut config = TestConfig(0);
-        config.set_connect(connect);
+        match speed {
+            Some(speed) => {
+                config.set_connect(true);
+                config.set_speed(speed);
+            },
+            None => {
+                config.set_connect(false);
+            }
+        };
         config
     }
 }
@@ -345,10 +354,10 @@ impl CynthionHandle {
         Ok(())
     }
 
-    pub fn configure_test_device(&mut self, connect: bool)
+    pub fn configure_test_device(&mut self, speed: Option<Speed>)
         -> Result<(), Error>
     {
-        let test_config = TestConfig::new(connect);
+        let test_config = TestConfig::new(speed);
         self.write_request(3, test_config.0)
             .context("Failed to set test device configuration")
     }

--- a/src/backend/cynthion.rs
+++ b/src/backend/cynthion.rs
@@ -83,6 +83,20 @@ impl State {
     }
 }
 
+bitfield! {
+    #[derive(Copy, Clone)]
+    struct TestConfig(u8);
+    bool, connect, set_connect: 0;
+}
+
+impl TestConfig {
+    fn new(connect: bool) -> TestConfig {
+        let mut config = TestConfig(0);
+        config.set_connect(connect);
+        config
+    }
+}
+
 pub struct InterfaceSelection {
     interface_number: u8,
     alt_setting_number: u8,
@@ -320,30 +334,38 @@ impl CynthionHandle {
     }
 
     fn start_capture(&mut self, speed: Speed) -> Result<(), Error> {
-        self.write_state(State::new(true, speed))?;
+        self.write_request(1, State::new(true, speed).0)?;
         println!("Capture enabled, speed: {}", speed.description());
         Ok(())
     }
 
     fn stop_capture(&mut self) -> Result<(), Error> {
-        self.write_state(State::new(false, Speed::High))?;
+        self.write_request(1, State::new(false, Speed::High).0)?;
         println!("Capture disabled");
         Ok(())
     }
 
-    fn write_state(&mut self, state: State) -> Result<(), Error> {
+    pub fn configure_test_device(&mut self, connect: bool)
+        -> Result<(), Error>
+    {
+        let test_config = TestConfig::new(connect);
+        self.write_request(3, test_config.0)
+            .context("Failed to set test device configuration")
+    }
+
+    fn write_request(&mut self, request: u8, value: u8) -> Result<(), Error> {
         let control = Control {
             control_type: ControlType::Vendor,
             recipient: Recipient::Interface,
-            request: 1,
-            value: u16::from(state.0),
+            request,
+            value: u16::from(value),
             index: self.interface.interface_number() as u16,
         };
         let data = &[];
         let timeout = Duration::from_secs(1);
         self.interface
             .control_out_blocking(control, data, timeout)
-            .context("Failed writing state to device")?;
+            .context("Write request failed")?;
         Ok(())
     }
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1005,7 +1005,7 @@ impl CaptureReader {
 }
 
 impl EndpointReader {
-    fn transfer_data_range(&mut self, range: &Range<EndpointTransactionId>)
+    pub fn transfer_data_range(&mut self, range: &Range<EndpointTransactionId>)
         -> Result<Range<EndpointDataEvent>, Error>
     {
         let first_data_id = self.data_transactions.bisect_left(&range.start)?;
@@ -1013,7 +1013,7 @@ impl EndpointReader {
         Ok(first_data_id..last_data_id)
     }
 
-    fn transfer_data_length(&mut self, range: &Range<EndpointDataEvent>)
+    pub fn transfer_data_length(&mut self, range: &Range<EndpointDataEvent>)
         -> Result<u64, Error>
     {
         if range.start == range.end {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -817,10 +817,10 @@ impl CaptureReader {
         self.packet_data.get_range(&data_byte_range)
     }
 
-    fn transfer_bytes(&mut self,
-                      endpoint_id: EndpointId,
-                      data_range: &Range<EndpointDataEvent>,
-                      length: usize)
+    pub fn transfer_bytes(&mut self,
+                          endpoint_id: EndpointId,
+                          data_range: &Range<EndpointDataEvent>,
+                          length: usize)
         -> Result<Vec<u8>, Error>
     {
         let mut transfer_bytes = Vec::with_capacity(length);

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -323,7 +323,7 @@ pub struct DeviceData {
 }
 
 impl DeviceData {
-    fn description(&self) -> String {
+    pub fn description(&self) -> String {
         match self.device_descriptor.load().as_ref() {
             None => "Unknown".to_string(),
             Some(descriptor) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate bitfield;
 
-mod backend;
-mod capture;
+pub mod backend;
+pub mod capture;
 mod compact_index;
 mod data_stream;
 pub mod decoder;

--- a/src/test_cynthion.rs
+++ b/src/test_cynthion.rs
@@ -1,0 +1,88 @@
+use packetry::backend::cynthion::{CynthionDevice, CynthionUsability, Speed};
+use packetry::capture::{create_capture, CaptureReader, EndpointId, EndpointTransferId};
+use packetry::decoder::Decoder;
+
+use anyhow::{Context, Error};
+use futures_lite::future::block_on;
+use nusb::transfer::RequestBuffer;
+
+const TRANSFER_LENGTH: usize = 0x1000;
+
+fn main() {
+    test().unwrap();
+}
+
+fn test() -> Result<(), Error> {
+    // Create capture and decoder.
+    let (writer, mut reader) = create_capture()
+        .context("Failed to create capture")?;
+    let mut decoder = Decoder::new(writer)
+        .context("Failed to create decoder")?;
+
+    // Open analyzer device.
+    let analyzer = CynthionDevice::scan()
+        .context("Failed to scan for analyzers")?
+        .iter()
+        .find(|dev| matches!(dev.usability, CynthionUsability::Usable(..)))
+        .context("No usable analyzer found")?
+        .open()
+        .context("Failed to open analyzer")?;
+
+    // Start capture.
+    let (packets, stop_handle) = analyzer
+        .start(Speed::High,
+               |err| err.context("Failure in capture thread").unwrap())
+        .context("Failed to start analyzer")?;
+
+    // Open test device on AUX port.
+    let test_device = nusb::list_devices()
+        .context("Failed to list USB devices")?
+        .find(|dev| dev.vendor_id() == 0x1209 && dev.product_id() == 0x000A)
+        .context("Test device not found")?
+        .open()
+        .context("Failed to open test device")?;
+    let test_interface = test_device.claim_interface(0)
+        .context("Failed to claim interface 0 on test device")?;
+
+    // Read some data from the test device.
+    println!("Starting read from test device");
+    let buf = RequestBuffer::new(TRANSFER_LENGTH);
+    let transfer = test_interface.bulk_in(0x81, buf);
+    let completion = block_on(transfer);
+    completion.status.context("Transfer from test device failed")?;
+    println!("Read {} bytes from test device", completion.data.len());
+    assert_eq!(completion.data.len(), TRANSFER_LENGTH);
+
+    // Stop analyzer.
+    stop_handle.stop()
+        .context("Failed to stop analyzer")?;
+
+    // Decode all packets that were received.
+    for packet in packets {
+        decoder.handle_raw_packet(&packet)
+            .context("Error decoding packet")?;
+    }
+
+    // Look up the endpoint we're interested in and count payload bytes.
+    let bytes_captured = bytes_on_endpoint(&mut reader)
+        .context("Error counting captured bytes on endpoint")?;
+    println!("Captured {}/{} bytes of data read from test device",
+             bytes_captured, TRANSFER_LENGTH);
+    assert_eq!(bytes_captured, TRANSFER_LENGTH as u64);
+
+    Ok(())
+}
+
+fn bytes_on_endpoint(reader: &mut CaptureReader) -> Result<u64, Error> {
+    // Endpoint IDs 0 and 1 are special (used for invalid and framing packets).
+    // The first normal endpoint in the capture will have endpoint ID 2.
+    let endpoint_id = EndpointId::from(2);
+    // We're looking for the first and only transfer on the endpoint.
+    let ep_transfer_id = EndpointTransferId::from(0);
+    let ep_traf = reader.endpoint_traffic(endpoint_id)?;
+    let ep_transaction_ids = ep_traf.transfer_index.target_range(
+        ep_transfer_id, ep_traf.transaction_ids.len())?;
+    let data_range = ep_traf.transfer_data_range(&ep_transaction_ids)?;
+    let data_length = ep_traf.transfer_data_length(&data_range)?;
+    Ok(data_length)
+}


### PR DESCRIPTION
This PR adds a hardware-in-the-loop test of Packetry's capture functionality, using a Cynthion device.

This test requires a Cynthion r0.6 or higher board, running analyzer gateware including the self-test device added in https://github.com/greatscottgadgets/cynthion/pull/98.

The host must be connected to both the CONTROL and TARGET-C ports. The TARGET-A port must be connected to the AUX port.

This test is optional and requires the `test-cynthion` feature to be enabled.