### PR TITLE
CI: Enable rust caching for Windows, if vcpkg dependencies unchanged.

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -137,12 +137,12 @@ jobs:
           mv /home/runner/.nvm     $HOME
           mv /home/runner/.rustup  $HOME
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Install toolchain
         run: |
           rustup toolchain install stable
           rustup default stable
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build packetry binary
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,12 +23,12 @@ jobs:
           packages: libgtk-4-dev build-essential
           version: 2
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Install toolchain
         run: |
           rustup toolchain install stable
           rustup default stable
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
         run: cargo clippy -- --deny warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
+      VCPKG_COMMIT: 01f602195983451bc83e72f4214af2cbc495aa94 # 2024.05.24 release
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg/installed
 
     steps:
@@ -53,6 +54,11 @@ jobs:
         run: |
           rustup toolchain install ${{ matrix.rust }}
           rustup default ${{ matrix.rust }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: VCPKG_COMMIT
+        if: runner.os == 'Windows'
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
@@ -79,7 +85,7 @@ jobs:
       - name: Install dependencies (Windows)
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 01f602195983451bc83e72f4214af2cbc495aa94 # 2024.05.24 release
+          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
           runVcpkgInstall: true
           doNotCache: false
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
We had previously disabled the `rust-cache` action, because it could cause problems on macOS builds, where the latest GTK and dependencies are installed from Homebrew and it was possible for the cached Rust crate builds to end up pointing to library install paths that were no longer valid in the latest Homebrew install.

However, Windows is currently our slowest build platform, and our non-Rust dependency versions are fixed there by our choice of vcpkg commit ID, so by using this as a key to the rust-cache action, we can cache safely.

This cuts the Windows build time from 9m33s to 4m20s. Which is still the longest (Linux & macOS are around 3 mins each), but much less annoying.