### PR TITLE
Add `--version` option and About dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "glib"
 version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +985,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
+ "git-version",
  "gtk4",
  "humansize",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ lrumap = "0.1.0"
 memmap2 = "0.9.4"
 page_size = "0.6.0"
 anyhow = { version = "1.0.79", features = ["backtrace"] }
+git-version = "0.3.9"
 
 [dev-dependencies]
 serde = { version = "1.0.196", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,9 @@ fn have_argument(name: &str) -> bool {
 }
 
 fn main() {
-    if have_argument("--test-cynthion") {
+    if have_argument("--version") {
+        println!("Packetry version {}", git_version::git_version!())
+    } else if have_argument("--test-cynthion") {
         let save_captures = have_argument("--save-captures");
         test_cynthion::run_test(save_captures);
     } else {


### PR DESCRIPTION
This PR adds a `--version` command line option, and an About dialog to the UI.

Version information is captured at compile time with the [git_version](https://docs.rs/git-version/latest/git_version/) macro, so that it is possible to identify builds from non-release versions.

The About dialog includes basic package information, the BSD license text for Packetry itself, and some system information: OS, architecture and GTK library version in use.

It does not yet include copyright or license information for any dependencies.