### PR TITLE
Simplify vcpkg path usage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,10 @@ jobs:
         rust: ['stable', '1.57']
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg/installed
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -72,15 +76,15 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - name: Set PKG_CONFIG (Windows)
-        run: echo "PKG_CONFIG=$env:VCPKG_DEFAULT_BINARY_CACHE/../vcpkg_installed/x64-windows/tools/pkgconf/pkgconf.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
+        run: echo "PKG_CONFIG=$env:VCPKG_INSTALLED_DIR/x64-windows/tools/pkgconf/pkgconf.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: matrix.os == 'windows-latest'
 
       - name: Set PKG_CONFIG_PATH (Windows)
-        run: echo "PKG_CONFIG_PATH=$env:VCPKG_DEFAULT_BINARY_CACHE/../vcpkg_installed/x64-windows/lib/pkgconfig" | Out-File -FilePath $env:GITHUB_ENV -Append
+        run: echo "PKG_CONFIG_PATH=$env:VCPKG_INSTALLED_DIR/x64-windows/lib/pkgconfig" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: matrix.os == 'windows-latest'
 
       - name: Set PATH (Windows)
-        run: echo "$env:VCPKG_DEFAULT_BINARY_CACHE/../vcpkg_installed/x64-windows/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+        run: echo "$env:VCPKG_INSTALLED_DIR/x64-windows/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
         if: matrix.os == 'windows-latest'
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Apparently when preparing #83 I had missed that you can set `VCPKG_INSTALLED_DIR` to choose where `run-vcpkg` will install to.