### PR TITLE
CI: Disable rust-cache action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,8 +83,6 @@ jobs:
         run: echo "$env:VCPKG_DEFAULT_BINARY_CACHE/../vcpkg_installed/x64-windows/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
         if: matrix.os == 'windows-latest'
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
The `rust-cache` action cuts down on compile times, but it keeps causing failures on the Mac builds because the cache brings along with it paths to libraries in specific versions of Homebrew packages, without which the final linking step fails.

If we could figure out a way to hash the Homebrew installation and use that as an additional key to the Rust cache, that would avoid this issue, but that doesn't seem straightforward.

So for now, remove this as it causes more trouble than it's worth.