### PR TITLE
Implement iterators for our stream types, and use for faster saving

### DIFF
--- a/src/compact_index.rs
+++ b/src/compact_index.rs
@@ -231,8 +231,8 @@ where
         let mut values = Vec::with_capacity(total_count);
         // Determine which segments we need to read from.
         let first = self.segment_start_reader.bisect_right(&range.start)? - 1;
-        let last = self.segment_start_reader.bisect_left(&range.end)? - 1;
-        let seg_range = first..(last + 1);
+        let last = self.segment_start_reader.bisect_left(&range.end)?;
+        let seg_range = first..last;
         let segment_starts = self.segment_start_reader.get_range(&seg_range)?;
         let base_values = self.segment_base_reader.get_range(&seg_range)?;
         let data_offsets = self.segment_offset_reader.get_range(&seg_range)?;
@@ -436,7 +436,7 @@ mod tests {
 
     #[test]
     fn test_compact_index() {
-        let (mut writer, mut reader) = index_stream().unwrap();
+        let (mut writer, mut reader) = compact_index::<_, _, 1>().unwrap();
         let mut expected = Vec::<Id<u8>>::new();
         let mut x = 10;
         let n = 4321;

--- a/src/index_stream.rs
+++ b/src/index_stream.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 
 use anyhow::Error;
 
-use crate::data_stream::{data_stream, DataReader, DataWriter};
+use crate::data_stream::{data_stream, DataReader, DataWriter, DataIterator};
 use crate::id::Id;
 use crate::stream::MIN_BLOCK;
 use crate::util::{fmt_count, fmt_size};
@@ -20,6 +20,12 @@ pub struct IndexWriter<Position, Value, const S: usize = MIN_BLOCK> {
 pub struct IndexReader<Position, Value, const S: usize = MIN_BLOCK> {
     marker: PhantomData<(Position, Value)>,
     data_reader: DataReader<u64, S>,
+}
+
+/// Iterator over values in an index.
+pub struct IndexIterator<Position, Value, const S: usize = MIN_BLOCK> {
+    marker: PhantomData<(Position, Value)>,
+    data_iterator: DataIterator<u64, S>,
 }
 
 type IndexPair<P, V> = (IndexWriter<P, V>, IndexReader<P, V>);
@@ -64,7 +70,7 @@ where Position: From<u64>, Value: Into<u64>
     }
 }
 
-impl<Position, Value> IndexReader<Position, Value>
+impl<Position, Value, const S: usize> IndexReader<Position, Value, S>
 where Position: Copy + From<u64> + Into<u64>,
       Value: Copy + From<u64> + Into<u64> + Ord
 {
@@ -94,6 +100,18 @@ where Position: Copy + From<u64> + Into<u64>,
         let data = self.data_reader.get_range(&(start..end))?;
         let values = data.into_iter().map(Value::from).collect();
         Ok(values)
+    }
+
+    /// Create an iterator over values in the index.
+    pub fn iter(&self, range: &Range<Position>)
+        -> IndexIterator<Position, Value, S>
+    {
+        let start = Id::<u64>::from(range.start.into());
+        let end = Id::<u64>::from(range.end.into());
+        IndexIterator {
+            marker: PhantomData,
+            data_iterator: self.data_reader.iter(&(start..end)),
+        }
     }
 
     /// Get the range of values between the specified position and the next.
@@ -251,6 +269,22 @@ where Position: From<u64>, Value: Into<u64>
     }
 }
 
+impl<Position, Value, const S: usize>
+std::iter::Iterator for IndexIterator<Position, Value, S>
+where Value: From<u64>
+{
+    type Item = Result<Value, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.data_iterator.next() {
+            Some(Ok(value)) => Some(Ok(Value::from(value))),
+            Some(Err(err)) => Some(Err(err)),
+            None => None,
+        }
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -281,6 +315,11 @@ mod tests {
             let vr = reader.get_range(&vrng).unwrap();
             let xr = &expected[xrng];
             assert!(vr == xr);
+            let ir = reader
+                .iter(&vrng)
+                .collect::<Result<Vec<Id<u8>>, Error>>()
+                .unwrap();
+            assert!(ir == xr);
         }
         let start = Id::<Id<u8>>::from(0 as u64);
         for i in 0..n {
@@ -290,6 +329,11 @@ mod tests {
             let vr = reader.get_range(&vrng).unwrap();
             let xr = &expected[xrng];
             assert!(vr == xr);
+            let ir = reader
+                .iter(&vrng)
+                .collect::<Result<Vec<Id<u8>>, Error>>()
+                .unwrap();
+            assert!(ir == xr);
         }
         for i in 0..(n - 10) {
             let start = Id::<Id<u8>>::from(i as u64);
@@ -299,6 +343,11 @@ mod tests {
             let vr = reader.get_range(&vrng).unwrap();
             let xr = &expected[xrng];
             assert!(vr == xr);
+            let ir = reader
+                .iter(&vrng)
+                .collect::<Result<Vec<Id<u8>>, Error>>()
+                .unwrap();
+            assert!(ir == xr);
         }
         for i in 0..n {
             let id = Id::<Id<u8>>::from(i);

--- a/src/index_stream.rs
+++ b/src/index_stream.rs
@@ -23,7 +23,9 @@ pub struct IndexReader<Position, Value, const S: usize = MIN_BLOCK> {
 }
 
 /// Iterator over values in an index.
-pub struct IndexIterator<Position, Value, const S: usize = MIN_BLOCK> {
+pub struct IndexIterator<Position, Value, const S: usize = MIN_BLOCK>
+where Position: From<u64>
+{
     marker: PhantomData<(Position, Value)>,
     data_iterator: DataIterator<u64, S>,
 }
@@ -271,7 +273,7 @@ where Position: From<u64>, Value: Into<u64>
 
 impl<Position, Value, const S: usize>
 std::iter::Iterator for IndexIterator<Position, Value, S>
-where Value: From<u64>
+where Position: From<u64>, Value: From<u64>
 {
     type Item = Result<Value, Error>;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -54,7 +54,7 @@ pub struct StreamReader<const S: usize = MIN_BLOCK> {
 }
 
 /// Data that is part of a stream and currently in memory.
-struct Buffer<const S: usize> {
+pub struct Buffer<const S: usize> {
     /// Block to which this data belongs.
     block_base: u64,
     /// Raw pointer to space allocated to hold the data.
@@ -62,7 +62,7 @@ struct Buffer<const S: usize> {
 }
 
 /// A read-only handle to any data that is part of a stream.
-enum Data<const S: usize> {
+pub enum Data<const S: usize> {
     /// Data in the file, accessed through a mapping.
     Mapped(Arc<Mmap>, Range<usize>),
     /// Data in memory, accessed within a buffer.
@@ -257,7 +257,7 @@ impl<const BLOCK_SIZE: usize> StreamReader<BLOCK_SIZE> {
     /// requested length. The method may be called again to access further data.
     ///
     pub fn access(&mut self, range: &Range<u64>)
-        -> Result<impl Deref<Target=[u8]>, Error>
+        -> Result<Data<BLOCK_SIZE>, Error>
     {
         use Data::*;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -71,7 +71,6 @@ use crate::capture::{
     ItemSource,
     TrafficItem,
     DeviceItem,
-    PacketId,
 };
 use crate::decoder::Decoder;
 use crate::expander::ExpanderWrapper;
@@ -1004,10 +1003,8 @@ fn save_pcap(file: gio::File,
         .replace(None, false, FileCreateFlags::NONE, Some(&cancel_handle))?
         .into_write();
     let mut writer = Writer::open(dest)?;
-    for i in 0..packet_count {
-        let packet_id = PacketId::from(i);
-        let packet = capture.packet(packet_id)?;
-        let timestamp_ns = capture.packet_time(packet_id)?;
+    for (result, i) in capture.timestamped_packets()?.zip(0..packet_count) {
+        let (timestamp_ns, packet) = result?;
         writer.add_packet(&packet, timestamp_ns)?;
         CURRENT.store(i + 1, Ordering::Relaxed);
         if STOP.load(Ordering::Relaxed) {


### PR DESCRIPTION
Followup to #169 and #170.

Implements efficient iterators for our stream and index types, and uses them to iterate over timestamps and packets when saving a file.

For my test file of 371MB (3.5 million packets, 1.5 million transactions), this reduces save time from 4 seconds to 1.7 seconds, a speedup of **2.35x**.

This puts save speed almost on par with load speed.