### PR TITLE
Fix flushed capture data being missed at shutdown

### DIFF
--- a/src/backend/cynthion.rs
+++ b/src/backend/cynthion.rs
@@ -424,19 +424,24 @@ impl CynthionStop {
         println!("Requesting capture stop");
         self.stop_request.send(())
             .or_else(|_| bail!("Failed sending stop request"))?;
-        match self.worker.join() {
-            Ok(()) => Ok(()),
-            Err(panic) => {
-                let msg = match (
-                    panic.downcast_ref::<&str>(),
-                    panic.downcast_ref::<String>())
-                {
-                    (Some(&s), _) => s,
-                    (_,  Some(s)) => s,
-                    (None,  None) => "<No panic message>"
-                };
-                bail!("Worker thread panic: {msg}");
-            }
+        handle_thread_panic(self.worker.join())?;
+        Ok(())
+    }
+}
+
+fn handle_thread_panic<T>(result: std::thread::Result<T>) -> Result<T, Error> {
+    match result {
+        Ok(x) => Ok(x),
+        Err(panic) => {
+            let msg = match (
+                panic.downcast_ref::<&str>(),
+                panic.downcast_ref::<String>())
+            {
+                (Some(&s), _) => s,
+                (_,  Some(s)) => s,
+                (None,  None) => "<No panic message>"
+            };
+            bail!("Worker thread panic: {msg}");
         }
     }
 }


### PR DESCRIPTION
This PR does a fair bit of refactoring of the Cynthion capture backend, in order to solve a quite simple problem.

The bug was that during shutdown, Packetry was tearing down the data transfer queue before sending the control request to stop capture. This meant that capture data which was flushed by the analyzer at stop time was lost. In most cases, this wasn't noticeable, but when using low-traffic devices (especially LS keyboards), a whole capture could be lost entirely, if it never produced the 512 bytes needed to fill a packet to the host.

Test case:

- Start a low speed capture.
- Plug in a USB LS keyboard.
- Stop capture.
- No traffic is captured.

To fix this there were basically two options:

1. Do a bunch more fiddly work to integrate the start/stop control requests into the same async task as the data transfer queue handling, including re-implementing timeouts for them.

2. Spawn an additional worker thread for the data transfer queue processing, allowing the existing capture thread to continue to use nusb's synchronous API for control requests.

I spent a bunch of time trying to do option 1. It's ugly and difficult. So this PR implements option 2.

This choice also helps with the upcoming HITL test work, where we need to send additional control requests during capture, to manage the test device on the AUX port. Option 1 would have required these too to be integrated into the async task.

To simplify the HITL use case further, this PR also makes `CynthionHandle::start()` clone `self` to pass to the worker thread, rather than consuming it, meaning the test can keep that handle to make its additional requests with.