### PR TITLE
Command line and file handling fixes

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1741,7 +1741,8 @@ mod tests {
             ref_path.push("reference.txt");
             out_path.push("output.txt");
             {
-                let mut loader = Loader::open(cap_path).unwrap();
+                let file = File::open(cap_path).unwrap();
+                let mut loader = Loader::open(file).unwrap();
                 let (writer, mut reader) = create_capture().unwrap();
                 let mut decoder = Decoder::new(writer).unwrap();
                 while let Some(result) = loader.next() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ mod test_replay;
 
 use gtk::prelude::*;
 use gtk::gio::ApplicationFlags;
+use gtk::glib::{self, OptionArg, OptionFlags};
 
 use ui::{
     activate,
@@ -74,6 +75,16 @@ fn main() {
             ApplicationFlags::NON_UNIQUE |
             ApplicationFlags::HANDLES_OPEN
         );
+        application.set_option_context_parameter_string(
+           Some("[filename.pcap]"));
+        application.add_main_option(
+           "version", glib::Char::from(0),
+           OptionFlags::NONE, OptionArg::None,
+           "Print version information", None);
+        application.add_main_option(
+           "test-cynthion", glib::Char::from(0),
+           OptionFlags::NONE, OptionArg::None,
+           "Test an attached Cynthion USB analyzer", None);
         application.connect_activate(|app| display_error(activate(app)));
         application.connect_open(|app, files, _hint| {
            app.activate();

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ use gtk::gio::ApplicationFlags;
 use ui::{
     activate,
     display_error,
+    open,
     stop_cynthion
 };
 use version::{version, version_info};
@@ -70,10 +71,17 @@ fn main() {
     } else {
         let application = gtk::Application::new(
             Some("com.greatscottgadgets.packetry"),
-            ApplicationFlags::NON_UNIQUE
+            ApplicationFlags::NON_UNIQUE |
+            ApplicationFlags::HANDLES_OPEN
         );
         application.connect_activate(|app| display_error(activate(app)));
-        application.run_with_args::<&str>(&[]);
+        application.connect_open(|app, files, _hint| {
+           app.activate();
+           if let Some(file) = files.first() {
+              display_error(open(file));
+           }
+        });
+        application.run();
         display_error(stop_cynthion());
     }
 }

--- a/src/test_cynthion.rs
+++ b/src/test_cynthion.rs
@@ -14,6 +14,7 @@ use anyhow::{Context, Error};
 use futures_lite::future::block_on;
 use nusb::transfer::RequestBuffer;
 
+use std::fs::File;
 use std::path::PathBuf;
 use std::thread::sleep;
 use std::time::Duration;
@@ -103,7 +104,8 @@ fn test(save_capture: bool,
     if save_capture {
         // Write the capture to a file.
         let path = PathBuf::from(format!("./HITL-{name}.pcap"));
-        let mut writer = Writer::open(path)?;
+        let file = File::open(path)?;
+        let mut writer = Writer::open(file)?;
         for i in 0..reader.packet_index.len() {
             let packet_id = PacketId::from(i);
             let packet = reader.packet(packet_id)?;

--- a/src/test_replay.rs
+++ b/src/test_replay.rs
@@ -112,8 +112,10 @@ fn check_replays() {
                         Ok(())
                     }).unwrap();
                     if let Some(capture) = capture {
-                        let loader = Loader::open(path)
+                        let file = File::open(path)
                             .expect("Failed to open pcap file");
+                        let loader = Loader::open(file)
+                            .expect("Failed to create pcap loader");
                         let decoder = Decoder::new(writer)
                             .expect("Failed to create decoder");
                         replay = Some((loader, decoder, capture));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -722,8 +722,8 @@ pub fn update_view() -> Result<(), Error> {
         } else {
             let (devices, endpoints, transactions, packets) = {
                 let cap = &ui.capture;
-                let devices = cap.devices.len() - 1;
-                let endpoints = cap.endpoints.len() - 2;
+                let devices = cap.devices.len().saturating_sub(1);
+                let endpoints = cap.endpoints.len().saturating_sub(2);
                 let transactions = cap.transaction_index.len();
                 let packets = cap.packet_index.len();
                 (devices, endpoints, transactions, packets)


### PR DESCRIPTION
Changes in this PR:
- Fix UI crashing with an underflow error when a non-existent filename is passed on the command line.
- Use the standard command line handling and file open mechanism for GTK applications.
  - Previously we were doing our own command line processing in the `activate` callback.
  - The correct method is to provide an `open` callback.
  - Fixes a panic in `test_replay` when `--nocapture` was passed to the test and interpreted as a filename.
- Add information about command line options to the `Application` instance.
  - This gets us a a useful `--help` output.
- Use the [`gio::File`](https://gtk-rs.org/gtk-rs-core/stable/latest/docs/gio/struct.File.html) abstraction.
  - This allows us to load and save files from anywhere that GIO knows how to access, such as SMB and MTP filesystems that are dynamically accessed from the file chooser rather than mounted into the filesystem.