### PR TITLE
Use `usb.ids` database to interpret various ID values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +999,16 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1091,6 +1107,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "usb-ids",
 ]
 
 [[package]]
@@ -1149,6 +1166,44 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1379,6 +1434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +1642,19 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "usb-ids"
+version = "1.2024.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fbafa81873964b6fb260b7d7d4da4dcb59b58aaa9e713dcbacf162862984f63"
+dependencies = [
+ "nom",
+ "phf",
+ "phf_codegen",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ memmap2 = "0.9.4"
 page_size = "0.6.0"
 anyhow = { version = "1.0.79", features = ["backtrace"] }
 crc = "3.2.1"
+usb-ids = "1.2024.4"
 
 [dev-dependencies]
 serde = { version = "1.0.196", features = ["derive"] }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -440,7 +440,11 @@ impl StandardRequest {
                     fields.value & 0xFF,
                     match (descriptor_type, fields.index) {
                         (DescriptorType::String, language) if language > 0 =>
-                            format!(", language 0x{language:04x}"),
+                            format!(", language 0x{language:04x}{}",
+                                language_name(language)
+                                    .map_or_else(
+                                        String::new,
+                                        |l| format!(" ({l})"))),
                         (..) => format!(""),
                     }
                 )
@@ -453,6 +457,20 @@ impl StandardRequest {
             SynchFrame => format!("Synchronising frame"),
             Unknown => format!("Unknown standard request"),
         }
+    }
+}
+
+fn language_name(code: u16) -> Option<String> {
+    let language_id = code & 0x3ff;
+    let dialect_id = (code >> 10) as u8;
+    let language = usb_ids::Language::from_id(language_id);
+    let dialect = usb_ids::Dialect::from_lid_did(language_id, dialect_id);
+    match (language, dialect) {
+        (Some(language), Some(dialect)) =>
+            Some(format!("{}/{}", language.name(), dialect.name())),
+        (Some(language), None) =>
+            Some(language.name().to_string()),
+        _ => None
     }
 }
 

--- a/tests/analyzer-test-bad-cable/reference.txt
+++ b/tests/analyzer-test-bad-cable/reference.txt
@@ -1879,7 +1879,7 @@ Getting device descriptor #0 for device 1, reading 18 bytes
   OUT packet on 1.0, CRC 1D
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #2, language 0x0409 for device 1, reading 2 bytes
+Getting string descriptor #2, language 0x0409 (English/US) for device 1, reading 2 bytes
  SETUP transaction on 1.0 with 8 data bytes, ACK: [80, 06, 02, 03, 09, 04, 02, 00]
   SETUP packet on 1.0, CRC 1D
   DATA0 packet with CRC 4BD7 and 8 data bytes: [80, 06, 02, 03, 09, 04, 02, 00]
@@ -1892,7 +1892,7 @@ Getting string descriptor #2, language 0x0409 for device 1, reading 2 bytes
   OUT packet on 1.0, CRC 1D
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #2, language 0x0409 for device 1, reading 50 bytes: 'USB Analyzer Test Device'
+Getting string descriptor #2, language 0x0409 (English/US) for device 1, reading 50 bytes: 'USB Analyzer Test Device'
  SETUP transaction on 1.0 with 8 data bytes, ACK: [80, 06, 02, 03, 09, 04, 32, 00]
   SETUP packet on 1.0, CRC 1D
   DATA0 packet with CRC 4BC3 and 8 data bytes: [80, 06, 02, 03, 09, 04, 32, 00]
@@ -1905,7 +1905,7 @@ Getting string descriptor #2, language 0x0409 for device 1, reading 50 bytes: 'U
   OUT packet on 1.0, CRC 1D
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #1, language 0x0409 for device 1, reading 2 bytes
+Getting string descriptor #1, language 0x0409 (English/US) for device 1, reading 2 bytes
  SETUP transaction on 1.0 with 8 data bytes, ACK: [80, 06, 01, 03, 09, 04, 02, 00]
   SETUP packet on 1.0, CRC 1D
   DATA0 packet with CRC 78D7 and 8 data bytes: [80, 06, 01, 03, 09, 04, 02, 00]
@@ -1918,7 +1918,7 @@ Getting string descriptor #1, language 0x0409 for device 1, reading 2 bytes
   OUT packet on 1.0, CRC 1D
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #1, language 0x0409 for device 1, reading 34 bytes: 'Cynthion Project'
+Getting string descriptor #1, language 0x0409 (English/US) for device 1, reading 34 bytes: 'Cynthion Project'
  SETUP transaction on 1.0 with 8 data bytes, ACK: [80, 06, 01, 03, 09, 04, 22, 00]
   SETUP packet on 1.0, CRC 1D
   DATA0 packet with CRC B8CE and 8 data bytes: [80, 06, 01, 03, 09, 04, 22, 00]

--- a/tests/emf2022-badge/reference.txt
+++ b/tests/emf2022-badge/reference.txt
@@ -3881,7 +3881,7 @@ Getting string descriptor #0 for device 1, reading 4 of 255 requested bytes
   OUT packet on 1.0, CRC 1D
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #2, language 0x0409 for device 1, reading 56 of 255 requested bytes: 'USB JTAG/serial debug unit\u{0}'
+Getting string descriptor #2, language 0x0409 (English/US) for device 1, reading 56 of 255 requested bytes: 'USB JTAG/serial debug unit\u{0}'
  SETUP transaction on 1.0 with 8 data bytes, ACK: [80, 06, 02, 03, 09, 04, FF, 00]
   SETUP packet on 1.0, CRC 1D
   DATA0 packet with CRC DB97 and 8 data bytes: [80, 06, 02, 03, 09, 04, FF, 00]
@@ -3894,7 +3894,7 @@ Getting string descriptor #2, language 0x0409 for device 1, reading 56 of 255 re
   OUT packet on 1.0, CRC 1D
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #1, language 0x0409 for device 1, reading 22 of 255 requested bytes: 'Espressif\u{0}'
+Getting string descriptor #1, language 0x0409 (English/US) for device 1, reading 22 of 255 requested bytes: 'Espressif\u{0}'
  SETUP transaction on 1.0 with 8 data bytes, ACK: [80, 06, 01, 03, 09, 04, FF, 00]
   SETUP packet on 1.0, CRC 1D
   DATA0 packet with CRC E897 and 8 data bytes: [80, 06, 01, 03, 09, 04, FF, 00]
@@ -3907,7 +3907,7 @@ Getting string descriptor #1, language 0x0409 for device 1, reading 22 of 255 re
   OUT packet on 1.0, CRC 1D
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #3, language 0x0409 for device 1, reading 36 of 255 requested bytes: 'F4:12:FA:4D:F1:7C'
+Getting string descriptor #3, language 0x0409 (English/US) for device 1, reading 36 of 255 requested bytes: 'F4:12:FA:4D:F1:7C'
  SETUP transaction on 1.0 with 8 data bytes, ACK: [80, 06, 03, 03, 09, 04, FF, 00]
   SETUP packet on 1.0, CRC 1D
   DATA0 packet with CRC 0A96 and 8 data bytes: [80, 06, 03, 03, 09, 04, FF, 00]
@@ -4090,7 +4090,7 @@ Getting string descriptor #0 for device 2, reading 4 of 255 requested bytes
   OUT packet on 2.0, CRC 15
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #2, language 0x0409 for device 2, reading 12 of 255 requested bytes: 'TiDAL'
+Getting string descriptor #2, language 0x0409 (English/US) for device 2, reading 12 of 255 requested bytes: 'TiDAL'
  SETUP transaction on 2.0 with 8 data bytes, ACK: [80, 06, 02, 03, 09, 04, FF, 00]
   SETUP packet on 2.0, CRC 15
   DATA0 packet with CRC DB97 and 8 data bytes: [80, 06, 02, 03, 09, 04, FF, 00]
@@ -4110,7 +4110,7 @@ Getting string descriptor #2, language 0x0409 for device 2, reading 12 of 255 re
   OUT packet on 2.0, CRC 15
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #1, language 0x0409 for device 2, reading 44 of 255 requested bytes: 'Electromagnetic Field'
+Getting string descriptor #1, language 0x0409 (English/US) for device 2, reading 44 of 255 requested bytes: 'Electromagnetic Field'
  SETUP transaction on 2.0 with 8 data bytes, ACK: [80, 06, 01, 03, 09, 04, FF, 00]
   SETUP packet on 2.0, CRC 15
   DATA0 packet with CRC E897 and 8 data bytes: [80, 06, 01, 03, 09, 04, FF, 00]
@@ -4126,7 +4126,7 @@ Getting string descriptor #1, language 0x0409 for device 2, reading 44 of 255 re
   OUT packet on 2.0, CRC 15
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #3, language 0x0409 for device 2, reading 14 of 255 requested bytes: '123456'
+Getting string descriptor #3, language 0x0409 (English/US) for device 2, reading 14 of 255 requested bytes: '123456'
  SETUP transaction on 2.0 with 8 data bytes, ACK: [80, 06, 03, 03, 09, 04, FF, 00]
   SETUP packet on 2.0, CRC 15
   DATA0 packet with CRC 0A96 and 8 data bytes: [80, 06, 03, 03, 09, 04, FF, 00]
@@ -4154,7 +4154,7 @@ Setting configuration 1 for device 2
   IN packet on 2.0, CRC 15
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #4, language 0x0409 for device 2, reading 42 of 255 requested bytes: 'Espressif CDC Device'
+Getting string descriptor #4, language 0x0409 (English/US) for device 2, reading 42 of 255 requested bytes: 'Espressif CDC Device'
  SETUP transaction on 2.0 with 8 data bytes, ACK: [80, 06, 04, 03, 09, 04, FF, 00]
   SETUP packet on 2.0, CRC 15
   DATA0 packet with CRC BD97 and 8 data bytes: [80, 06, 04, 03, 09, 04, FF, 00]
@@ -4194,7 +4194,7 @@ Class request #32, index 0, value 0 for interface 2.0, writing 7 bytes
   IN packet on 2.0, CRC 15
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #5, language 0x0409 for device 2, reading 24 of 255 requested bytes: 'TiDAL badge'
+Getting string descriptor #5, language 0x0409 (English/US) for device 2, reading 24 of 255 requested bytes: 'TiDAL badge'
  SETUP transaction on 2.0 with 8 data bytes, ACK: [80, 06, 05, 03, 09, 04, FF, 00]
   SETUP packet on 2.0, CRC 15
   DATA0 packet with CRC 6C96 and 8 data bytes: [80, 06, 05, 03, 09, 04, FF, 00]
@@ -4214,7 +4214,7 @@ Getting string descriptor #5, language 0x0409 for device 2, reading 24 of 255 re
   OUT packet on 2.0, CRC 15
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #3, language 0x0409 for device 2, reading 14 of 255 requested bytes: '123456'
+Getting string descriptor #3, language 0x0409 (English/US) for device 2, reading 14 of 255 requested bytes: '123456'
  SETUP transaction on 2.0 with 8 data bytes, ACK: [80, 06, 03, 03, 09, 04, FF, 00]
   SETUP packet on 2.0, CRC 15
   DATA0 packet with CRC 0A96 and 8 data bytes: [80, 06, 03, 03, 09, 04, FF, 00]

--- a/tests/hackrf-connect/reference.txt
+++ b/tests/hackrf-connect/reference.txt
@@ -192,7 +192,7 @@ Getting string descriptor #0 for device 29, reading 4 of 255 requested bytes
   OUT packet on 29.0, CRC 08
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #2, language 0x0409 for device 29, reading 22 of 255 requested bytes: 'HackRF One'
+Getting string descriptor #2, language 0x0409 (English/US) for device 29, reading 22 of 255 requested bytes: 'HackRF One'
  SETUP transaction on 29.0 with 8 data bytes, ACK: [80, 06, 02, 03, 09, 04, FF, 00]
   SETUP packet on 29.0, CRC 08
   DATA0 packet with CRC DB97 and 8 data bytes: [80, 06, 02, 03, 09, 04, FF, 00]
@@ -205,7 +205,7 @@ Getting string descriptor #2, language 0x0409 for device 29, reading 22 of 255 r
   OUT packet on 29.0, CRC 08
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #1, language 0x0409 for device 29, reading 40 of 255 requested bytes: 'Great Scott Gadgets'
+Getting string descriptor #1, language 0x0409 (English/US) for device 29, reading 40 of 255 requested bytes: 'Great Scott Gadgets'
  SETUP transaction on 29.0 with 8 data bytes, ACK: [80, 06, 01, 03, 09, 04, FF, 00]
   SETUP packet on 29.0, CRC 08
   DATA0 packet with CRC E897 and 8 data bytes: [80, 06, 01, 03, 09, 04, FF, 00]
@@ -221,7 +221,7 @@ Getting string descriptor #1, language 0x0409 for device 29, reading 40 of 255 r
   OUT packet on 29.0, CRC 08
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #4, language 0x0409 for device 29, reading 66 of 255 requested bytes: '0000000000000000325866e6215c4023'
+Getting string descriptor #4, language 0x0409 (English/US) for device 29, reading 66 of 255 requested bytes: '0000000000000000325866e6215c4023'
  SETUP transaction on 29.0 with 8 data bytes, ACK: [80, 06, 04, 03, 09, 04, FF, 00]
   SETUP packet on 29.0, CRC 08
   DATA0 packet with CRC BD97 and 8 data bytes: [80, 06, 04, 03, 09, 04, FF, 00]
@@ -250,7 +250,7 @@ Setting configuration 1 for device 29
   IN packet on 29.0, CRC 08
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #3, language 0x0409 for device 29, reading 24 of 255 requested bytes: 'Transceiver'
+Getting string descriptor #3, language 0x0409 (English/US) for device 29, reading 24 of 255 requested bytes: 'Transceiver'
  SETUP transaction on 29.0 with 8 data bytes, ACK: [80, 06, 03, 03, 09, 04, FF, 00]
   SETUP packet on 29.0, CRC 08
   DATA0 packet with CRC 0A96 and 8 data bytes: [80, 06, 03, 03, 09, 04, FF, 00]

--- a/tests/hackrf-dfu-enum/reference.txt
+++ b/tests/hackrf-dfu-enum/reference.txt
@@ -109,7 +109,7 @@ Getting string descriptor #0 for device 11, reading 4 of 255 requested bytes
   OUT packet on 11.0, CRC 04
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #2, language 0x0409 for device 11, reading 8 of 255 requested bytes: 'LPC'
+Getting string descriptor #2, language 0x0409 (English/US) for device 11, reading 8 of 255 requested bytes: 'LPC'
  SETUP transaction on 11.0 with 8 data bytes, ACK: [80, 06, 02, 03, 09, 04, FF, 00]
   SETUP packet on 11.0, CRC 04
   DATA0 packet with CRC DB97 and 8 data bytes: [80, 06, 02, 03, 09, 04, FF, 00]
@@ -132,7 +132,7 @@ Getting string descriptor #2, language 0x0409 for device 11, reading 8 of 255 re
   OUT packet on 11.0, CRC 04
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #1, language 0x0409 for device 11, reading 8 of 255 requested bytes: 'NXP'
+Getting string descriptor #1, language 0x0409 (English/US) for device 11, reading 8 of 255 requested bytes: 'NXP'
  SETUP transaction on 11.0 with 8 data bytes, ACK: [80, 06, 01, 03, 09, 04, FF, 00]
   SETUP packet on 11.0, CRC 04
   DATA0 packet with CRC E897 and 8 data bytes: [80, 06, 01, 03, 09, 04, FF, 00]
@@ -155,7 +155,7 @@ Getting string descriptor #1, language 0x0409 for device 11, reading 8 of 255 re
   OUT packet on 11.0, CRC 04
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #3, language 0x0409 for device 11, reading 10 of 255 requested bytes: 'ABCD'
+Getting string descriptor #3, language 0x0409 (English/US) for device 11, reading 10 of 255 requested bytes: 'ABCD'
  SETUP transaction on 11.0 with 8 data bytes, ACK: [80, 06, 03, 03, 09, 04, FF, 00]
   SETUP packet on 11.0, CRC 04
   DATA0 packet with CRC 0A96 and 8 data bytes: [80, 06, 03, 03, 09, 04, FF, 00]
@@ -190,7 +190,7 @@ Setting configuration 1 for device 11
   IN packet on 11.0, CRC 04
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #4, language 0x0409 for device 11, reading 8 of 255 requested bytes: 'DFU'
+Getting string descriptor #4, language 0x0409 (English/US) for device 11, reading 8 of 255 requested bytes: 'DFU'
  SETUP transaction on 11.0 with 8 data bytes, ACK: [80, 06, 04, 03, 09, 04, FF, 00]
   SETUP packet on 11.0, CRC 04
   DATA0 packet with CRC BD97 and 8 data bytes: [80, 06, 04, 03, 09, 04, FF, 00]

--- a/tests/mouse/reference.txt
+++ b/tests/mouse/reference.txt
@@ -156,7 +156,7 @@ Getting string descriptor #0 for device 4, reading 4 of 255 requested bytes
   OUT packet on 4.0, CRC 05
   DATA1 packet with CRC 0000 and no data
   ACK packet
-Getting string descriptor #2, language 0x0409 for device 4, reading 36 of 255 requested bytes: 'USB Optical Mouse'
+Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 36 of 255 requested bytes: 'USB Optical Mouse'
  SETUP transaction on 4.0 with 8 data bytes, ACK: [80, 06, 02, 03, 09, 04, FF, 00]
   SETUP packet on 4.0, CRC 05
   DATA0 packet with CRC DB97 and 8 data bytes: [80, 06, 02, 03, 09, 04, FF, 00]

--- a/tests/split-enum/reference.txt
+++ b/tests/split-enum/reference.txt
@@ -655,7 +655,7 @@ Getting string descriptor #0 for device 14, reading 4 of 255 requested bytes
   SPLIT packet completing low speed control transaction on hub 12 port 2
   OUT packet on 14.0, CRC 1C
   ACK packet
-Getting string descriptor #2, language 0x0409 for device 14, reading 22 of 255 requested bytes: 'USB Device'
+Getting string descriptor #2, language 0x0409 (English/US) for device 14, reading 22 of 255 requested bytes: 'USB Device'
  Starting SETUP transaction on 14.0 with 8 data bytes, ACK: [80, 06, 02, 03, 09, 04, FF, 00]
   SPLIT packet starting low speed control transaction on hub 12 port 2
   SETUP packet on 14.0, CRC 1C

--- a/tests/ui/emf2022-badge/reference.txt
+++ b/tests/ui/emf2022-badge/reference.txt
@@ -52,9 +52,9 @@ At devices row 2:
 + Length: 18 bytes
 + Type: 0x01
 + USB Version: 2.00
-+ Class: 0xEF
-+ Subclass: 0x02
-+ Protocol: 0x01
++ Class: 0xEF: Miscellaneous Device
++ Subclass: 0x02: ?
++ Protocol: 0x01: Interface Association
 + Max EP0 packet size: 64 bytes
 + Vendor ID: 0x303A
 + Product ID: 0x1001
@@ -139,9 +139,9 @@ At devices row 2:
 - Length: 18 bytes
 - Type: 0x01
 - USB Version: 2.00
-- Class: 0xEF
-- Subclass: 0x02
-- Protocol: 0x01
+- Class: 0xEF: Miscellaneous Device
+- Subclass: 0x02: ?
+- Protocol: 0x01: Interface Association
 - Max EP0 packet size: 64 bytes
 - Vendor ID: 0x303A
 - Product ID: 0x1001

--- a/tests/ui/emf2022-badge/reference.txt
+++ b/tests/ui/emf2022-badge/reference.txt
@@ -9,9 +9,9 @@ At traffic row 0:
 + Getting configuration descriptor #0 for device 1, reading 9 bytes
 + Getting configuration descriptor #0 for device 1, reading 98 bytes
 + Getting string descriptor #0 for device 1, reading 4 of 255 requested bytes
-+ Getting string descriptor #2, language 0x0409 for device 1, reading 56 of 255 requested bytes: 'USB JTAG/serial debug unit\u{0}'
-+ Getting string descriptor #1, language 0x0409 for device 1, reading 22 of 255 requested bytes: 'Espressif\u{0}'
-+ Getting string descriptor #3, language 0x0409 for device 1, reading 36 of 255 requested bytes: 'F4:12:FA:4D:F1:7C'
++ Getting string descriptor #2, language 0x0409 (English/US) for device 1, reading 56 of 255 requested bytes: 'USB JTAG/serial debug unit\u{0}'
++ Getting string descriptor #1, language 0x0409 (English/US) for device 1, reading 22 of 255 requested bytes: 'Espressif\u{0}'
++ Getting string descriptor #3, language 0x0409 (English/US) for device 1, reading 36 of 255 requested bytes: 'F4:12:FA:4D:F1:7C'
 + Setting configuration 1 for device 1
 + Class request #32, index 0, value 0 for interface 1.0, writing 7 bytes
 + Getting device descriptor #0 for device 0, reading 18 of 64 requested bytes
@@ -21,14 +21,14 @@ At traffic row 0:
 + Getting configuration descriptor #0 for device 2, reading 9 bytes
 + Getting configuration descriptor #0 for device 2, reading 100 bytes
 + Getting string descriptor #0 for device 2, reading 4 of 255 requested bytes
-+ Getting string descriptor #2, language 0x0409 for device 2, reading 12 of 255 requested bytes: 'TiDAL'
-+ Getting string descriptor #1, language 0x0409 for device 2, reading 44 of 255 requested bytes: 'Electromagnetic Field'
-+ Getting string descriptor #3, language 0x0409 for device 2, reading 14 of 255 requested bytes: '123456'
++ Getting string descriptor #2, language 0x0409 (English/US) for device 2, reading 12 of 255 requested bytes: 'TiDAL'
++ Getting string descriptor #1, language 0x0409 (English/US) for device 2, reading 44 of 255 requested bytes: 'Electromagnetic Field'
++ Getting string descriptor #3, language 0x0409 (English/US) for device 2, reading 14 of 255 requested bytes: '123456'
 + Setting configuration 1 for device 2
-+ Getting string descriptor #4, language 0x0409 for device 2, reading 42 of 255 requested bytes: 'Espressif CDC Device'
++ Getting string descriptor #4, language 0x0409 (English/US) for device 2, reading 42 of 255 requested bytes: 'Espressif CDC Device'
 + Class request #32, index 0, value 0 for interface 2.0, writing 7 bytes
-+ Getting string descriptor #5, language 0x0409 for device 2, reading 24 of 255 requested bytes: 'TiDAL badge'
-+ Getting string descriptor #3, language 0x0409 for device 2, reading 14 of 255 requested bytes: '123456'
++ Getting string descriptor #5, language 0x0409 (English/US) for device 2, reading 24 of 255 requested bytes: 'TiDAL badge'
++ Getting string descriptor #3, language 0x0409 (English/US) for device 2, reading 14 of 255 requested bytes: '123456'
 + Class request #10, index 0, value 0 for interface 2.2
 + Getting unknown descriptor #0 for interface 2.2, reading 144 bytes
 + Class request #9, index 0, value 513 for interface 2.2, writing 2 bytes
@@ -152,7 +152,7 @@ At devices row 2:
 At devices row 1:
 - Device descriptor
 - Configuration 1
-Expanding traffic view, row 10: Getting string descriptor #2, language 0x0409 for device 1, reading 56 of 255 requested bytes: 'USB JTAG/serial debug unit\u{0}'
+Expanding traffic view, row 10: Getting string descriptor #2, language 0x0409 (English/US) for device 1, reading 56 of 255 requested bytes: 'USB JTAG/serial debug unit\u{0}'
 At traffic row 11:
 + SETUP transaction on 1.0 with 8 data bytes, ACK: [80, 06, 02, 03, 09, 04, FF, 00]
 + IN transaction on 1.0 with 56 data bytes, ACK: [38, 03, 55, 00, 53, 00, 42, 00, 20, 00, 4A, 00, 54, 00, 41, 00, 47, 00, 2F, 00, 73, 00, 65, 00, 72, 00, 69, 00, 61, 00, 6C, 00, 20, 00, 64, 00, 65, 00, 62, 00, 75, 00, 67, 00, 20, 00, 75, 00, 6E, 00, 69, 00, 74, 00, 00, 00]
@@ -193,7 +193,7 @@ At traffic row 34:
 - SETUP transaction on 2.0 with 8 data bytes, ACK: [00, 09, 01, 00, 00, 00, 00, 00]
 - 4 times: IN transaction on 2.0, NAK
 - IN transaction on 2.0 with no data, ACK
-Collapsing traffic view, row 10: Getting string descriptor #2, language 0x0409 for device 1, reading 56 of 255 requested bytes: 'USB JTAG/serial debug unit\u{0}'
+Collapsing traffic view, row 10: Getting string descriptor #2, language 0x0409 (English/US) for device 1, reading 56 of 255 requested bytes: 'USB JTAG/serial debug unit\u{0}'
 At traffic row 13:
 - IN packet on 1.0, CRC 1D
 - DATA1 packet with CRC 5EC0 and 56 data bytes: [38, 03, 55, 00, 53, 00, 42, 00, 20, 00, 4A, 00, 54, 00, 41, 00, 47, 00, 2F, 00, 73, 00, 65, 00, 72, 00, 69, 00, 61, 00, 6C, 00, 20, 00, 64, 00, 65, 00, 62, 00, 75, 00, 67, 00, 20, 00, 75, 00, 6E, 00, 69, 00, 74, 00, 00, 00]

--- a/tests/ui/mouse-step/reference.txt
+++ b/tests/ui/mouse-step/reference.txt
@@ -512,72 +512,72 @@ Updating after 132 packets decoded
 Updating after 133 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 0 of 255 requested bytes, incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 0 of 255 requested bytes, incomplete
 Updating after 134 packets decoded
 Updating after 135 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 0 of 255 requested bytes, incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 0 of 255 requested bytes, incomplete
 Updating after 136 packets decoded
 Updating after 137 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 0 of 255 requested bytes, incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 0 of 255 requested bytes, incomplete
 Updating after 138 packets decoded
 Updating after 139 packets decoded
 Updating after 140 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 8 of 255 requested bytes: 'USB', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 8 of 255 requested bytes: 'USB', incomplete
 Updating after 141 packets decoded
 Updating after 142 packets decoded
 Updating after 143 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 16 of 255 requested bytes: 'USB Opt', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 16 of 255 requested bytes: 'USB Opt', incomplete
 Updating after 144 packets decoded
 Updating after 145 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 16 of 255 requested bytes: 'USB Opt', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 16 of 255 requested bytes: 'USB Opt', incomplete
 Updating after 146 packets decoded
 Updating after 147 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 16 of 255 requested bytes: 'USB Opt', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 16 of 255 requested bytes: 'USB Opt', incomplete
 Updating after 148 packets decoded
 Updating after 149 packets decoded
 Updating after 150 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 24 of 255 requested bytes: 'USB Optical', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 24 of 255 requested bytes: 'USB Optical', incomplete
 Updating after 151 packets decoded
 Updating after 152 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 24 of 255 requested bytes: 'USB Optical', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 24 of 255 requested bytes: 'USB Optical', incomplete
 Updating after 153 packets decoded
 Updating after 154 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 24 of 255 requested bytes: 'USB Optical', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 24 of 255 requested bytes: 'USB Optical', incomplete
 Updating after 155 packets decoded
 Updating after 156 packets decoded
 Updating after 157 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 32 of 255 requested bytes: 'USB Optical Mou', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 32 of 255 requested bytes: 'USB Optical Mou', incomplete
 Updating after 158 packets decoded
 Updating after 159 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 32 of 255 requested bytes: 'USB Optical Mou', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 32 of 255 requested bytes: 'USB Optical Mou', incomplete
 Updating after 160 packets decoded
 Updating after 161 packets decoded
 Updating after 162 packets decoded
 At traffic row 29:
 - Incomplete control transfer on device 4
-+ Getting string descriptor #2, language 0x0409 for device 4, reading 36 of 255 requested bytes: 'USB Optical Mouse', incomplete
++ Getting string descriptor #2, language 0x0409 (English/US) for device 4, reading 36 of 255 requested bytes: 'USB Optical Mouse', incomplete
 Updating after 163 packets decoded
 Updating after 164 packets decoded
 At devices row 0:

--- a/tests/ui/mouse-step/reference.txt
+++ b/tests/ui/mouse-step/reference.txt
@@ -291,12 +291,12 @@ At devices row 2:
 + Length: 18 bytes
 + Type: 0x01
 + USB Version: 2.00
-+ Class: 0x00
++ Class: 0x00: (Defined at Interface level)
 + Subclass: 0x00
 + Protocol: 0x00
 + Max EP0 packet size: 8 bytes
-+ Vendor ID: 0x1BCF
-+ Product ID: 0x0005
++ Vendor ID: 0x1BCF: Sunplus Innovation Technology Inc.
++ Product ID: 0x0005: Optical Mouse
 + Version: 0.14
 + Manufacturer string: (none)
 + Product string: #2 (not seen)
@@ -462,9 +462,9 @@ At devices row 27:
 + Interface number: 0
 + Alternate setting: 0
 + Number of endpoints: 1
-+ Class: 0x03
-+ Subclass: 0x01
-+ Protocol: 0x02
++ Class: 0x03: Human Interface Device
++ Subclass: 0x01: Boot Interface Subclass
++ Protocol: 0x02: Mouse
 + Interface string: (none)
 Expanding devices view, row 36: Endpoint 1 IN
 At devices row 37:
@@ -615,9 +615,9 @@ At devices row 19:
 - Interface number: 0
 - Alternate setting: 0
 - Number of endpoints: 1
-- Class: 0x03
-- Subclass: 0x01
-- Protocol: 0x02
+- Class: 0x03: Human Interface Device
+- Subclass: 0x01: Boot Interface Subclass
+- Protocol: 0x02: Mouse
 - Interface string: (none)
 At devices row 20:
 - Length: 7 bytes
@@ -637,12 +637,12 @@ At devices row 2:
 - Length: 18 bytes
 - Type: 0x01
 - USB Version: 2.00
-- Class: 0x00
+- Class: 0x00: (Defined at Interface level)
 - Subclass: 0x00
 - Protocol: 0x00
 - Max EP0 packet size: 8 bytes
-- Vendor ID: 0x1BCF
-- Product ID: 0x0005
+- Vendor ID: 0x1BCF: Sunplus Innovation Technology Inc.
+- Product ID: 0x0005: Optical Mouse
 - Version: 0.14
 - Manufacturer string: (none)
 - Product string: #2 (not seen)


### PR DESCRIPTION
I spotted that someone had written [this Rust crate](https://crates.io/crates/usb-ids) for the [Linux USB ID database](http://www.linux-usb.org/usb-ids.html), which gets us some easy quality of life improvements with very little code, e.g:

Recognition of vendor IDs, product IDs, and class/subclass/protocol values as seen in device and interface descriptors:

![image](https://github.com/user-attachments/assets/095323a6-df5e-40c5-bff2-c5ab7bd36eda)

Recognition of language IDs in string descriptor requests:

![image](https://github.com/user-attachments/assets/8a5029e7-1660-4ce2-9d8a-90978ab3d340)

This should also be helpful when we come to interpreting HID descriptors and traffic.

The crate used is under the MIT license, and the usb.ids database is under LGPL _or_ BSD-3-Clause.