### PR TITLE
Fixes for `gio::File` usage

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -877,7 +877,8 @@ fn start_pcap(action: FileAction, file: gio::File) -> Result<(), Error> {
                 TOTAL.store(packet_count, Ordering::Relaxed);
                 CURRENT.store(0, Ordering::Relaxed);
                 let dest = file
-                    .create(FileCreateFlags::NONE, Cancellable::NONE)?
+                    .replace(
+                        None, false, FileCreateFlags::NONE, Cancellable::NONE)?
                     .into_write();
                 let mut writer = Writer::open(dest)?;
                 for i in 0..packet_count {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -889,10 +889,12 @@ fn load_pcap(file: gio::File, writer: CaptureWriter) -> Result<(), Error> {
     let info = file.query_info("standard::*",
                                FileQueryInfoFlags::NONE,
                                Cancellable::NONE)?;
-    let file_size = info.size() as u64;
+    if info.has_attribute(gio::FILE_ATTRIBUTE_STANDARD_SIZE) {
+        let file_size = info.size() as u64;
+        TOTAL.store(file_size, Ordering::Relaxed);
+    }
     let source = file.read(Cancellable::NONE)?.into_read();
     let mut loader = Loader::open(source)?;
-    TOTAL.store(file_size, Ordering::Relaxed);
     let mut decoder = Decoder::new(writer)?;
     #[cfg(feature="step-decoder")]
     let (mut client, _addr) =

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -838,6 +838,9 @@ fn start_pcap(action: FileAction, file: gio::File) -> Result<(), Error> {
         ui.vbox.insert_child_after(&ui.separator, Some(&ui.paned));
         ui.vbox.insert_child_after(&ui.progress_bar, Some(&ui.separator));
         ui.show_progress = Some(action);
+        ui.file_name = file
+            .basename()
+            .map(|path| path.to_string_lossy().to_string());
         let capture = ui.capture.clone();
         std::thread::spawn(move || {
             display_error(match action {


### PR DESCRIPTION
Followup to these two PRs:
- #141
- #148

Changes in this PR:
- Use `replace` rather than `create` when saving files.
  - Fixes #152.
- Move UI save and load routines into separate functions rather than one big closure (cleanup).
- Use the `basename` method to get a filename from a `gio::File` to show in the status bar, without relying on IO.
  - Updating the status bar filename was disabled in #148.
- Fix GTK warnings due to invalid progress bar updates, when file size not yet known.
  - This allows loading a file from an HTTPS URL to work cleanly.
- Cancel blocking `gio::File` operations if load/save is stopped by UI.