### PR TITLE
Bump MSRV to 1.74, and fix MSRV testing in CI.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['macos-latest', 'ubuntu-22.04', 'windows-latest']
-        rust: ['stable', '1.57']
+        rust: ['stable', '1.74']
 
     runs-on: ${{ matrix.os }}
 
@@ -56,6 +56,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          override: true
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/greatscottgadgets/packetry"
 repository = "https://github.com/greatscottgadgets/packetry"
 documentation = "https://packetry.readthedocs.io"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.74"
 
 include = [
     "CHANGELOG.md",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Packetry is currently in active development and not yet ready for initial releas
 
 Packetry is written in [Rust](https://rust-lang.org/), with its GUI using [GTK 4](https://gtk.org) via the [gtk-rs](https://gtk-rs.org/) bindings.
 
-To build it, you need a working Rust development environment. The minimum supported Rust version is 1.57.
+To build it, you need a working Rust development environment. The minimum supported Rust version is 1.74.
 
 You must also have the GTK 4 headers installed and discoverable via `pkg-config`, as this is required for Rust to build the gtk-rs crates.
 
@@ -28,7 +28,7 @@ Note: Do not build with `--all-features`. All the optional features currently in
 
 Install the Rust build tools, other essential build tools, and GTK 4 headers.
 
-On Debian based systems it should be sufficient to use the command:
+On Debian based systems it may be sufficient to use the command:
 
 `apt install rustc cargo build-essential libgtk-4-dev`
 
@@ -38,7 +38,7 @@ For Fedora systems:
 
 For other distributions, a similar set of packages should be required.
 
-You can also omit Rust and Cargo and use [rustup](https://rustup.rs/) to get the latest Rust toolchain and manage your Rust installation.
+Note that Packetry requires a minimum Rust version of 1.74. If your distribution's packages are older than this, use [rustup](https://rustup.rs/) to get the latest Rust toolchain and manage your Rust installation.
 
 #### macOS
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -93,8 +93,10 @@ static UPDATE_INTERVAL: Duration = Duration::from_millis(10);
 static UPDATE_LOCK: Mutex<()> = Mutex::new(());
 
 thread_local!(
-    static WINDOW: RefCell<Option<ApplicationWindow>> = RefCell::new(None);
-    static UI: RefCell<Option<UserInterface>> = RefCell::new(None);
+    static WINDOW: RefCell<Option<ApplicationWindow>> =
+        const { RefCell::new(None) };
+    static UI: RefCell<Option<UserInterface>> =
+        const { RefCell::new(None) };
 );
 
 #[derive(Copy, Clone, PartialEq)]


### PR DESCRIPTION
Our minimum supported Rust version (MSRV) is now 1.74.

This is imposed by the MSRV of recent versions of `nusb` - see https://github.com/kevinmehall/nusb/pull/62.

:ballot_box_with_check: Update the README and Cargo metadata to reflect this.

:ballot_box_with_check:  Fix CI testing of the MSRV, which was broken due to missing the `override: true` parameter for `actions-rs/toolchain`.