### PR TITLE
HITL test fixes

### DIFF
--- a/src/test_cynthion.rs
+++ b/src/test_cynthion.rs
@@ -104,7 +104,7 @@ fn test(save_capture: bool,
     if save_capture {
         // Write the capture to a file.
         let path = PathBuf::from(format!("./HITL-{name}.pcap"));
-        let file = File::open(path)?;
+        let file = File::create(path)?;
         let mut writer = Writer::open(file)?;
         for i in 0..reader.packet_index.len() {
             let packet_id = PacketId::from(i);

--- a/src/test_cynthion.rs
+++ b/src/test_cynthion.rs
@@ -151,7 +151,7 @@ fn test(save_capture: bool,
             for id in range.start.value..range.end.value {
                 let packet_id = PacketId::from(id);
                 let timestamp = reader.packet_times.get(packet_id)?;
-                if let Some(prev) = last {
+                if let Some(prev) = last.replace(timestamp) {
                     let interval = timestamp - prev;
                     if !(interval > min_interval && interval < max_interval) {
                         if interval > 10000000 {
@@ -164,7 +164,6 @@ fn test(save_capture: bool,
                     }
                 }
                 sof_count += 1;
-                last = Some(timestamp);
             }
         }
         println!("Found {} SOF packets with expected interval range", sof_count);


### PR DESCRIPTION
Fixes some bugs in the HITL test:

- The `--save-captures` option was broken due to calling `File::open` rather than `File::create`.
    - Fixes #158.
- Due to a bug in the SOF checking loop, only SOF packets up to the first bus reset were being counted.
- We were only checking for a small minimum of SOF packets. Calculate what range we should actually expect.
- Handle failures cleanly rather than panicking.
- Ensure that capture is stopped cleanly if test device access fails.