### PR TITLE
Fix failures in license scripts being lost

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,6 +117,8 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - name: Gather licenses (Windows)
+        # If the default shell is used, one command failing does not fail the action.
+        shell: bash
         run: |
           pip install license-expression
           python wix/rust_licenses.py > wix/LICENSE-static-libraries.txt

--- a/wix/rust_licenses.py
+++ b/wix/rust_licenses.py
@@ -121,6 +121,7 @@ for line in cargo_result.stdout.decode().rstrip().split("\n"):
             'license-mit',
             'LICENSE',
             'LICENSE.md',
+            'COPYING',
         )
         src_dir = os.path.join(deps.name, f'{package}-{version}')
         src_files = os.listdir(src_dir)

--- a/wix/rust_licenses.py
+++ b/wix/rust_licenses.py
@@ -9,6 +9,7 @@ licensing = get_spdx_licensing()
 # We accept these licenses unconditionally.
 accepted_license_strings = (
     'MIT',
+    'BSD-2-Clause',
     'BSD-3-Clause',
     'BSL-1.0',
     'Unicode-DFS-2016',


### PR DESCRIPTION
Errors returned from `rust_licenses.py` were being ignored, because on Windows runners, commands are executed by PowerShell, and there's no equivalent of `set -e` there, so a multi-line `run` command will ignore errors as long as the last command in the sequence succeeds. This is documented [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference). What a footgun!

Fix this by forcing the shell to `bash` (thanks @miek for the tip), and then fix the underlying failure, which was that I hadn't added `BSD-2-Clause` to the list of accepted licenses when adding the `git-version` crate in #125. Also add `COPYING` to the list of filenames to check for a license in the crate source,  which is also needed to accept this crate.

We're about to remove the `git-version` dependency in #126 anyway, but these changes are valid regardless.