### PR TITLE
Use 24-bit rather than 16-bit increments for timestamps.

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -35,7 +35,7 @@ pub struct CaptureWriter {
     pub shared: Arc<CaptureShared>,
     pub packet_data: DataWriter<u8, PACKET_DATA_BLOCK_SIZE>,
     pub packet_index: CompactWriter<PacketId, PacketByteId, 2>,
-    pub packet_times: CompactWriter<PacketId, Timestamp, 2>,
+    pub packet_times: CompactWriter<PacketId, Timestamp, 3>,
     pub transaction_index: CompactWriter<TransactionId, PacketId>,
     pub transfer_index: DataWriter<TransferIndexEntry>,
     pub item_index: CompactWriter<TrafficItemId, TransferId>,


### PR DESCRIPTION
Using 16-bit deltas (2 bytes) in `CompactIndex` is a poor fit for nanosecond timestamp data, and causes the index to write a lot of blocks each time the delta range overflows, which also makes access inefficient. This is most noticeable when saving a capture, which requires reading all timestamps.

Using 24-bit deltas (3 bytes) works a lot better. I also tried 32-bit (4 bytes) but didn't see much difference in performance.

Fixes #169.