### PR TITLE
ui: Add bulk/int/iso/cntl type to endpoint summary info

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1637,12 +1637,12 @@ impl ItemSource<DeviceItem> for CaptureReader {
                 interface.descriptor.field_text(*field, strings.as_ref())
             },
             EndpointDescriptor(dev, conf, iface, ep) => {
-                let addr = self.device_data(dev)?
-                               .configuration(conf)?
-                               .interface(iface)?
-                               .endpoint_descriptor(ep)?
-                               .endpoint_address;
-                format!("Endpoint {} {}", addr.number(), addr.direction())
+                let config = self.device_data(dev)?.configuration(conf)?;
+                let desc = config.interface(iface)?.endpoint_descriptor(ep)?;
+                let addr = desc.endpoint_address;
+                let attrs = desc.attributes;
+                format!("Endpoint {} {} ({})", addr.number(),
+                   addr.direction(), attrs.endpoint_type())
             },
             EndpointDescriptorField(dev, conf, iface, ep, field, _ver) => {
                 self.device_data(dev)?

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -214,6 +214,17 @@ pub enum EndpointType {
     Interrupt   = 3,
 }
 
+impl std::fmt::Display for EndpointType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Control => write!(f, "control"),
+            Self::Isochronous => write!(f, "isochronous"),
+            Self::Bulk => write!(f, "bulk"),
+            Self::Interrupt => write!(f, "interrupt"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Default, Pod, Zeroable)]
 #[repr(C)]
 pub struct BCDVersion {

--- a/tests/ui/emf2022-badge/reference.txt
+++ b/tests/ui/emf2022-badge/reference.txt
@@ -71,17 +71,17 @@ At devices row 16:
 Expanding devices view, row 17: Interface 0
 At devices row 18:
 + Interface descriptor
-+ Endpoint 2 IN
++ Endpoint 2 IN (interrupt)
 Expanding devices view, row 20: Interface 1
 At devices row 21:
 + Interface descriptor
-+ Endpoint 1 OUT
-+ Endpoint 1 IN
++ Endpoint 1 OUT (bulk)
++ Endpoint 1 IN (bulk)
 Expanding devices view, row 24: Interface 2
 At devices row 25:
 + Interface descriptor
-+ Endpoint 2 OUT
-+ Endpoint 3 IN
++ Endpoint 2 OUT (bulk)
++ Endpoint 3 IN (bulk)
 Expanding devices view, row 28: Device 2: TiDAL
 At devices row 29:
 + Device descriptor
@@ -95,13 +95,13 @@ At devices row 31:
 Expanding devices view, row 34: Interface 2
 At devices row 35:
 + Interface descriptor
-+ Endpoint 3 IN
++ Endpoint 3 IN (interrupt)
 Expanding devices view, row 33: Interface 1
 At devices row 34:
 + Interface descriptor
-+ Endpoint 2 OUT
-+ Endpoint 2 IN
-Expanding devices view, row 35: Endpoint 2 OUT
++ Endpoint 2 OUT (bulk)
++ Endpoint 2 IN (bulk)
+Expanding devices view, row 35: Endpoint 2 OUT (bulk)
 At devices row 36:
 + Length: 7 bytes
 + Type: 0x05
@@ -109,7 +109,7 @@ At devices row 36:
 + Attributes: 0x02
 + Max packet size: 64 bytes
 + Interval: 0x00
-Expanding devices view, row 42: Endpoint 2 IN
+Expanding devices view, row 42: Endpoint 2 IN (bulk)
 At devices row 43:
 + Length: 7 bytes
 + Type: 0x05
@@ -120,15 +120,15 @@ At devices row 43:
 Collapsing devices view, row 15: Configuration 1
 At devices row 18:
 - Interface descriptor
-- Endpoint 2 IN
+- Endpoint 2 IN (interrupt)
 At devices row 19:
 - Interface descriptor
-- Endpoint 1 OUT
-- Endpoint 1 IN
+- Endpoint 1 OUT (bulk)
+- Endpoint 1 IN (bulk)
 At devices row 20:
 - Interface descriptor
-- Endpoint 2 OUT
-- Endpoint 3 IN
+- Endpoint 2 OUT (bulk)
+- Endpoint 3 IN (bulk)
 At devices row 16:
 - Configuration descriptor
 - Interface 0
@@ -230,11 +230,11 @@ At devices row 10:
 - Interval: 0x00
 At devices row 7:
 - Interface descriptor
-- Endpoint 2 OUT
-- Endpoint 2 IN
+- Endpoint 2 OUT (bulk)
+- Endpoint 2 IN (bulk)
 At devices row 8:
 - Interface descriptor
-- Endpoint 3 IN
+- Endpoint 3 IN (interrupt)
 At devices row 4:
 - Configuration descriptor
 - Interface 0

--- a/tests/ui/mouse-step/reference.txt
+++ b/tests/ui/mouse-step/reference.txt
@@ -454,7 +454,7 @@ At devices row 25:
 Expanding devices view, row 25: Interface 0
 At devices row 26:
 + Interface descriptor
-+ Endpoint 1 IN
++ Endpoint 1 IN (interrupt)
 Expanding devices view, row 26: Interface descriptor
 At devices row 27:
 + Length: 9 bytes
@@ -466,7 +466,7 @@ At devices row 27:
 + Subclass: 0x01: Boot Interface Subclass
 + Protocol: 0x02: Mouse
 + Interface string: (none)
-Expanding devices view, row 36: Endpoint 1 IN
+Expanding devices view, row 36: Endpoint 1 IN (interrupt)
 At devices row 37:
 + Length: 7 bytes
 + Type: 0x05
@@ -628,7 +628,7 @@ At devices row 20:
 - Interval: 0x0A
 At devices row 18:
 - Interface descriptor
-- Endpoint 1 IN
+- Endpoint 1 IN (interrupt)
 At devices row 16:
 - Configuration descriptor
 - Interface 0


### PR DESCRIPTION
The Endpoint summary line in the Interface descriptor list currently contains the address and direction data:

  Endpoint 3 IN

This change adds the endpoint type too, as derived from the attribute data:

  Endpoint 3 BULK IN

\- by defining std::fmt::Display for EndpointType, and using that in the summary data.