### PR TITLE
fix: disable console window for Windows GUI application

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![windows_subsystem = "windows"]
+
 use gtk::prelude::*;
 use gtk::gio::ApplicationFlags;
 


### PR DESCRIPTION
Rust 1.18.0 added support for windows GUI application preventing to open a console window when the application is started.