### PR TITLE
Gather more build information and improve version string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "built"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4"
+dependencies = [
+ "cargo-lock",
+ "git2",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,10 +160,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-lock"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72"
+dependencies = [
+ "semver",
+ "serde",
+ "toml 0.7.8",
+ "url",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cfg-expr"
@@ -303,6 +330,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fuchsia-zircon"
@@ -513,23 +549,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-version"
-version = "0.3.9"
+name = "git2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "git-version-macro",
-]
-
-[[package]]
-name = "git-version-macro"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
+ "bitflags 2.5.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -716,6 +745,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,10 +849,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -978,6 +1050,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "bitfield",
+ "built",
  "bytemuck",
  "bytemuck_derive",
  "ctor",
@@ -985,7 +1058,6 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "git-version",
  "gtk4",
  "humansize",
  "itertools",
@@ -1055,6 +1127,12 @@ dependencies = [
  "derive-into-owned",
  "thiserror",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -1240,6 +1318,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -1327,7 +1408,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.8.14",
  "version-compare",
 ]
 
@@ -1370,6 +1451,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1496,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -1415,10 +1536,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "uuid"
@@ -1428,6 +1575,12 @@ checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom 0.2.15",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/greatscottgadgets/packetry"
 documentation = "https://packetry.readthedocs.io"
 edition = "2021"
 rust-version = "1.74"
+build = "src/build.rs"
 
 include = [
     "CHANGELOG.md",
@@ -21,7 +22,8 @@ include = [
     "tests/**/*",
 ]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[build-dependencies]
+built = { version = "0.7.4", features = ["cargo-lock", "git2"] }
 
 [dependencies]
 bytemuck = "1.14.1"
@@ -47,7 +49,6 @@ lrumap = "0.1.0"
 memmap2 = "0.9.4"
 page_size = "0.6.0"
 anyhow = { version = "1.0.79", features = ["backtrace"] }
-git-version = "0.3.9"
 
 [dev-dependencies]
 serde = { version = "1.0.196", features = ["derive"] }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,12 @@ extern crate bitfield;
 #[macro_use]
 extern crate ctor;
 
+// Include build-time info.
+pub mod built {
+   // The file has been placed there by the build script.
+   include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
 // Declare all modules used.
 mod backend;
 mod capture;
@@ -31,6 +37,7 @@ mod ui;
 mod usb;
 mod util;
 mod vec_map;
+mod version;
 
 // Declare optional modules.
 #[cfg(any(test, feature="record-ui-test"))]
@@ -46,6 +53,7 @@ use ui::{
     display_error,
     stop_cynthion
 };
+use version::{version, version_info};
 
 fn have_argument(name: &str) -> bool {
     std::env::args().any(|arg| arg == name)
@@ -53,7 +61,9 @@ fn have_argument(name: &str) -> bool {
 
 fn main() {
     if have_argument("--version") {
-        println!("Packetry version {}", git_version::git_version!())
+        println!("Packetry version {}\n\n{}",
+                 version(),
+                 version_info(have_argument("--dependencies")));
     } else if have_argument("--test-cynthion") {
         let save_captures = have_argument("--save-captures");
         test_cynthion::run_test(save_captures);
@@ -67,4 +77,3 @@ fn main() {
         display_error(stop_cynthion());
     }
 }
-

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -72,6 +72,7 @@ use crate::row_data::{
     TrafficRowData,
     DeviceRowData};
 use crate::util::{fmt_count, fmt_size};
+use crate::version::{version, version_info};
 
 #[cfg(any(test, feature="record-ui-test"))]
 use {
@@ -995,26 +996,17 @@ pub fn stop_cynthion() -> Result<(), Error> {
 }
 
 fn show_about() -> Result<(), Error> {
-    const GIT_VERSION: &str = git_version::git_version!();
     const LICENSE: &str = include_str!("../LICENSE");
     let about = AboutDialog::builder()
         .program_name("Packetry")
-        .version(format!("Version: {GIT_VERSION}"))
+        .version(format!("Version: {}", version()))
         .comments("A fast, intuitive USB 2.0 protocol analysis application")
         .copyright("© 2022-2024 Great Scott Gadgets. All rights reserved.")
         .license_type(License::Bsd3)
         .license(LICENSE)
         .website("https://github.com/greatscottgadgets/packetry/")
         .website_label("https://github.com/greatscottgadgets/packetry/")
-        .system_information(format!(
-            "OS: {}\n\
-             Architecture: {}\n\
-             GTK version: {}.{}.{}",
-            std::env::consts::OS,
-            std::env::consts::ARCH,
-            gtk::major_version(),
-            gtk::minor_version(),
-            gtk::micro_version()))
+        .system_information(version_info(true))
         .build();
     about.present();
     Ok(())

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,70 @@
+use std::fmt::Write;
+
+use crate::built::*;
+
+pub fn version() -> String {
+   const MOD: &str = match GIT_DIRTY {
+      Some(true) => "-modified",
+      Some(false) | None => ""
+   };
+
+   match GIT_VERSION {
+      None => PKG_VERSION.to_string(),
+      Some(description) => format!("{PKG_VERSION} (git {description}{MOD})")
+   }
+}
+
+pub fn version_info(with_dependencies: bool) -> String {
+   let gtk_version = format!("{}.{}.{}",
+      gtk::major_version(),
+      gtk::minor_version(),
+      gtk::micro_version());
+
+   const COMMIT: &str = match GIT_COMMIT_HASH {
+      Some(commit) => commit,
+      None => "unknown"
+   };
+
+   const MODIFIED: &str = match GIT_DIRTY {
+      Some(true) => " (modified)",
+      Some(false) | None => ""
+   };
+
+   #[allow(clippy::const_is_empty)]
+   const FEATURE_LIST: &str = if FEATURES.is_empty() {
+      "(none)"
+   } else {
+      FEATURES_LOWERCASE_STR
+   };
+
+   const DEBUG_STR: &str = if DEBUG {"yes"} else {"no"};
+
+   let output = format!("\
+Runtime information:
+  GTK version: {gtk_version}
+
+Packetry build information:
+  Git commit: {COMMIT}{MODIFIED}
+  Cargo package version: {PKG_VERSION}
+  Enabled features: {FEATURE_LIST}
+
+Rust compiler:
+  Version: {RUSTC_VERSION}
+  Target: {TARGET} ({CFG_ENDIAN}-endian, {CFG_POINTER_WIDTH}-bit)
+  Optimization level: {OPT_LEVEL}
+  Debug build: {DEBUG_STR}");
+
+  if with_dependencies {
+     DEPENDENCIES
+        .iter()
+        .fold(
+            format!("{output}\n\nBuilt with dependencies:"),
+            |mut string, (pkg, ver)| {
+                write!(string, "\n  {pkg} {ver}").unwrap();
+                string
+            }
+        )
+   } else {
+      output
+   }
+}

--- a/wix/rust_licenses.py
+++ b/wix/rust_licenses.py
@@ -118,6 +118,7 @@ for line in cargo_result.stdout.decode().rstrip().split("\n"):
         # Look for a license file.
         src_filenames = (
             'LICENSE-MIT',
+            'LICENSE-MIT.md',
             'license-mit',
             'LICENSE',
             'LICENSE.md',


### PR DESCRIPTION
This PR uses the [`built`](https://docs.rs/built/latest/built/) crate to gather additional build-time information which is reported in the `--version` output and the About dialog.

Fixes the failure to build without a `.git` directory, caused by #125.

Output of `--version` when built with a `.git` directory:
```
Packetry version 0.1.0 (git b2029df)

Runtime information:
  GTK version: 4.12.5

Packetry build information:
  Git commit: b2029df15600f1ddcb2e0655b6baa0abfc6355cd
  Cargo package version: 0.1.0
  Enabled features: (none)

Rust compiler:
  Version: rustc 1.79.0 (129f3b996 2024-06-10)
  Target: x86_64-unknown-linux-gnu (little-endian, 64-bit)
  Optimization level: 3
  Debug build: no
```

Output when built without a `.git` directory:
```
Packetry version 0.1.0

Runtime information:
  GTK version: 4.12.5

Packetry build information:
  Git commit: unknown
  Cargo package version: 0.1.0
  Enabled features: (none)

Rust compiler:
  Version: rustc 1.79.0 (129f3b996 2024-06-10)
  Target: x86_64-unknown-linux-gnu (little-endian, 64-bit)
  Optimization level: 3
  Debug build: no
```

The `--dependencies` option can now be used along with `--version` to print crate dependencies used. This is omitted by default as it generates a lot of output.

The same information as above, as well as the dependency listing, is displayed in the About dialog.