### PR TITLE
Update github actions to latest versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
@@ -52,7 +52,7 @@ jobs:
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg/installed
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -135,19 +135,20 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - name: Upload binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Binary for ${{ matrix.os }}
           path: |
             target/release/packetry
             target/release/packetry.exe
           if-no-files-found: error
+        if: matrix.rust == 'stable'
 
       - name: Upload installer (Windows)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows installer
           path: |
             target/wix/*.msi
           if-no-files-found: error
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.rust == 'stable'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu-')
 
       - name: Install dependencies (macOS)
-        run: brew install gtk4 pkg-config
+        run: brew install gtk4
         if: matrix.os == 'macos-latest'
 
       - name: Install cargo-wix (Windows)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,9 +100,12 @@ jobs:
         run: cargo build --release
 
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: cargo test
+        run: cargo test
+        if: runner.os != 'Linux'
+
+      - name: Test under XVFB (Linux)
+        run: xvfb-run cargo test
+        if: runner.os == 'Linux'
 
       - name: Compile glib schemas (Windows)
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,18 +25,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install stable components
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: clippy
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
 
       - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --verbose --release -- -D warnings
+        run: cargo clippy -- --deny warnings
 
   build_and_test:
     name: Build and test
@@ -53,10 +48,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
@@ -101,10 +97,7 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+        run: cargo build --release
 
       - name: Test
         uses: GabrielBB/xvfb-action@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ name: CI
 jobs:
   clippy:
     name: Clippy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-latest', 'ubuntu-22.04', 'windows-latest']
+        os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
         rust: ['stable', '1.74']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- Update `actions/checkout` from v2/3 to v4
- Update `actions/upload-artifact` from v2 to v4
  - Avoid conflicting artifacts by uploading only those from the `stable` Rust build.
- Replace unmaintained `actions-rs` actions with direct use of `rustup` and `cargo`.
- Always use the latest version of the Ubuntu runner.
- Replace deprecated `GabrielBB/xvfb-action` with direct use of `xvfb-run`.
- Don't try to install `pkg-config` on macOS; the runner has it.