### PR TITLE
Add libharfbuzz to Linux AppImage

### DIFF
--- a/appimage/action.yml
+++ b/appimage/action.yml
@@ -44,6 +44,14 @@ runs:
         rm -f libxcb-render*
         rm -f libzstd*
 
+        # add libharfbuzz even though we don't link to it directly as
+        # some systems will attempt to dlopen(3) its own version if it
+        # is not present
+        cp -a /opt/gtk-*/lib/x86_64-linux-gnu/libharfbuzz.* .
+        cp -a /opt/gtk-*/lib/x86_64-linux-gnu/libharfbuzz-gobject.* .
+        cp -a /opt/gtk-*/lib/x86_64-linux-gnu/libharfbuzz-icu.* .
+        cp -a /opt/gtk-*/lib/x86_64-linux-gnu/libharfbuzz-subset.* .
+
         # remove duplicate library files and replace with symlinks
         fdupes --sameline --order=name . | while read -r lib ; do
             src=$(echo $lib | rev | cut -d' ' -f1 | rev)

--- a/appimage/packetry.AppDir/usr/share/doc/libharfbuzz-gobject0/copyright
+++ b/appimage/packetry.AppDir/usr/share/doc/libharfbuzz-gobject0/copyright
@@ -1,0 +1,708 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: HarfBuzz
+Upstream-Contact: Behdad Esfahbod
+Source: https://www.freedesktop.org/wiki/Software/HarfBuzz
+
+Files: *
+Copyright: 2018-2020, Adobe, Inc
+           2005-2023, Behdad Esfahbod
+           2007, Chris Wilson
+           2011, Codethink Limited
+           2005, David Turner
+           1998-2004, David Turner and Werner Lemberg
+           2015-2020, Ebrahim Byagowi
+           2016, Elie Roux
+           2019-2020, Facebook, Inc
+           2010-2023, Google, Inc
+           2016, Igalia S.L
+           2009, Keith Stribley
+           2018-2021, Khaled Hosny
+           2011, Martin Hosken and SIL International
+           2022, Matthias Clasen
+           2012-2015, Mozilla Foundation
+           2008-2010, Nokia Corporation and/or its subsidiary(-ies)
+           1998-2023, Red Hat, Inc
+           2013-2015, Alexei Podtelezhnikov
+           2012 Zilong Tan <eric.zltan@gmail.com>
+License: MIT
+
+Files: debian/*
+Copyright: 2012-2019,2023, أحمد المحمودي (Ahmed El-Mahmoudy) <aelmahmoudy@users.sourceforge.net>
+License: MIT
+
+Files: src/hb-unicode-emoji-table.hh
+Copyright: 2022, Unicode®, Inc
+License: Unicode
+Comment: https://www.unicode.org/terms_of_use.html
+
+Files: src/hb-ucd.cc
+Copyright: 2012, Grigori Goronzy <greg@kinoho.net>
+License: ISC
+
+Files: test/shape/data/text-rendering-tests/*
+Copyright: 2016, Unicode Inc
+License: Apache-2.0
+
+Files: perf/fonts/Amiri-Regular.ttf
+       perf/fonts/NotoNastaliqUrdu-Regular.ttf
+       test/api/fonts/*
+       test/fuzzing/fonts/*
+       test/shape/data/text-rendering-tests/fonts/*
+Copyright: 2002-2018, Adobe Systems Incorporated
+           2017-2019, Amin Abedi (@aminabedi68)-www.fontamin.com
+           2015, Cadson Demak <info@cadsondemak.com>
+           2011-2020, Google Inc
+           2016, Igalia S.L. (http://igalia.com/)
+           2017, Jens Kutilek
+           2010-2017, Khaled Hosny <khaledhosny@eglug.org>
+           2016, Sascha Brawer
+           2010, Sebastian Kosch <sebastian@aldusleaf.org>
+           2008, The Bungee Project Authors <david@djr.com>
+           1993-2016, The Font Bureau, Inc
+           2016, The M+ Project Authors
+           2021, The Qahiri Project Authors (github.com/aliftype/qahiri)
+           2016-2019, Unicode, Inc
+License: OFL-1.1
+
+Files: test/shape/data/in-house/fonts/*
+Copyright: 2000-2016, Adobe Systems Incorporated
+           2016, Alfredo Marco Pradil
+           2018-2022, David Corbett
+           2010-2022, Google, Inc
+           2011-2012, Lohit Fonts Project contributors <https://pagure.io/lohit>
+           2013-2020, Microsoft Corporation
+           2018, SIL International (http://scripts.sil.org)
+           2010-2021, The Amiri Project Authors (https://github.com/aliftype/amiri)
+           2015-2021, The Mada Project Authors
+           2021, The Qahiri Project Authors (github.com/aliftype/qahiri)
+           2021, The Raqq Project Authors (github.com/aliftype/raqq)
+           2018, Unicode, Inc
+           2005, Zawgyi.net & Alpha Mandalay
+License: OFL-1.1
+
+Files: test/subset/data/*
+Copyright: 2002-2018, Adobe Systems Incorporated (http://www.adobe.com/)
+           2012, Andhrapradesh Society for Knowledge Networks (fonts.siliconandhra.org)
+           2013, Danh Hong (khmertype.org)
+           2007, Denis Moyogo Jacquerye <moyogo@gmail.com>
+           2011-2012, George W. Nuss (http://www.fulbefouta.com)
+           2010-2016, Google Inc
+           2011, Hjort Nidudsson
+           2019, Inter IKEA Systems B.V. (www.ikea.com)
+           2010, NHN Corporation
+           2011-2012, Sorkin Type Co (www.sorkintype.com)
+           2013, The Alegreya Sans Project Authors (https://github.com/huertatipografica/Alegreya-Sans)
+           2010-2020, The Amiri Project Authors (https://github.com/alif-type/amiri)
+           2008, The Bungee Project Authors <david@djr.com>
+           2007-2008, The C&MA Guinea Fulbe Team
+           2011, The Comfortaa Project Authors (https://github.com/alexeiva/comfortaa)
+           2020, The Fraunces Project Authors (github.com/undercasetype/Fraunces)
+           2016, The M+ Project Authors
+           2021, The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS)
+           2019, The Noto Project Authors (github. com/googlei18n/noto-fonts)
+           2017, The Roboto Flex Project Authors (https://github.com/TypeNetwork/Roboto-Flex)
+           2004-2020, SIL International (http://www.sil.org)
+           2017, The Spectral Project Authors (http://github.com/productiontype/spectral)
+           2001-2021, The STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
+License: OFL-1.1
+
+Files: test/shape/data/aots/*
+Copyright: 2000-2016, Adobe Systems Incorporated
+License: Apache-2.0
+
+Files: perf/fonts/Roboto-Regular.ttf
+       test/api/fonts/nameID.origin.ttf
+       test/api/fonts/nameID.override.expected.ttf
+       test/api/fonts/OpenSans-Regular.ttf
+       test/shape/data/text-rendering-tests/fonts/TestShapeKndaV3.ttf
+       test/subset/data/fonts/Tinos-Italic.ttf
+       test/subset/data/fonts/IndicTestHowrah-Regular.ttf
+       test/subset/data/fonts/IndicTestJalandhar-Regular.ttf
+       test/subset/data/fonts/Roboto-Regular.ttf
+       test/subset/data/fonts/Roboto-Variable.ttf
+Copyright: 2010-2013, Google Corporation
+License: Apache-2.0
+
+Files: test/shape/data/in-house/fonts/e8691822f6a705e3e9fb48a0405c645b1a036590.ttf
+Copyright: 2020, Fredrick R. Brennan
+License: Apache-2.0
+
+Files: test/subset/data/fonts/Khmer.ttf
+Copyright: 2013, Danh Hong (khmertype.org)
+License: Apache-2.0
+
+Files: test/api/fonts/TestGVAREight.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVAREight.ttf
+Copyright: 1992-2017, Thomas A. Rickner
+License: Apache-2.0
+Comment: License mismatch resolved: https://github.com/harfbuzz/harfbuzz/issues/4062
+
+Files: test/api/fonts/TestGVAROne.ttf
+       test/api/fonts/TestGVARThree.ttf
+       test/api/fonts/TestGVARTwo.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVAROne.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVARThree.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVARTwo.ttf
+Copyright: 2016, Monotype Hong Kong Ltd. and Monotype Imaging Inc
+License: Monotype
+
+Files: test/shape/data/in-house/fonts/074a5ae6b19de8f29772fdd5df2d3d833f81f5e6.ttf
+       test/shape/data/in-house/fonts/1a3d8f381387dd29be1e897e4b5100ac8b4829e1.ttf
+       test/shape/data/in-house/fonts/b151cfcdaa77585d77f17a42158e0873fc8e2633.ttf
+       test/shape/data/in-house/fonts/d9b8bc10985f24796826c29f7ccba3d0ae11ec02.ttf
+Copyright: 2017, David Corbett
+License: CC0-1.0
+
+Files: test/shape/data/in-house/fonts/b722a7d09e60421f3efbc706ad348ab47b88567b.ttf
+Copyright: 2005, Mihail Bayaryn
+License: GPL-3+
+
+Files: test/shape/data/in-house/fonts/b895f8ff06493cc893ec44de380690ca0074edfa.ttf
+Copyright: 2009-2010, Yoram Gnat (yoram.gnat@gmail.com)
+           2003-2007, Ralph Hancock & John Hudson
+License: GPL-2+ with Font exception
+
+Files: test/shape/data/in-house/fonts/DFONT.dfont
+       test/shape/data/in-house/fonts/TTC.ttc
+Copyright: 2015, FontTools
+License: MIT
+Comment: https://github.com/fonttools/fonttools/blob/main/LICENSE
+
+Files: test/subset/data/expected/glyph_names/*
+       test/subset/data/fonts/Ubuntu-Regular.ttf
+Copyright: 2011, Canonical Ltd.
+License: UFL-1.0
+
+Files: aclocal.m4
+       Makefile.in
+       m4/*
+       docs/Makefile.in
+       perf/Makefile.in
+       src/Makefile.in
+       test/Makefile.in
+       test/api/Makefile.in
+       test/fuzzing/Makefile.in
+       test/shape/Makefile.in
+       test/shape/data/Makefile.in
+       test/shape/data/aots/Makefile.in
+       test/shape/data/in-house/Makefile.in
+       test/shape/data/text-rendering-tests/Makefile.in
+       test/subset/Makefile.in
+       test/subset/data/Makefile.in
+       test/subset/data/repack_tests/Makefile.in
+       test/threads/Makefile.in
+       util/Makefile.in
+Copyright: 1994-2018, Free Software Foundation, Inc
+           2004-2007, Damon Chaplin
+           2012-2015, Dan Nicholson <dbn.lists@gmail.com>
+           2003, James Henstridge
+           2009, Johan Dahlin
+           2004, Scott James Remnant <scott@netsplit.com>
+           2007-2017, Stefan Sauer
+           2003-2005, Thomas Vander Stichele <thomas@apestaart.org>
+License: FSFULLR
+
+Files: ar-lib
+       compile
+       depcomp
+       missing
+       test-driver
+Copyright: 1996-2018, Free Software Foundation, Inc
+License: GPL-2+ with AutoConf exception
+
+Files: config.guess
+       config.sub
+Copyright: 1992-2018, Free Software Foundation, Inc
+License: GPL-3+ with AutoConf exception
+
+Files: m4/ax_cxx_compile_stdcxx.m4
+Copyright: 2008, Benjamin Kosnik <bkoz@redhat.com>
+           2014-2015, Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+           2016, Krzesimir Nowak <qdlacz@gmail.com>
+           2015, Moritz Klammler <moritz@klammler.eu>
+           2015, Paul Norman <penorman@mac.com>
+           2013, Roy Stogner <roystgnr@ices.utexas.edu>
+           2012, Zack Weinberg <zackw@panix.com>
+License: FSFAP
+
+Files: m4/ax_code_coverage.m4
+Copyright: 2015, Bastien ROUCARIES
+           2012, Christian Persch
+           2012, Dan Winship
+           2012, Paolo Borelli
+           2012-2016, Philip Withnall
+           2012, Xan Lopez
+License: LGPL-2.1+
+
+Files: ltmain.sh
+Copyright: 1996-2015, Free Software Foundation, Inc
+License: GPL-2+ with LibTool exception
+
+Files: gtk-doc.make
+Copyright: 2004-2007, Damon Chaplin
+           2003, James Henstridge
+           2007-2017, Stefan Sauer
+License: GPL-3+
+
+Files: m4/ax_check_link_flag.m4
+Copyright: 2008, Guido U. Draheim <guidod@gmx.de>
+           2011, Maarten Bosmans <mkbosmans@gmail.com>
+License: GPL-3+ with AutoConf exception
+
+Files: m4/gtk-doc.m4
+Copyright: 2003, James Henstridge
+           2007-2017, Stefan Sauer
+License: GPL-3+
+
+Files: m4/ax_pthread.m4
+Copyright: 2011, Daniel Richard G <skunk@iSKUNK.ORG>
+           2008, Steven G. Johnson <stevenj@alum.mit.edu>
+License: GPL-3+ with AutoConf exception
+
+Files: install-sh
+Copyright: 1994, X Consortium
+License: Expat
+
+Files: INSTALL
+Copyright: 1994-2016, Free Software
+License: FSFAP
+
+Files: configure
+Copyright: 1992-2014, Free Software Foundation, Inc
+License: FSFUL
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+  http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License
+ can be found in the file `/usr/share/common-licenses/Apache-2.0'.
+
+License: CC0-1.0
+ On Debian systems, the text of the CC0 1.0 Universal license can be
+ found in ‘/usr/share/common-licenses/CC0-1.0’.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to
+ deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNEC-
+ TION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ .
+ Except as contained in this notice, the name of the X Consortium shall not
+ be used in advertising or otherwise to promote the sale, use or other deal-
+ ings in this Software without prior written authorization from the X Consor-
+ tium.
+
+License: FSFAP
+ Copying and distribution of this file, with or without modification, are
+ permitted in any medium without royalty provided the copyright notice
+ and this notice are preserved.  This file is offered as-is, without any
+ warranty.
+
+License: FSFUL
+ This script is free software; the Free Software Foundation
+ gives unlimited permission to copy, distribute and modify it.
+
+License: FSFULLR
+ This file is free software; the Free Software Foundation
+ gives unlimited permission to copy and/or distribute it,
+ with or without modifications, as long as this notice is preserved.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+ even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE.
+
+License: GPL-2+ with AutoConf exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception to the GNU General Public License, if you
+ distribute this file as part of a program that contains a
+ configuration script generated by Autoconf, you may include it under
+ the same distribution terms that you use for the rest of that program.
+
+License: GPL-2+ with Font exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception, if you create a document which uses this font,
+ and embed this font or unaltered portions of this font into the
+ document, this font does not by itself cause the resulting document
+ to be covered by the GNU General Public License. This exception does
+ not however invalidate any other reasons why the document might be
+ covered by the GNU General Public License. If you modify this font,
+ you may extend this exception to your version of the font, but you
+ are not obligated to do so. If you do not wish to do so, delete this
+ exception statement from your version.
+
+License: GPL-2+ with LibTool exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception to the GNU General Public License,
+ if you distribute this file as part of a program or library that
+ is built using GNU Libtool, you may include this file under the
+ same distribution terms that you use for the rest of that program.
+
+License: GPL-3+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or (at
+ your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+License: GPL-3+ with AutoConf exception
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 3 can be found in "/usr/share/common-licenses/GPL-3".
+ .
+ As a special exception to the GNU General Public License, if you
+ distribute this file as part of a program that contains a
+ configuration script generated by Autoconf, you may include it under
+ the same distribution terms that you use for the rest of that program.
+
+License: ISC
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+License: LGPL-2.1+
+ This library is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation; either version 2.1 of the License, or (at
+ your option) any later version.
+ .
+ This library is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU Lesser General Public
+ License, version 2.1 can be found in "/usr/share/common-licenses/LGPL-2.1".
+
+License: MIT
+ Permission is hereby granted, without written agreement and without license or
+ royalty fees, to use, copy, modify, and distribute this software and its
+ documentation for any purpose, provided that the above copyright notice and
+ the following two paragraphs appear in all copies of this software.
+ .
+ IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR DIRECT,
+ INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE
+ OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE COPYRIGHT HOLDER HAS BEEN
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ .
+ THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+ AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT,
+ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+License: OFL-1.1
+ SIL OPEN FONT LICENSE
+ .
+ Version 1.1 - 26 February 2007
+ .
+ PREAMBLE
+ The goals of the Open Font License (OFL) are to stimulate worldwide
+ development of collaborative font projects, to support the font creation
+ efforts of academic and linguistic communities, and to provide a free and
+ open framework in which fonts may be shared and improved in partnership
+ with others.
+ .
+ The OFL allows the licensed fonts to be used, studied, modified and
+ redistributed freely as long as they are not sold by themselves. The
+ fonts, including any derivative works, can be bundled, embedded,
+ redistributed and/or sold with any software provided that any reserved
+ names are not used by derivative works. The fonts and derivatives,
+ however, cannot be released under any other type of license. The
+ requirement for fonts to remain under this license does not apply
+ to any document created using the fonts or their derivatives.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this license and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Reserved Font Name" refers to any names specified as such after the
+ copyright statement(s).
+ .
+ "Original Version" refers to the collection of Font Software components as
+ distributed by the Copyright Holder(s).
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting - in part or in whole - any of the components of the
+ Original Version, by changing formats or by porting the Font Software to a
+ new environment.
+ .
+ "Author" refers to any designer, engineer, programmer, technical
+ writer or other person who contributed to the Font Software.
+ .
+ PERMISSION & CONDITIONS
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Font Software, to use, study, copy, merge, embed, modify,
+ redistribute, and sell modified and unmodified copies of the Font
+ Software, subject to the following conditions:
+ .
+ 1) Neither the Font Software nor any of its individual components,
+ in Original or Modified Versions, may be sold by itself.
+ .
+ 2) Original or Modified Versions of the Font Software may be bundled,
+ redistributed and/or sold with any software, provided that each copy
+ contains the above copyright notice and this license. These can be
+ included either as stand-alone text files, human-readable headers or
+ in the appropriate machine-readable metadata fields within text or
+ binary files as long as those fields can be easily viewed by the user.
+ .
+ 3) No Modified Version of the Font Software may use the Reserved Font
+ Name(s) unless explicit written permission is granted by the corresponding
+ Copyright Holder. This restriction only applies to the primary font name as
+ presented to the users.
+ .
+ 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+ Software shall not be used to promote, endorse or advertise any
+ Modified Version, except to acknowledge the contribution(s) of the
+ Copyright Holder(s) and the Author(s) or with their explicit written
+ permission.
+ .
+ 5) The Font Software, modified or unmodified, in part or in whole,
+ must be distributed entirely under this license, and must not be
+ distributed under any other license. The requirement for fonts to
+ remain under this license does not apply to any document created
+ using the Font Software.
+ .
+ TERMINATION
+ This license becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+ OTHER DEALINGS IN THE FONT SOFTWARE.
+
+License: Monotype
+ This font software is the property of Monotype Imaging Inc., one of its
+ affiliated entities, or its licensors (collectively, Monotype) and its use
+ by you is covered under the terms of a license agreement.
+ .
+ You have obtained this font software either directly from Monotype or from the
+ Unicode Consortium. Monotype has granted the Consortium and recipients of the
+ this font distributed by the Consortium, permission, free of charge, to use,
+ copy modify, publish, distribute, sublicense, and/or sell copies of the font,
+ and to permit persons to whom the font is distributed to do so. In addition,
+ Monotype grants to the Consortium the worldwide, nonexclusive, royalty-free,
+ paid-up, and irrevocable rights under Monotype's copyright rights to
+ reproduce, publicly display, publicly perform, prepare derivative works of,
+ and distribute copies of the font, and the right to sublicense others who
+ legally receive copies of the font.
+ .
+ You can learn more about Monotype here:  www.monotype.com
+
+License: UFL-1.0
+ -------------------------------
+ UBUNTU FONT LICENCE Version 1.0
+ -------------------------------
+ .
+ PREAMBLE
+ This licence allows the licensed fonts to be used, studied, modified and
+ redistributed freely. The fonts, including any derivative works, can be
+ bundled, embedded, and redistributed provided the terms of this licence
+ are met. The fonts and derivatives, however, cannot be released under
+ any other licence. The requirement for fonts to remain under this
+ licence does not require any document created using the fonts or their
+ derivatives to be published under this licence, as long as the primary
+ purpose of the document is not to be a vehicle for the distribution of
+ the fonts.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this licence and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Original Version" refers to the collection of Font Software components
+ as received under this licence.
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting -- in part or in whole -- any of the components of the
+ Original Version, by changing formats or by porting the Font Software to
+ a new environment.
+ .
+ "Copyright Holder(s)" refers to all individuals and companies who have a
+ copyright ownership of the Font Software.
+ .
+ "Substantially Changed" refers to Modified Versions which can be easily
+ identified as dissimilar to the Font Software by users of the Font
+ Software comparing the Original Version with the Modified Version.
+ .
+ To "Propagate" a work means to do anything with it that, without
+ permission, would make you directly or secondarily liable for
+ infringement under applicable copyright law, except executing it on a
+ computer or modifying a private copy. Propagation includes copying,
+ distribution (with or without modification and with or without charging
+ a redistribution fee), making available to the public, and in some
+ countries other activities as well.
+ .
+ PERMISSION & CONDITIONS
+ This licence does not grant any rights under trademark law and all such
+ rights are reserved.
+ .
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of the Font Software, to propagate the Font Software, subject to
+ the below conditions:
+ .
+ 1) Each copy of the Font Software must contain the above copyright
+ notice and this licence. These can be included either as stand-alone
+ text files, human-readable headers or in the appropriate machine-
+ readable metadata fields within text or binary files as long as those
+ fields can be easily viewed by the user.
+ .
+ 2) The font name complies with the following:
+ (a) The Original Version must retain its name, unmodified.
+ (b) Modified Versions which are Substantially Changed must be renamed to
+ avoid use of the name of the Original Version or similar names entirely.
+ (c) Modified Versions which are not Substantially Changed must be
+ renamed to both (i) retain the name of the Original Version and (ii) add
+ additional naming elements to distinguish the Modified Version from the
+ Original Version. The name of such Modified Versions must be the name of
+ the Original Version, with "derivative X" where X represents the name of
+ the new work, appended to that name.
+ .
+ 3) The name(s) of the Copyright Holder(s) and any contributor to the
+ Font Software shall not be used to promote, endorse or advertise any
+ Modified Version, except (i) as required by this licence, (ii) to
+ acknowledge the contribution(s) of the Copyright Holder(s) or (iii) with
+ their explicit written permission.
+ .
+ 4) The Font Software, modified or unmodified, in part or in whole, must
+ be distributed entirely under this licence, and must not be distributed
+ under any other licence. The requirement for fonts to remain under this
+ licence does not affect any document created using the Font Software,
+ except any version of the Font Software extracted from a document
+ created using the Font Software may only be distributed under this
+ licence.
+ .
+ TERMINATION
+ This licence becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+ DEALINGS IN THE FONT SOFTWARE.
+
+License: Unicode
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Unicode data files and any associated documentation
+ (the "Data Files") or Unicode software and any associated documentation
+ (the "Software") to deal in the Data Files or Software
+ without restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, and/or sell copies of
+ the Data Files or Software, and to permit persons to whom the Data Files
+ or Software are furnished to do so, provided that either
+ (a) this copyright and permission notice appear with all copies
+ of the Data Files or Software, or
+ (b) this copyright and permission notice appear in associated
+ Documentation.
+ .
+ THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+ IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+ NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+ DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+ .
+ Except as contained in this notice, the name of a copyright holder
+ shall not be used in advertising or otherwise to promote the sale,
+ use or other dealings in these Data Files or Software without prior
+ written authorization of the copyright holder.

--- a/appimage/packetry.AppDir/usr/share/doc/libharfbuzz-icu0/copyright
+++ b/appimage/packetry.AppDir/usr/share/doc/libharfbuzz-icu0/copyright
@@ -1,0 +1,708 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: HarfBuzz
+Upstream-Contact: Behdad Esfahbod
+Source: https://www.freedesktop.org/wiki/Software/HarfBuzz
+
+Files: *
+Copyright: 2018-2020, Adobe, Inc
+           2005-2023, Behdad Esfahbod
+           2007, Chris Wilson
+           2011, Codethink Limited
+           2005, David Turner
+           1998-2004, David Turner and Werner Lemberg
+           2015-2020, Ebrahim Byagowi
+           2016, Elie Roux
+           2019-2020, Facebook, Inc
+           2010-2023, Google, Inc
+           2016, Igalia S.L
+           2009, Keith Stribley
+           2018-2021, Khaled Hosny
+           2011, Martin Hosken and SIL International
+           2022, Matthias Clasen
+           2012-2015, Mozilla Foundation
+           2008-2010, Nokia Corporation and/or its subsidiary(-ies)
+           1998-2023, Red Hat, Inc
+           2013-2015, Alexei Podtelezhnikov
+           2012 Zilong Tan <eric.zltan@gmail.com>
+License: MIT
+
+Files: debian/*
+Copyright: 2012-2019,2023, أحمد المحمودي (Ahmed El-Mahmoudy) <aelmahmoudy@users.sourceforge.net>
+License: MIT
+
+Files: src/hb-unicode-emoji-table.hh
+Copyright: 2022, Unicode®, Inc
+License: Unicode
+Comment: https://www.unicode.org/terms_of_use.html
+
+Files: src/hb-ucd.cc
+Copyright: 2012, Grigori Goronzy <greg@kinoho.net>
+License: ISC
+
+Files: test/shape/data/text-rendering-tests/*
+Copyright: 2016, Unicode Inc
+License: Apache-2.0
+
+Files: perf/fonts/Amiri-Regular.ttf
+       perf/fonts/NotoNastaliqUrdu-Regular.ttf
+       test/api/fonts/*
+       test/fuzzing/fonts/*
+       test/shape/data/text-rendering-tests/fonts/*
+Copyright: 2002-2018, Adobe Systems Incorporated
+           2017-2019, Amin Abedi (@aminabedi68)-www.fontamin.com
+           2015, Cadson Demak <info@cadsondemak.com>
+           2011-2020, Google Inc
+           2016, Igalia S.L. (http://igalia.com/)
+           2017, Jens Kutilek
+           2010-2017, Khaled Hosny <khaledhosny@eglug.org>
+           2016, Sascha Brawer
+           2010, Sebastian Kosch <sebastian@aldusleaf.org>
+           2008, The Bungee Project Authors <david@djr.com>
+           1993-2016, The Font Bureau, Inc
+           2016, The M+ Project Authors
+           2021, The Qahiri Project Authors (github.com/aliftype/qahiri)
+           2016-2019, Unicode, Inc
+License: OFL-1.1
+
+Files: test/shape/data/in-house/fonts/*
+Copyright: 2000-2016, Adobe Systems Incorporated
+           2016, Alfredo Marco Pradil
+           2018-2022, David Corbett
+           2010-2022, Google, Inc
+           2011-2012, Lohit Fonts Project contributors <https://pagure.io/lohit>
+           2013-2020, Microsoft Corporation
+           2018, SIL International (http://scripts.sil.org)
+           2010-2021, The Amiri Project Authors (https://github.com/aliftype/amiri)
+           2015-2021, The Mada Project Authors
+           2021, The Qahiri Project Authors (github.com/aliftype/qahiri)
+           2021, The Raqq Project Authors (github.com/aliftype/raqq)
+           2018, Unicode, Inc
+           2005, Zawgyi.net & Alpha Mandalay
+License: OFL-1.1
+
+Files: test/subset/data/*
+Copyright: 2002-2018, Adobe Systems Incorporated (http://www.adobe.com/)
+           2012, Andhrapradesh Society for Knowledge Networks (fonts.siliconandhra.org)
+           2013, Danh Hong (khmertype.org)
+           2007, Denis Moyogo Jacquerye <moyogo@gmail.com>
+           2011-2012, George W. Nuss (http://www.fulbefouta.com)
+           2010-2016, Google Inc
+           2011, Hjort Nidudsson
+           2019, Inter IKEA Systems B.V. (www.ikea.com)
+           2010, NHN Corporation
+           2011-2012, Sorkin Type Co (www.sorkintype.com)
+           2013, The Alegreya Sans Project Authors (https://github.com/huertatipografica/Alegreya-Sans)
+           2010-2020, The Amiri Project Authors (https://github.com/alif-type/amiri)
+           2008, The Bungee Project Authors <david@djr.com>
+           2007-2008, The C&MA Guinea Fulbe Team
+           2011, The Comfortaa Project Authors (https://github.com/alexeiva/comfortaa)
+           2020, The Fraunces Project Authors (github.com/undercasetype/Fraunces)
+           2016, The M+ Project Authors
+           2021, The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS)
+           2019, The Noto Project Authors (github. com/googlei18n/noto-fonts)
+           2017, The Roboto Flex Project Authors (https://github.com/TypeNetwork/Roboto-Flex)
+           2004-2020, SIL International (http://www.sil.org)
+           2017, The Spectral Project Authors (http://github.com/productiontype/spectral)
+           2001-2021, The STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
+License: OFL-1.1
+
+Files: test/shape/data/aots/*
+Copyright: 2000-2016, Adobe Systems Incorporated
+License: Apache-2.0
+
+Files: perf/fonts/Roboto-Regular.ttf
+       test/api/fonts/nameID.origin.ttf
+       test/api/fonts/nameID.override.expected.ttf
+       test/api/fonts/OpenSans-Regular.ttf
+       test/shape/data/text-rendering-tests/fonts/TestShapeKndaV3.ttf
+       test/subset/data/fonts/Tinos-Italic.ttf
+       test/subset/data/fonts/IndicTestHowrah-Regular.ttf
+       test/subset/data/fonts/IndicTestJalandhar-Regular.ttf
+       test/subset/data/fonts/Roboto-Regular.ttf
+       test/subset/data/fonts/Roboto-Variable.ttf
+Copyright: 2010-2013, Google Corporation
+License: Apache-2.0
+
+Files: test/shape/data/in-house/fonts/e8691822f6a705e3e9fb48a0405c645b1a036590.ttf
+Copyright: 2020, Fredrick R. Brennan
+License: Apache-2.0
+
+Files: test/subset/data/fonts/Khmer.ttf
+Copyright: 2013, Danh Hong (khmertype.org)
+License: Apache-2.0
+
+Files: test/api/fonts/TestGVAREight.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVAREight.ttf
+Copyright: 1992-2017, Thomas A. Rickner
+License: Apache-2.0
+Comment: License mismatch resolved: https://github.com/harfbuzz/harfbuzz/issues/4062
+
+Files: test/api/fonts/TestGVAROne.ttf
+       test/api/fonts/TestGVARThree.ttf
+       test/api/fonts/TestGVARTwo.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVAROne.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVARThree.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVARTwo.ttf
+Copyright: 2016, Monotype Hong Kong Ltd. and Monotype Imaging Inc
+License: Monotype
+
+Files: test/shape/data/in-house/fonts/074a5ae6b19de8f29772fdd5df2d3d833f81f5e6.ttf
+       test/shape/data/in-house/fonts/1a3d8f381387dd29be1e897e4b5100ac8b4829e1.ttf
+       test/shape/data/in-house/fonts/b151cfcdaa77585d77f17a42158e0873fc8e2633.ttf
+       test/shape/data/in-house/fonts/d9b8bc10985f24796826c29f7ccba3d0ae11ec02.ttf
+Copyright: 2017, David Corbett
+License: CC0-1.0
+
+Files: test/shape/data/in-house/fonts/b722a7d09e60421f3efbc706ad348ab47b88567b.ttf
+Copyright: 2005, Mihail Bayaryn
+License: GPL-3+
+
+Files: test/shape/data/in-house/fonts/b895f8ff06493cc893ec44de380690ca0074edfa.ttf
+Copyright: 2009-2010, Yoram Gnat (yoram.gnat@gmail.com)
+           2003-2007, Ralph Hancock & John Hudson
+License: GPL-2+ with Font exception
+
+Files: test/shape/data/in-house/fonts/DFONT.dfont
+       test/shape/data/in-house/fonts/TTC.ttc
+Copyright: 2015, FontTools
+License: MIT
+Comment: https://github.com/fonttools/fonttools/blob/main/LICENSE
+
+Files: test/subset/data/expected/glyph_names/*
+       test/subset/data/fonts/Ubuntu-Regular.ttf
+Copyright: 2011, Canonical Ltd.
+License: UFL-1.0
+
+Files: aclocal.m4
+       Makefile.in
+       m4/*
+       docs/Makefile.in
+       perf/Makefile.in
+       src/Makefile.in
+       test/Makefile.in
+       test/api/Makefile.in
+       test/fuzzing/Makefile.in
+       test/shape/Makefile.in
+       test/shape/data/Makefile.in
+       test/shape/data/aots/Makefile.in
+       test/shape/data/in-house/Makefile.in
+       test/shape/data/text-rendering-tests/Makefile.in
+       test/subset/Makefile.in
+       test/subset/data/Makefile.in
+       test/subset/data/repack_tests/Makefile.in
+       test/threads/Makefile.in
+       util/Makefile.in
+Copyright: 1994-2018, Free Software Foundation, Inc
+           2004-2007, Damon Chaplin
+           2012-2015, Dan Nicholson <dbn.lists@gmail.com>
+           2003, James Henstridge
+           2009, Johan Dahlin
+           2004, Scott James Remnant <scott@netsplit.com>
+           2007-2017, Stefan Sauer
+           2003-2005, Thomas Vander Stichele <thomas@apestaart.org>
+License: FSFULLR
+
+Files: ar-lib
+       compile
+       depcomp
+       missing
+       test-driver
+Copyright: 1996-2018, Free Software Foundation, Inc
+License: GPL-2+ with AutoConf exception
+
+Files: config.guess
+       config.sub
+Copyright: 1992-2018, Free Software Foundation, Inc
+License: GPL-3+ with AutoConf exception
+
+Files: m4/ax_cxx_compile_stdcxx.m4
+Copyright: 2008, Benjamin Kosnik <bkoz@redhat.com>
+           2014-2015, Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+           2016, Krzesimir Nowak <qdlacz@gmail.com>
+           2015, Moritz Klammler <moritz@klammler.eu>
+           2015, Paul Norman <penorman@mac.com>
+           2013, Roy Stogner <roystgnr@ices.utexas.edu>
+           2012, Zack Weinberg <zackw@panix.com>
+License: FSFAP
+
+Files: m4/ax_code_coverage.m4
+Copyright: 2015, Bastien ROUCARIES
+           2012, Christian Persch
+           2012, Dan Winship
+           2012, Paolo Borelli
+           2012-2016, Philip Withnall
+           2012, Xan Lopez
+License: LGPL-2.1+
+
+Files: ltmain.sh
+Copyright: 1996-2015, Free Software Foundation, Inc
+License: GPL-2+ with LibTool exception
+
+Files: gtk-doc.make
+Copyright: 2004-2007, Damon Chaplin
+           2003, James Henstridge
+           2007-2017, Stefan Sauer
+License: GPL-3+
+
+Files: m4/ax_check_link_flag.m4
+Copyright: 2008, Guido U. Draheim <guidod@gmx.de>
+           2011, Maarten Bosmans <mkbosmans@gmail.com>
+License: GPL-3+ with AutoConf exception
+
+Files: m4/gtk-doc.m4
+Copyright: 2003, James Henstridge
+           2007-2017, Stefan Sauer
+License: GPL-3+
+
+Files: m4/ax_pthread.m4
+Copyright: 2011, Daniel Richard G <skunk@iSKUNK.ORG>
+           2008, Steven G. Johnson <stevenj@alum.mit.edu>
+License: GPL-3+ with AutoConf exception
+
+Files: install-sh
+Copyright: 1994, X Consortium
+License: Expat
+
+Files: INSTALL
+Copyright: 1994-2016, Free Software
+License: FSFAP
+
+Files: configure
+Copyright: 1992-2014, Free Software Foundation, Inc
+License: FSFUL
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+  http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License
+ can be found in the file `/usr/share/common-licenses/Apache-2.0'.
+
+License: CC0-1.0
+ On Debian systems, the text of the CC0 1.0 Universal license can be
+ found in ‘/usr/share/common-licenses/CC0-1.0’.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to
+ deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNEC-
+ TION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ .
+ Except as contained in this notice, the name of the X Consortium shall not
+ be used in advertising or otherwise to promote the sale, use or other deal-
+ ings in this Software without prior written authorization from the X Consor-
+ tium.
+
+License: FSFAP
+ Copying and distribution of this file, with or without modification, are
+ permitted in any medium without royalty provided the copyright notice
+ and this notice are preserved.  This file is offered as-is, without any
+ warranty.
+
+License: FSFUL
+ This script is free software; the Free Software Foundation
+ gives unlimited permission to copy, distribute and modify it.
+
+License: FSFULLR
+ This file is free software; the Free Software Foundation
+ gives unlimited permission to copy and/or distribute it,
+ with or without modifications, as long as this notice is preserved.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+ even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE.
+
+License: GPL-2+ with AutoConf exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception to the GNU General Public License, if you
+ distribute this file as part of a program that contains a
+ configuration script generated by Autoconf, you may include it under
+ the same distribution terms that you use for the rest of that program.
+
+License: GPL-2+ with Font exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception, if you create a document which uses this font,
+ and embed this font or unaltered portions of this font into the
+ document, this font does not by itself cause the resulting document
+ to be covered by the GNU General Public License. This exception does
+ not however invalidate any other reasons why the document might be
+ covered by the GNU General Public License. If you modify this font,
+ you may extend this exception to your version of the font, but you
+ are not obligated to do so. If you do not wish to do so, delete this
+ exception statement from your version.
+
+License: GPL-2+ with LibTool exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception to the GNU General Public License,
+ if you distribute this file as part of a program or library that
+ is built using GNU Libtool, you may include this file under the
+ same distribution terms that you use for the rest of that program.
+
+License: GPL-3+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or (at
+ your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+License: GPL-3+ with AutoConf exception
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 3 can be found in "/usr/share/common-licenses/GPL-3".
+ .
+ As a special exception to the GNU General Public License, if you
+ distribute this file as part of a program that contains a
+ configuration script generated by Autoconf, you may include it under
+ the same distribution terms that you use for the rest of that program.
+
+License: ISC
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+License: LGPL-2.1+
+ This library is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation; either version 2.1 of the License, or (at
+ your option) any later version.
+ .
+ This library is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU Lesser General Public
+ License, version 2.1 can be found in "/usr/share/common-licenses/LGPL-2.1".
+
+License: MIT
+ Permission is hereby granted, without written agreement and without license or
+ royalty fees, to use, copy, modify, and distribute this software and its
+ documentation for any purpose, provided that the above copyright notice and
+ the following two paragraphs appear in all copies of this software.
+ .
+ IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR DIRECT,
+ INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE
+ OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE COPYRIGHT HOLDER HAS BEEN
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ .
+ THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+ AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT,
+ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+License: OFL-1.1
+ SIL OPEN FONT LICENSE
+ .
+ Version 1.1 - 26 February 2007
+ .
+ PREAMBLE
+ The goals of the Open Font License (OFL) are to stimulate worldwide
+ development of collaborative font projects, to support the font creation
+ efforts of academic and linguistic communities, and to provide a free and
+ open framework in which fonts may be shared and improved in partnership
+ with others.
+ .
+ The OFL allows the licensed fonts to be used, studied, modified and
+ redistributed freely as long as they are not sold by themselves. The
+ fonts, including any derivative works, can be bundled, embedded,
+ redistributed and/or sold with any software provided that any reserved
+ names are not used by derivative works. The fonts and derivatives,
+ however, cannot be released under any other type of license. The
+ requirement for fonts to remain under this license does not apply
+ to any document created using the fonts or their derivatives.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this license and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Reserved Font Name" refers to any names specified as such after the
+ copyright statement(s).
+ .
+ "Original Version" refers to the collection of Font Software components as
+ distributed by the Copyright Holder(s).
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting - in part or in whole - any of the components of the
+ Original Version, by changing formats or by porting the Font Software to a
+ new environment.
+ .
+ "Author" refers to any designer, engineer, programmer, technical
+ writer or other person who contributed to the Font Software.
+ .
+ PERMISSION & CONDITIONS
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Font Software, to use, study, copy, merge, embed, modify,
+ redistribute, and sell modified and unmodified copies of the Font
+ Software, subject to the following conditions:
+ .
+ 1) Neither the Font Software nor any of its individual components,
+ in Original or Modified Versions, may be sold by itself.
+ .
+ 2) Original or Modified Versions of the Font Software may be bundled,
+ redistributed and/or sold with any software, provided that each copy
+ contains the above copyright notice and this license. These can be
+ included either as stand-alone text files, human-readable headers or
+ in the appropriate machine-readable metadata fields within text or
+ binary files as long as those fields can be easily viewed by the user.
+ .
+ 3) No Modified Version of the Font Software may use the Reserved Font
+ Name(s) unless explicit written permission is granted by the corresponding
+ Copyright Holder. This restriction only applies to the primary font name as
+ presented to the users.
+ .
+ 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+ Software shall not be used to promote, endorse or advertise any
+ Modified Version, except to acknowledge the contribution(s) of the
+ Copyright Holder(s) and the Author(s) or with their explicit written
+ permission.
+ .
+ 5) The Font Software, modified or unmodified, in part or in whole,
+ must be distributed entirely under this license, and must not be
+ distributed under any other license. The requirement for fonts to
+ remain under this license does not apply to any document created
+ using the Font Software.
+ .
+ TERMINATION
+ This license becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+ OTHER DEALINGS IN THE FONT SOFTWARE.
+
+License: Monotype
+ This font software is the property of Monotype Imaging Inc., one of its
+ affiliated entities, or its licensors (collectively, Monotype) and its use
+ by you is covered under the terms of a license agreement.
+ .
+ You have obtained this font software either directly from Monotype or from the
+ Unicode Consortium. Monotype has granted the Consortium and recipients of the
+ this font distributed by the Consortium, permission, free of charge, to use,
+ copy modify, publish, distribute, sublicense, and/or sell copies of the font,
+ and to permit persons to whom the font is distributed to do so. In addition,
+ Monotype grants to the Consortium the worldwide, nonexclusive, royalty-free,
+ paid-up, and irrevocable rights under Monotype's copyright rights to
+ reproduce, publicly display, publicly perform, prepare derivative works of,
+ and distribute copies of the font, and the right to sublicense others who
+ legally receive copies of the font.
+ .
+ You can learn more about Monotype here:  www.monotype.com
+
+License: UFL-1.0
+ -------------------------------
+ UBUNTU FONT LICENCE Version 1.0
+ -------------------------------
+ .
+ PREAMBLE
+ This licence allows the licensed fonts to be used, studied, modified and
+ redistributed freely. The fonts, including any derivative works, can be
+ bundled, embedded, and redistributed provided the terms of this licence
+ are met. The fonts and derivatives, however, cannot be released under
+ any other licence. The requirement for fonts to remain under this
+ licence does not require any document created using the fonts or their
+ derivatives to be published under this licence, as long as the primary
+ purpose of the document is not to be a vehicle for the distribution of
+ the fonts.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this licence and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Original Version" refers to the collection of Font Software components
+ as received under this licence.
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting -- in part or in whole -- any of the components of the
+ Original Version, by changing formats or by porting the Font Software to
+ a new environment.
+ .
+ "Copyright Holder(s)" refers to all individuals and companies who have a
+ copyright ownership of the Font Software.
+ .
+ "Substantially Changed" refers to Modified Versions which can be easily
+ identified as dissimilar to the Font Software by users of the Font
+ Software comparing the Original Version with the Modified Version.
+ .
+ To "Propagate" a work means to do anything with it that, without
+ permission, would make you directly or secondarily liable for
+ infringement under applicable copyright law, except executing it on a
+ computer or modifying a private copy. Propagation includes copying,
+ distribution (with or without modification and with or without charging
+ a redistribution fee), making available to the public, and in some
+ countries other activities as well.
+ .
+ PERMISSION & CONDITIONS
+ This licence does not grant any rights under trademark law and all such
+ rights are reserved.
+ .
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of the Font Software, to propagate the Font Software, subject to
+ the below conditions:
+ .
+ 1) Each copy of the Font Software must contain the above copyright
+ notice and this licence. These can be included either as stand-alone
+ text files, human-readable headers or in the appropriate machine-
+ readable metadata fields within text or binary files as long as those
+ fields can be easily viewed by the user.
+ .
+ 2) The font name complies with the following:
+ (a) The Original Version must retain its name, unmodified.
+ (b) Modified Versions which are Substantially Changed must be renamed to
+ avoid use of the name of the Original Version or similar names entirely.
+ (c) Modified Versions which are not Substantially Changed must be
+ renamed to both (i) retain the name of the Original Version and (ii) add
+ additional naming elements to distinguish the Modified Version from the
+ Original Version. The name of such Modified Versions must be the name of
+ the Original Version, with "derivative X" where X represents the name of
+ the new work, appended to that name.
+ .
+ 3) The name(s) of the Copyright Holder(s) and any contributor to the
+ Font Software shall not be used to promote, endorse or advertise any
+ Modified Version, except (i) as required by this licence, (ii) to
+ acknowledge the contribution(s) of the Copyright Holder(s) or (iii) with
+ their explicit written permission.
+ .
+ 4) The Font Software, modified or unmodified, in part or in whole, must
+ be distributed entirely under this licence, and must not be distributed
+ under any other licence. The requirement for fonts to remain under this
+ licence does not affect any document created using the Font Software,
+ except any version of the Font Software extracted from a document
+ created using the Font Software may only be distributed under this
+ licence.
+ .
+ TERMINATION
+ This licence becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+ DEALINGS IN THE FONT SOFTWARE.
+
+License: Unicode
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Unicode data files and any associated documentation
+ (the "Data Files") or Unicode software and any associated documentation
+ (the "Software") to deal in the Data Files or Software
+ without restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, and/or sell copies of
+ the Data Files or Software, and to permit persons to whom the Data Files
+ or Software are furnished to do so, provided that either
+ (a) this copyright and permission notice appear with all copies
+ of the Data Files or Software, or
+ (b) this copyright and permission notice appear in associated
+ Documentation.
+ .
+ THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+ IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+ NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+ DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+ .
+ Except as contained in this notice, the name of a copyright holder
+ shall not be used in advertising or otherwise to promote the sale,
+ use or other dealings in these Data Files or Software without prior
+ written authorization of the copyright holder.

--- a/appimage/packetry.AppDir/usr/share/doc/libharfbuzz-subset0/copyright
+++ b/appimage/packetry.AppDir/usr/share/doc/libharfbuzz-subset0/copyright
@@ -1,0 +1,708 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: HarfBuzz
+Upstream-Contact: Behdad Esfahbod
+Source: https://www.freedesktop.org/wiki/Software/HarfBuzz
+
+Files: *
+Copyright: 2018-2020, Adobe, Inc
+           2005-2023, Behdad Esfahbod
+           2007, Chris Wilson
+           2011, Codethink Limited
+           2005, David Turner
+           1998-2004, David Turner and Werner Lemberg
+           2015-2020, Ebrahim Byagowi
+           2016, Elie Roux
+           2019-2020, Facebook, Inc
+           2010-2023, Google, Inc
+           2016, Igalia S.L
+           2009, Keith Stribley
+           2018-2021, Khaled Hosny
+           2011, Martin Hosken and SIL International
+           2022, Matthias Clasen
+           2012-2015, Mozilla Foundation
+           2008-2010, Nokia Corporation and/or its subsidiary(-ies)
+           1998-2023, Red Hat, Inc
+           2013-2015, Alexei Podtelezhnikov
+           2012 Zilong Tan <eric.zltan@gmail.com>
+License: MIT
+
+Files: debian/*
+Copyright: 2012-2019,2023, أحمد المحمودي (Ahmed El-Mahmoudy) <aelmahmoudy@users.sourceforge.net>
+License: MIT
+
+Files: src/hb-unicode-emoji-table.hh
+Copyright: 2022, Unicode®, Inc
+License: Unicode
+Comment: https://www.unicode.org/terms_of_use.html
+
+Files: src/hb-ucd.cc
+Copyright: 2012, Grigori Goronzy <greg@kinoho.net>
+License: ISC
+
+Files: test/shape/data/text-rendering-tests/*
+Copyright: 2016, Unicode Inc
+License: Apache-2.0
+
+Files: perf/fonts/Amiri-Regular.ttf
+       perf/fonts/NotoNastaliqUrdu-Regular.ttf
+       test/api/fonts/*
+       test/fuzzing/fonts/*
+       test/shape/data/text-rendering-tests/fonts/*
+Copyright: 2002-2018, Adobe Systems Incorporated
+           2017-2019, Amin Abedi (@aminabedi68)-www.fontamin.com
+           2015, Cadson Demak <info@cadsondemak.com>
+           2011-2020, Google Inc
+           2016, Igalia S.L. (http://igalia.com/)
+           2017, Jens Kutilek
+           2010-2017, Khaled Hosny <khaledhosny@eglug.org>
+           2016, Sascha Brawer
+           2010, Sebastian Kosch <sebastian@aldusleaf.org>
+           2008, The Bungee Project Authors <david@djr.com>
+           1993-2016, The Font Bureau, Inc
+           2016, The M+ Project Authors
+           2021, The Qahiri Project Authors (github.com/aliftype/qahiri)
+           2016-2019, Unicode, Inc
+License: OFL-1.1
+
+Files: test/shape/data/in-house/fonts/*
+Copyright: 2000-2016, Adobe Systems Incorporated
+           2016, Alfredo Marco Pradil
+           2018-2022, David Corbett
+           2010-2022, Google, Inc
+           2011-2012, Lohit Fonts Project contributors <https://pagure.io/lohit>
+           2013-2020, Microsoft Corporation
+           2018, SIL International (http://scripts.sil.org)
+           2010-2021, The Amiri Project Authors (https://github.com/aliftype/amiri)
+           2015-2021, The Mada Project Authors
+           2021, The Qahiri Project Authors (github.com/aliftype/qahiri)
+           2021, The Raqq Project Authors (github.com/aliftype/raqq)
+           2018, Unicode, Inc
+           2005, Zawgyi.net & Alpha Mandalay
+License: OFL-1.1
+
+Files: test/subset/data/*
+Copyright: 2002-2018, Adobe Systems Incorporated (http://www.adobe.com/)
+           2012, Andhrapradesh Society for Knowledge Networks (fonts.siliconandhra.org)
+           2013, Danh Hong (khmertype.org)
+           2007, Denis Moyogo Jacquerye <moyogo@gmail.com>
+           2011-2012, George W. Nuss (http://www.fulbefouta.com)
+           2010-2016, Google Inc
+           2011, Hjort Nidudsson
+           2019, Inter IKEA Systems B.V. (www.ikea.com)
+           2010, NHN Corporation
+           2011-2012, Sorkin Type Co (www.sorkintype.com)
+           2013, The Alegreya Sans Project Authors (https://github.com/huertatipografica/Alegreya-Sans)
+           2010-2020, The Amiri Project Authors (https://github.com/alif-type/amiri)
+           2008, The Bungee Project Authors <david@djr.com>
+           2007-2008, The C&MA Guinea Fulbe Team
+           2011, The Comfortaa Project Authors (https://github.com/alexeiva/comfortaa)
+           2020, The Fraunces Project Authors (github.com/undercasetype/Fraunces)
+           2016, The M+ Project Authors
+           2021, The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS)
+           2019, The Noto Project Authors (github. com/googlei18n/noto-fonts)
+           2017, The Roboto Flex Project Authors (https://github.com/TypeNetwork/Roboto-Flex)
+           2004-2020, SIL International (http://www.sil.org)
+           2017, The Spectral Project Authors (http://github.com/productiontype/spectral)
+           2001-2021, The STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
+License: OFL-1.1
+
+Files: test/shape/data/aots/*
+Copyright: 2000-2016, Adobe Systems Incorporated
+License: Apache-2.0
+
+Files: perf/fonts/Roboto-Regular.ttf
+       test/api/fonts/nameID.origin.ttf
+       test/api/fonts/nameID.override.expected.ttf
+       test/api/fonts/OpenSans-Regular.ttf
+       test/shape/data/text-rendering-tests/fonts/TestShapeKndaV3.ttf
+       test/subset/data/fonts/Tinos-Italic.ttf
+       test/subset/data/fonts/IndicTestHowrah-Regular.ttf
+       test/subset/data/fonts/IndicTestJalandhar-Regular.ttf
+       test/subset/data/fonts/Roboto-Regular.ttf
+       test/subset/data/fonts/Roboto-Variable.ttf
+Copyright: 2010-2013, Google Corporation
+License: Apache-2.0
+
+Files: test/shape/data/in-house/fonts/e8691822f6a705e3e9fb48a0405c645b1a036590.ttf
+Copyright: 2020, Fredrick R. Brennan
+License: Apache-2.0
+
+Files: test/subset/data/fonts/Khmer.ttf
+Copyright: 2013, Danh Hong (khmertype.org)
+License: Apache-2.0
+
+Files: test/api/fonts/TestGVAREight.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVAREight.ttf
+Copyright: 1992-2017, Thomas A. Rickner
+License: Apache-2.0
+Comment: License mismatch resolved: https://github.com/harfbuzz/harfbuzz/issues/4062
+
+Files: test/api/fonts/TestGVAROne.ttf
+       test/api/fonts/TestGVARThree.ttf
+       test/api/fonts/TestGVARTwo.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVAROne.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVARThree.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVARTwo.ttf
+Copyright: 2016, Monotype Hong Kong Ltd. and Monotype Imaging Inc
+License: Monotype
+
+Files: test/shape/data/in-house/fonts/074a5ae6b19de8f29772fdd5df2d3d833f81f5e6.ttf
+       test/shape/data/in-house/fonts/1a3d8f381387dd29be1e897e4b5100ac8b4829e1.ttf
+       test/shape/data/in-house/fonts/b151cfcdaa77585d77f17a42158e0873fc8e2633.ttf
+       test/shape/data/in-house/fonts/d9b8bc10985f24796826c29f7ccba3d0ae11ec02.ttf
+Copyright: 2017, David Corbett
+License: CC0-1.0
+
+Files: test/shape/data/in-house/fonts/b722a7d09e60421f3efbc706ad348ab47b88567b.ttf
+Copyright: 2005, Mihail Bayaryn
+License: GPL-3+
+
+Files: test/shape/data/in-house/fonts/b895f8ff06493cc893ec44de380690ca0074edfa.ttf
+Copyright: 2009-2010, Yoram Gnat (yoram.gnat@gmail.com)
+           2003-2007, Ralph Hancock & John Hudson
+License: GPL-2+ with Font exception
+
+Files: test/shape/data/in-house/fonts/DFONT.dfont
+       test/shape/data/in-house/fonts/TTC.ttc
+Copyright: 2015, FontTools
+License: MIT
+Comment: https://github.com/fonttools/fonttools/blob/main/LICENSE
+
+Files: test/subset/data/expected/glyph_names/*
+       test/subset/data/fonts/Ubuntu-Regular.ttf
+Copyright: 2011, Canonical Ltd.
+License: UFL-1.0
+
+Files: aclocal.m4
+       Makefile.in
+       m4/*
+       docs/Makefile.in
+       perf/Makefile.in
+       src/Makefile.in
+       test/Makefile.in
+       test/api/Makefile.in
+       test/fuzzing/Makefile.in
+       test/shape/Makefile.in
+       test/shape/data/Makefile.in
+       test/shape/data/aots/Makefile.in
+       test/shape/data/in-house/Makefile.in
+       test/shape/data/text-rendering-tests/Makefile.in
+       test/subset/Makefile.in
+       test/subset/data/Makefile.in
+       test/subset/data/repack_tests/Makefile.in
+       test/threads/Makefile.in
+       util/Makefile.in
+Copyright: 1994-2018, Free Software Foundation, Inc
+           2004-2007, Damon Chaplin
+           2012-2015, Dan Nicholson <dbn.lists@gmail.com>
+           2003, James Henstridge
+           2009, Johan Dahlin
+           2004, Scott James Remnant <scott@netsplit.com>
+           2007-2017, Stefan Sauer
+           2003-2005, Thomas Vander Stichele <thomas@apestaart.org>
+License: FSFULLR
+
+Files: ar-lib
+       compile
+       depcomp
+       missing
+       test-driver
+Copyright: 1996-2018, Free Software Foundation, Inc
+License: GPL-2+ with AutoConf exception
+
+Files: config.guess
+       config.sub
+Copyright: 1992-2018, Free Software Foundation, Inc
+License: GPL-3+ with AutoConf exception
+
+Files: m4/ax_cxx_compile_stdcxx.m4
+Copyright: 2008, Benjamin Kosnik <bkoz@redhat.com>
+           2014-2015, Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+           2016, Krzesimir Nowak <qdlacz@gmail.com>
+           2015, Moritz Klammler <moritz@klammler.eu>
+           2015, Paul Norman <penorman@mac.com>
+           2013, Roy Stogner <roystgnr@ices.utexas.edu>
+           2012, Zack Weinberg <zackw@panix.com>
+License: FSFAP
+
+Files: m4/ax_code_coverage.m4
+Copyright: 2015, Bastien ROUCARIES
+           2012, Christian Persch
+           2012, Dan Winship
+           2012, Paolo Borelli
+           2012-2016, Philip Withnall
+           2012, Xan Lopez
+License: LGPL-2.1+
+
+Files: ltmain.sh
+Copyright: 1996-2015, Free Software Foundation, Inc
+License: GPL-2+ with LibTool exception
+
+Files: gtk-doc.make
+Copyright: 2004-2007, Damon Chaplin
+           2003, James Henstridge
+           2007-2017, Stefan Sauer
+License: GPL-3+
+
+Files: m4/ax_check_link_flag.m4
+Copyright: 2008, Guido U. Draheim <guidod@gmx.de>
+           2011, Maarten Bosmans <mkbosmans@gmail.com>
+License: GPL-3+ with AutoConf exception
+
+Files: m4/gtk-doc.m4
+Copyright: 2003, James Henstridge
+           2007-2017, Stefan Sauer
+License: GPL-3+
+
+Files: m4/ax_pthread.m4
+Copyright: 2011, Daniel Richard G <skunk@iSKUNK.ORG>
+           2008, Steven G. Johnson <stevenj@alum.mit.edu>
+License: GPL-3+ with AutoConf exception
+
+Files: install-sh
+Copyright: 1994, X Consortium
+License: Expat
+
+Files: INSTALL
+Copyright: 1994-2016, Free Software
+License: FSFAP
+
+Files: configure
+Copyright: 1992-2014, Free Software Foundation, Inc
+License: FSFUL
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+  http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License
+ can be found in the file `/usr/share/common-licenses/Apache-2.0'.
+
+License: CC0-1.0
+ On Debian systems, the text of the CC0 1.0 Universal license can be
+ found in ‘/usr/share/common-licenses/CC0-1.0’.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to
+ deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNEC-
+ TION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ .
+ Except as contained in this notice, the name of the X Consortium shall not
+ be used in advertising or otherwise to promote the sale, use or other deal-
+ ings in this Software without prior written authorization from the X Consor-
+ tium.
+
+License: FSFAP
+ Copying and distribution of this file, with or without modification, are
+ permitted in any medium without royalty provided the copyright notice
+ and this notice are preserved.  This file is offered as-is, without any
+ warranty.
+
+License: FSFUL
+ This script is free software; the Free Software Foundation
+ gives unlimited permission to copy, distribute and modify it.
+
+License: FSFULLR
+ This file is free software; the Free Software Foundation
+ gives unlimited permission to copy and/or distribute it,
+ with or without modifications, as long as this notice is preserved.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+ even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE.
+
+License: GPL-2+ with AutoConf exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception to the GNU General Public License, if you
+ distribute this file as part of a program that contains a
+ configuration script generated by Autoconf, you may include it under
+ the same distribution terms that you use for the rest of that program.
+
+License: GPL-2+ with Font exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception, if you create a document which uses this font,
+ and embed this font or unaltered portions of this font into the
+ document, this font does not by itself cause the resulting document
+ to be covered by the GNU General Public License. This exception does
+ not however invalidate any other reasons why the document might be
+ covered by the GNU General Public License. If you modify this font,
+ you may extend this exception to your version of the font, but you
+ are not obligated to do so. If you do not wish to do so, delete this
+ exception statement from your version.
+
+License: GPL-2+ with LibTool exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception to the GNU General Public License,
+ if you distribute this file as part of a program or library that
+ is built using GNU Libtool, you may include this file under the
+ same distribution terms that you use for the rest of that program.
+
+License: GPL-3+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or (at
+ your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+License: GPL-3+ with AutoConf exception
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 3 can be found in "/usr/share/common-licenses/GPL-3".
+ .
+ As a special exception to the GNU General Public License, if you
+ distribute this file as part of a program that contains a
+ configuration script generated by Autoconf, you may include it under
+ the same distribution terms that you use for the rest of that program.
+
+License: ISC
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+License: LGPL-2.1+
+ This library is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation; either version 2.1 of the License, or (at
+ your option) any later version.
+ .
+ This library is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU Lesser General Public
+ License, version 2.1 can be found in "/usr/share/common-licenses/LGPL-2.1".
+
+License: MIT
+ Permission is hereby granted, without written agreement and without license or
+ royalty fees, to use, copy, modify, and distribute this software and its
+ documentation for any purpose, provided that the above copyright notice and
+ the following two paragraphs appear in all copies of this software.
+ .
+ IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR DIRECT,
+ INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE
+ OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE COPYRIGHT HOLDER HAS BEEN
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ .
+ THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+ AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT,
+ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+License: OFL-1.1
+ SIL OPEN FONT LICENSE
+ .
+ Version 1.1 - 26 February 2007
+ .
+ PREAMBLE
+ The goals of the Open Font License (OFL) are to stimulate worldwide
+ development of collaborative font projects, to support the font creation
+ efforts of academic and linguistic communities, and to provide a free and
+ open framework in which fonts may be shared and improved in partnership
+ with others.
+ .
+ The OFL allows the licensed fonts to be used, studied, modified and
+ redistributed freely as long as they are not sold by themselves. The
+ fonts, including any derivative works, can be bundled, embedded,
+ redistributed and/or sold with any software provided that any reserved
+ names are not used by derivative works. The fonts and derivatives,
+ however, cannot be released under any other type of license. The
+ requirement for fonts to remain under this license does not apply
+ to any document created using the fonts or their derivatives.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this license and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Reserved Font Name" refers to any names specified as such after the
+ copyright statement(s).
+ .
+ "Original Version" refers to the collection of Font Software components as
+ distributed by the Copyright Holder(s).
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting - in part or in whole - any of the components of the
+ Original Version, by changing formats or by porting the Font Software to a
+ new environment.
+ .
+ "Author" refers to any designer, engineer, programmer, technical
+ writer or other person who contributed to the Font Software.
+ .
+ PERMISSION & CONDITIONS
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Font Software, to use, study, copy, merge, embed, modify,
+ redistribute, and sell modified and unmodified copies of the Font
+ Software, subject to the following conditions:
+ .
+ 1) Neither the Font Software nor any of its individual components,
+ in Original or Modified Versions, may be sold by itself.
+ .
+ 2) Original or Modified Versions of the Font Software may be bundled,
+ redistributed and/or sold with any software, provided that each copy
+ contains the above copyright notice and this license. These can be
+ included either as stand-alone text files, human-readable headers or
+ in the appropriate machine-readable metadata fields within text or
+ binary files as long as those fields can be easily viewed by the user.
+ .
+ 3) No Modified Version of the Font Software may use the Reserved Font
+ Name(s) unless explicit written permission is granted by the corresponding
+ Copyright Holder. This restriction only applies to the primary font name as
+ presented to the users.
+ .
+ 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+ Software shall not be used to promote, endorse or advertise any
+ Modified Version, except to acknowledge the contribution(s) of the
+ Copyright Holder(s) and the Author(s) or with their explicit written
+ permission.
+ .
+ 5) The Font Software, modified or unmodified, in part or in whole,
+ must be distributed entirely under this license, and must not be
+ distributed under any other license. The requirement for fonts to
+ remain under this license does not apply to any document created
+ using the Font Software.
+ .
+ TERMINATION
+ This license becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+ OTHER DEALINGS IN THE FONT SOFTWARE.
+
+License: Monotype
+ This font software is the property of Monotype Imaging Inc., one of its
+ affiliated entities, or its licensors (collectively, Monotype) and its use
+ by you is covered under the terms of a license agreement.
+ .
+ You have obtained this font software either directly from Monotype or from the
+ Unicode Consortium. Monotype has granted the Consortium and recipients of the
+ this font distributed by the Consortium, permission, free of charge, to use,
+ copy modify, publish, distribute, sublicense, and/or sell copies of the font,
+ and to permit persons to whom the font is distributed to do so. In addition,
+ Monotype grants to the Consortium the worldwide, nonexclusive, royalty-free,
+ paid-up, and irrevocable rights under Monotype's copyright rights to
+ reproduce, publicly display, publicly perform, prepare derivative works of,
+ and distribute copies of the font, and the right to sublicense others who
+ legally receive copies of the font.
+ .
+ You can learn more about Monotype here:  www.monotype.com
+
+License: UFL-1.0
+ -------------------------------
+ UBUNTU FONT LICENCE Version 1.0
+ -------------------------------
+ .
+ PREAMBLE
+ This licence allows the licensed fonts to be used, studied, modified and
+ redistributed freely. The fonts, including any derivative works, can be
+ bundled, embedded, and redistributed provided the terms of this licence
+ are met. The fonts and derivatives, however, cannot be released under
+ any other licence. The requirement for fonts to remain under this
+ licence does not require any document created using the fonts or their
+ derivatives to be published under this licence, as long as the primary
+ purpose of the document is not to be a vehicle for the distribution of
+ the fonts.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this licence and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Original Version" refers to the collection of Font Software components
+ as received under this licence.
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting -- in part or in whole -- any of the components of the
+ Original Version, by changing formats or by porting the Font Software to
+ a new environment.
+ .
+ "Copyright Holder(s)" refers to all individuals and companies who have a
+ copyright ownership of the Font Software.
+ .
+ "Substantially Changed" refers to Modified Versions which can be easily
+ identified as dissimilar to the Font Software by users of the Font
+ Software comparing the Original Version with the Modified Version.
+ .
+ To "Propagate" a work means to do anything with it that, without
+ permission, would make you directly or secondarily liable for
+ infringement under applicable copyright law, except executing it on a
+ computer or modifying a private copy. Propagation includes copying,
+ distribution (with or without modification and with or without charging
+ a redistribution fee), making available to the public, and in some
+ countries other activities as well.
+ .
+ PERMISSION & CONDITIONS
+ This licence does not grant any rights under trademark law and all such
+ rights are reserved.
+ .
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of the Font Software, to propagate the Font Software, subject to
+ the below conditions:
+ .
+ 1) Each copy of the Font Software must contain the above copyright
+ notice and this licence. These can be included either as stand-alone
+ text files, human-readable headers or in the appropriate machine-
+ readable metadata fields within text or binary files as long as those
+ fields can be easily viewed by the user.
+ .
+ 2) The font name complies with the following:
+ (a) The Original Version must retain its name, unmodified.
+ (b) Modified Versions which are Substantially Changed must be renamed to
+ avoid use of the name of the Original Version or similar names entirely.
+ (c) Modified Versions which are not Substantially Changed must be
+ renamed to both (i) retain the name of the Original Version and (ii) add
+ additional naming elements to distinguish the Modified Version from the
+ Original Version. The name of such Modified Versions must be the name of
+ the Original Version, with "derivative X" where X represents the name of
+ the new work, appended to that name.
+ .
+ 3) The name(s) of the Copyright Holder(s) and any contributor to the
+ Font Software shall not be used to promote, endorse or advertise any
+ Modified Version, except (i) as required by this licence, (ii) to
+ acknowledge the contribution(s) of the Copyright Holder(s) or (iii) with
+ their explicit written permission.
+ .
+ 4) The Font Software, modified or unmodified, in part or in whole, must
+ be distributed entirely under this licence, and must not be distributed
+ under any other licence. The requirement for fonts to remain under this
+ licence does not affect any document created using the Font Software,
+ except any version of the Font Software extracted from a document
+ created using the Font Software may only be distributed under this
+ licence.
+ .
+ TERMINATION
+ This licence becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+ DEALINGS IN THE FONT SOFTWARE.
+
+License: Unicode
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Unicode data files and any associated documentation
+ (the "Data Files") or Unicode software and any associated documentation
+ (the "Software") to deal in the Data Files or Software
+ without restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, and/or sell copies of
+ the Data Files or Software, and to permit persons to whom the Data Files
+ or Software are furnished to do so, provided that either
+ (a) this copyright and permission notice appear with all copies
+ of the Data Files or Software, or
+ (b) this copyright and permission notice appear in associated
+ Documentation.
+ .
+ THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+ IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+ NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+ DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+ .
+ Except as contained in this notice, the name of a copyright holder
+ shall not be used in advertising or otherwise to promote the sale,
+ use or other dealings in these Data Files or Software without prior
+ written authorization of the copyright holder.

--- a/appimage/packetry.AppDir/usr/share/doc/libharfbuzz0b/copyright
+++ b/appimage/packetry.AppDir/usr/share/doc/libharfbuzz0b/copyright
@@ -1,0 +1,708 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: HarfBuzz
+Upstream-Contact: Behdad Esfahbod
+Source: https://www.freedesktop.org/wiki/Software/HarfBuzz
+
+Files: *
+Copyright: 2018-2020, Adobe, Inc
+           2005-2023, Behdad Esfahbod
+           2007, Chris Wilson
+           2011, Codethink Limited
+           2005, David Turner
+           1998-2004, David Turner and Werner Lemberg
+           2015-2020, Ebrahim Byagowi
+           2016, Elie Roux
+           2019-2020, Facebook, Inc
+           2010-2023, Google, Inc
+           2016, Igalia S.L
+           2009, Keith Stribley
+           2018-2021, Khaled Hosny
+           2011, Martin Hosken and SIL International
+           2022, Matthias Clasen
+           2012-2015, Mozilla Foundation
+           2008-2010, Nokia Corporation and/or its subsidiary(-ies)
+           1998-2023, Red Hat, Inc
+           2013-2015, Alexei Podtelezhnikov
+           2012 Zilong Tan <eric.zltan@gmail.com>
+License: MIT
+
+Files: debian/*
+Copyright: 2012-2019,2023, أحمد المحمودي (Ahmed El-Mahmoudy) <aelmahmoudy@users.sourceforge.net>
+License: MIT
+
+Files: src/hb-unicode-emoji-table.hh
+Copyright: 2022, Unicode®, Inc
+License: Unicode
+Comment: https://www.unicode.org/terms_of_use.html
+
+Files: src/hb-ucd.cc
+Copyright: 2012, Grigori Goronzy <greg@kinoho.net>
+License: ISC
+
+Files: test/shape/data/text-rendering-tests/*
+Copyright: 2016, Unicode Inc
+License: Apache-2.0
+
+Files: perf/fonts/Amiri-Regular.ttf
+       perf/fonts/NotoNastaliqUrdu-Regular.ttf
+       test/api/fonts/*
+       test/fuzzing/fonts/*
+       test/shape/data/text-rendering-tests/fonts/*
+Copyright: 2002-2018, Adobe Systems Incorporated
+           2017-2019, Amin Abedi (@aminabedi68)-www.fontamin.com
+           2015, Cadson Demak <info@cadsondemak.com>
+           2011-2020, Google Inc
+           2016, Igalia S.L. (http://igalia.com/)
+           2017, Jens Kutilek
+           2010-2017, Khaled Hosny <khaledhosny@eglug.org>
+           2016, Sascha Brawer
+           2010, Sebastian Kosch <sebastian@aldusleaf.org>
+           2008, The Bungee Project Authors <david@djr.com>
+           1993-2016, The Font Bureau, Inc
+           2016, The M+ Project Authors
+           2021, The Qahiri Project Authors (github.com/aliftype/qahiri)
+           2016-2019, Unicode, Inc
+License: OFL-1.1
+
+Files: test/shape/data/in-house/fonts/*
+Copyright: 2000-2016, Adobe Systems Incorporated
+           2016, Alfredo Marco Pradil
+           2018-2022, David Corbett
+           2010-2022, Google, Inc
+           2011-2012, Lohit Fonts Project contributors <https://pagure.io/lohit>
+           2013-2020, Microsoft Corporation
+           2018, SIL International (http://scripts.sil.org)
+           2010-2021, The Amiri Project Authors (https://github.com/aliftype/amiri)
+           2015-2021, The Mada Project Authors
+           2021, The Qahiri Project Authors (github.com/aliftype/qahiri)
+           2021, The Raqq Project Authors (github.com/aliftype/raqq)
+           2018, Unicode, Inc
+           2005, Zawgyi.net & Alpha Mandalay
+License: OFL-1.1
+
+Files: test/subset/data/*
+Copyright: 2002-2018, Adobe Systems Incorporated (http://www.adobe.com/)
+           2012, Andhrapradesh Society for Knowledge Networks (fonts.siliconandhra.org)
+           2013, Danh Hong (khmertype.org)
+           2007, Denis Moyogo Jacquerye <moyogo@gmail.com>
+           2011-2012, George W. Nuss (http://www.fulbefouta.com)
+           2010-2016, Google Inc
+           2011, Hjort Nidudsson
+           2019, Inter IKEA Systems B.V. (www.ikea.com)
+           2010, NHN Corporation
+           2011-2012, Sorkin Type Co (www.sorkintype.com)
+           2013, The Alegreya Sans Project Authors (https://github.com/huertatipografica/Alegreya-Sans)
+           2010-2020, The Amiri Project Authors (https://github.com/alif-type/amiri)
+           2008, The Bungee Project Authors <david@djr.com>
+           2007-2008, The C&MA Guinea Fulbe Team
+           2011, The Comfortaa Project Authors (https://github.com/alexeiva/comfortaa)
+           2020, The Fraunces Project Authors (github.com/undercasetype/Fraunces)
+           2016, The M+ Project Authors
+           2021, The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS)
+           2019, The Noto Project Authors (github. com/googlei18n/noto-fonts)
+           2017, The Roboto Flex Project Authors (https://github.com/TypeNetwork/Roboto-Flex)
+           2004-2020, SIL International (http://www.sil.org)
+           2017, The Spectral Project Authors (http://github.com/productiontype/spectral)
+           2001-2021, The STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
+License: OFL-1.1
+
+Files: test/shape/data/aots/*
+Copyright: 2000-2016, Adobe Systems Incorporated
+License: Apache-2.0
+
+Files: perf/fonts/Roboto-Regular.ttf
+       test/api/fonts/nameID.origin.ttf
+       test/api/fonts/nameID.override.expected.ttf
+       test/api/fonts/OpenSans-Regular.ttf
+       test/shape/data/text-rendering-tests/fonts/TestShapeKndaV3.ttf
+       test/subset/data/fonts/Tinos-Italic.ttf
+       test/subset/data/fonts/IndicTestHowrah-Regular.ttf
+       test/subset/data/fonts/IndicTestJalandhar-Regular.ttf
+       test/subset/data/fonts/Roboto-Regular.ttf
+       test/subset/data/fonts/Roboto-Variable.ttf
+Copyright: 2010-2013, Google Corporation
+License: Apache-2.0
+
+Files: test/shape/data/in-house/fonts/e8691822f6a705e3e9fb48a0405c645b1a036590.ttf
+Copyright: 2020, Fredrick R. Brennan
+License: Apache-2.0
+
+Files: test/subset/data/fonts/Khmer.ttf
+Copyright: 2013, Danh Hong (khmertype.org)
+License: Apache-2.0
+
+Files: test/api/fonts/TestGVAREight.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVAREight.ttf
+Copyright: 1992-2017, Thomas A. Rickner
+License: Apache-2.0
+Comment: License mismatch resolved: https://github.com/harfbuzz/harfbuzz/issues/4062
+
+Files: test/api/fonts/TestGVAROne.ttf
+       test/api/fonts/TestGVARThree.ttf
+       test/api/fonts/TestGVARTwo.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVAROne.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVARThree.ttf
+       test/shape/data/text-rendering-tests/fonts/TestGVARTwo.ttf
+Copyright: 2016, Monotype Hong Kong Ltd. and Monotype Imaging Inc
+License: Monotype
+
+Files: test/shape/data/in-house/fonts/074a5ae6b19de8f29772fdd5df2d3d833f81f5e6.ttf
+       test/shape/data/in-house/fonts/1a3d8f381387dd29be1e897e4b5100ac8b4829e1.ttf
+       test/shape/data/in-house/fonts/b151cfcdaa77585d77f17a42158e0873fc8e2633.ttf
+       test/shape/data/in-house/fonts/d9b8bc10985f24796826c29f7ccba3d0ae11ec02.ttf
+Copyright: 2017, David Corbett
+License: CC0-1.0
+
+Files: test/shape/data/in-house/fonts/b722a7d09e60421f3efbc706ad348ab47b88567b.ttf
+Copyright: 2005, Mihail Bayaryn
+License: GPL-3+
+
+Files: test/shape/data/in-house/fonts/b895f8ff06493cc893ec44de380690ca0074edfa.ttf
+Copyright: 2009-2010, Yoram Gnat (yoram.gnat@gmail.com)
+           2003-2007, Ralph Hancock & John Hudson
+License: GPL-2+ with Font exception
+
+Files: test/shape/data/in-house/fonts/DFONT.dfont
+       test/shape/data/in-house/fonts/TTC.ttc
+Copyright: 2015, FontTools
+License: MIT
+Comment: https://github.com/fonttools/fonttools/blob/main/LICENSE
+
+Files: test/subset/data/expected/glyph_names/*
+       test/subset/data/fonts/Ubuntu-Regular.ttf
+Copyright: 2011, Canonical Ltd.
+License: UFL-1.0
+
+Files: aclocal.m4
+       Makefile.in
+       m4/*
+       docs/Makefile.in
+       perf/Makefile.in
+       src/Makefile.in
+       test/Makefile.in
+       test/api/Makefile.in
+       test/fuzzing/Makefile.in
+       test/shape/Makefile.in
+       test/shape/data/Makefile.in
+       test/shape/data/aots/Makefile.in
+       test/shape/data/in-house/Makefile.in
+       test/shape/data/text-rendering-tests/Makefile.in
+       test/subset/Makefile.in
+       test/subset/data/Makefile.in
+       test/subset/data/repack_tests/Makefile.in
+       test/threads/Makefile.in
+       util/Makefile.in
+Copyright: 1994-2018, Free Software Foundation, Inc
+           2004-2007, Damon Chaplin
+           2012-2015, Dan Nicholson <dbn.lists@gmail.com>
+           2003, James Henstridge
+           2009, Johan Dahlin
+           2004, Scott James Remnant <scott@netsplit.com>
+           2007-2017, Stefan Sauer
+           2003-2005, Thomas Vander Stichele <thomas@apestaart.org>
+License: FSFULLR
+
+Files: ar-lib
+       compile
+       depcomp
+       missing
+       test-driver
+Copyright: 1996-2018, Free Software Foundation, Inc
+License: GPL-2+ with AutoConf exception
+
+Files: config.guess
+       config.sub
+Copyright: 1992-2018, Free Software Foundation, Inc
+License: GPL-3+ with AutoConf exception
+
+Files: m4/ax_cxx_compile_stdcxx.m4
+Copyright: 2008, Benjamin Kosnik <bkoz@redhat.com>
+           2014-2015, Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+           2016, Krzesimir Nowak <qdlacz@gmail.com>
+           2015, Moritz Klammler <moritz@klammler.eu>
+           2015, Paul Norman <penorman@mac.com>
+           2013, Roy Stogner <roystgnr@ices.utexas.edu>
+           2012, Zack Weinberg <zackw@panix.com>
+License: FSFAP
+
+Files: m4/ax_code_coverage.m4
+Copyright: 2015, Bastien ROUCARIES
+           2012, Christian Persch
+           2012, Dan Winship
+           2012, Paolo Borelli
+           2012-2016, Philip Withnall
+           2012, Xan Lopez
+License: LGPL-2.1+
+
+Files: ltmain.sh
+Copyright: 1996-2015, Free Software Foundation, Inc
+License: GPL-2+ with LibTool exception
+
+Files: gtk-doc.make
+Copyright: 2004-2007, Damon Chaplin
+           2003, James Henstridge
+           2007-2017, Stefan Sauer
+License: GPL-3+
+
+Files: m4/ax_check_link_flag.m4
+Copyright: 2008, Guido U. Draheim <guidod@gmx.de>
+           2011, Maarten Bosmans <mkbosmans@gmail.com>
+License: GPL-3+ with AutoConf exception
+
+Files: m4/gtk-doc.m4
+Copyright: 2003, James Henstridge
+           2007-2017, Stefan Sauer
+License: GPL-3+
+
+Files: m4/ax_pthread.m4
+Copyright: 2011, Daniel Richard G <skunk@iSKUNK.ORG>
+           2008, Steven G. Johnson <stevenj@alum.mit.edu>
+License: GPL-3+ with AutoConf exception
+
+Files: install-sh
+Copyright: 1994, X Consortium
+License: Expat
+
+Files: INSTALL
+Copyright: 1994-2016, Free Software
+License: FSFAP
+
+Files: configure
+Copyright: 1992-2014, Free Software Foundation, Inc
+License: FSFUL
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+  http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License
+ can be found in the file `/usr/share/common-licenses/Apache-2.0'.
+
+License: CC0-1.0
+ On Debian systems, the text of the CC0 1.0 Universal license can be
+ found in ‘/usr/share/common-licenses/CC0-1.0’.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to
+ deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNEC-
+ TION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ .
+ Except as contained in this notice, the name of the X Consortium shall not
+ be used in advertising or otherwise to promote the sale, use or other deal-
+ ings in this Software without prior written authorization from the X Consor-
+ tium.
+
+License: FSFAP
+ Copying and distribution of this file, with or without modification, are
+ permitted in any medium without royalty provided the copyright notice
+ and this notice are preserved.  This file is offered as-is, without any
+ warranty.
+
+License: FSFUL
+ This script is free software; the Free Software Foundation
+ gives unlimited permission to copy, distribute and modify it.
+
+License: FSFULLR
+ This file is free software; the Free Software Foundation
+ gives unlimited permission to copy and/or distribute it,
+ with or without modifications, as long as this notice is preserved.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+ even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE.
+
+License: GPL-2+ with AutoConf exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception to the GNU General Public License, if you
+ distribute this file as part of a program that contains a
+ configuration script generated by Autoconf, you may include it under
+ the same distribution terms that you use for the rest of that program.
+
+License: GPL-2+ with Font exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception, if you create a document which uses this font,
+ and embed this font or unaltered portions of this font into the
+ document, this font does not by itself cause the resulting document
+ to be covered by the GNU General Public License. This exception does
+ not however invalidate any other reasons why the document might be
+ covered by the GNU General Public License. If you modify this font,
+ you may extend this exception to your version of the font, but you
+ are not obligated to do so. If you do not wish to do so, delete this
+ exception statement from your version.
+
+License: GPL-2+ with LibTool exception
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ .
+ As a special exception to the GNU General Public License,
+ if you distribute this file as part of a program or library that
+ is built using GNU Libtool, you may include this file under the
+ same distribution terms that you use for the rest of that program.
+
+License: GPL-3+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or (at
+ your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+License: GPL-3+ with AutoConf exception
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License, version 3 can be found in "/usr/share/common-licenses/GPL-3".
+ .
+ As a special exception to the GNU General Public License, if you
+ distribute this file as part of a program that contains a
+ configuration script generated by Autoconf, you may include it under
+ the same distribution terms that you use for the rest of that program.
+
+License: ISC
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+License: LGPL-2.1+
+ This library is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation; either version 2.1 of the License, or (at
+ your option) any later version.
+ .
+ This library is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU Lesser General Public
+ License, version 2.1 can be found in "/usr/share/common-licenses/LGPL-2.1".
+
+License: MIT
+ Permission is hereby granted, without written agreement and without license or
+ royalty fees, to use, copy, modify, and distribute this software and its
+ documentation for any purpose, provided that the above copyright notice and
+ the following two paragraphs appear in all copies of this software.
+ .
+ IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR DIRECT,
+ INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE
+ OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE COPYRIGHT HOLDER HAS BEEN
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ .
+ THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+ AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT,
+ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+License: OFL-1.1
+ SIL OPEN FONT LICENSE
+ .
+ Version 1.1 - 26 February 2007
+ .
+ PREAMBLE
+ The goals of the Open Font License (OFL) are to stimulate worldwide
+ development of collaborative font projects, to support the font creation
+ efforts of academic and linguistic communities, and to provide a free and
+ open framework in which fonts may be shared and improved in partnership
+ with others.
+ .
+ The OFL allows the licensed fonts to be used, studied, modified and
+ redistributed freely as long as they are not sold by themselves. The
+ fonts, including any derivative works, can be bundled, embedded,
+ redistributed and/or sold with any software provided that any reserved
+ names are not used by derivative works. The fonts and derivatives,
+ however, cannot be released under any other type of license. The
+ requirement for fonts to remain under this license does not apply
+ to any document created using the fonts or their derivatives.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this license and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Reserved Font Name" refers to any names specified as such after the
+ copyright statement(s).
+ .
+ "Original Version" refers to the collection of Font Software components as
+ distributed by the Copyright Holder(s).
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting - in part or in whole - any of the components of the
+ Original Version, by changing formats or by porting the Font Software to a
+ new environment.
+ .
+ "Author" refers to any designer, engineer, programmer, technical
+ writer or other person who contributed to the Font Software.
+ .
+ PERMISSION & CONDITIONS
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Font Software, to use, study, copy, merge, embed, modify,
+ redistribute, and sell modified and unmodified copies of the Font
+ Software, subject to the following conditions:
+ .
+ 1) Neither the Font Software nor any of its individual components,
+ in Original or Modified Versions, may be sold by itself.
+ .
+ 2) Original or Modified Versions of the Font Software may be bundled,
+ redistributed and/or sold with any software, provided that each copy
+ contains the above copyright notice and this license. These can be
+ included either as stand-alone text files, human-readable headers or
+ in the appropriate machine-readable metadata fields within text or
+ binary files as long as those fields can be easily viewed by the user.
+ .
+ 3) No Modified Version of the Font Software may use the Reserved Font
+ Name(s) unless explicit written permission is granted by the corresponding
+ Copyright Holder. This restriction only applies to the primary font name as
+ presented to the users.
+ .
+ 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+ Software shall not be used to promote, endorse or advertise any
+ Modified Version, except to acknowledge the contribution(s) of the
+ Copyright Holder(s) and the Author(s) or with their explicit written
+ permission.
+ .
+ 5) The Font Software, modified or unmodified, in part or in whole,
+ must be distributed entirely under this license, and must not be
+ distributed under any other license. The requirement for fonts to
+ remain under this license does not apply to any document created
+ using the Font Software.
+ .
+ TERMINATION
+ This license becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+ OTHER DEALINGS IN THE FONT SOFTWARE.
+
+License: Monotype
+ This font software is the property of Monotype Imaging Inc., one of its
+ affiliated entities, or its licensors (collectively, Monotype) and its use
+ by you is covered under the terms of a license agreement.
+ .
+ You have obtained this font software either directly from Monotype or from the
+ Unicode Consortium. Monotype has granted the Consortium and recipients of the
+ this font distributed by the Consortium, permission, free of charge, to use,
+ copy modify, publish, distribute, sublicense, and/or sell copies of the font,
+ and to permit persons to whom the font is distributed to do so. In addition,
+ Monotype grants to the Consortium the worldwide, nonexclusive, royalty-free,
+ paid-up, and irrevocable rights under Monotype's copyright rights to
+ reproduce, publicly display, publicly perform, prepare derivative works of,
+ and distribute copies of the font, and the right to sublicense others who
+ legally receive copies of the font.
+ .
+ You can learn more about Monotype here:  www.monotype.com
+
+License: UFL-1.0
+ -------------------------------
+ UBUNTU FONT LICENCE Version 1.0
+ -------------------------------
+ .
+ PREAMBLE
+ This licence allows the licensed fonts to be used, studied, modified and
+ redistributed freely. The fonts, including any derivative works, can be
+ bundled, embedded, and redistributed provided the terms of this licence
+ are met. The fonts and derivatives, however, cannot be released under
+ any other licence. The requirement for fonts to remain under this
+ licence does not require any document created using the fonts or their
+ derivatives to be published under this licence, as long as the primary
+ purpose of the document is not to be a vehicle for the distribution of
+ the fonts.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this licence and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Original Version" refers to the collection of Font Software components
+ as received under this licence.
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting -- in part or in whole -- any of the components of the
+ Original Version, by changing formats or by porting the Font Software to
+ a new environment.
+ .
+ "Copyright Holder(s)" refers to all individuals and companies who have a
+ copyright ownership of the Font Software.
+ .
+ "Substantially Changed" refers to Modified Versions which can be easily
+ identified as dissimilar to the Font Software by users of the Font
+ Software comparing the Original Version with the Modified Version.
+ .
+ To "Propagate" a work means to do anything with it that, without
+ permission, would make you directly or secondarily liable for
+ infringement under applicable copyright law, except executing it on a
+ computer or modifying a private copy. Propagation includes copying,
+ distribution (with or without modification and with or without charging
+ a redistribution fee), making available to the public, and in some
+ countries other activities as well.
+ .
+ PERMISSION & CONDITIONS
+ This licence does not grant any rights under trademark law and all such
+ rights are reserved.
+ .
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of the Font Software, to propagate the Font Software, subject to
+ the below conditions:
+ .
+ 1) Each copy of the Font Software must contain the above copyright
+ notice and this licence. These can be included either as stand-alone
+ text files, human-readable headers or in the appropriate machine-
+ readable metadata fields within text or binary files as long as those
+ fields can be easily viewed by the user.
+ .
+ 2) The font name complies with the following:
+ (a) The Original Version must retain its name, unmodified.
+ (b) Modified Versions which are Substantially Changed must be renamed to
+ avoid use of the name of the Original Version or similar names entirely.
+ (c) Modified Versions which are not Substantially Changed must be
+ renamed to both (i) retain the name of the Original Version and (ii) add
+ additional naming elements to distinguish the Modified Version from the
+ Original Version. The name of such Modified Versions must be the name of
+ the Original Version, with "derivative X" where X represents the name of
+ the new work, appended to that name.
+ .
+ 3) The name(s) of the Copyright Holder(s) and any contributor to the
+ Font Software shall not be used to promote, endorse or advertise any
+ Modified Version, except (i) as required by this licence, (ii) to
+ acknowledge the contribution(s) of the Copyright Holder(s) or (iii) with
+ their explicit written permission.
+ .
+ 4) The Font Software, modified or unmodified, in part or in whole, must
+ be distributed entirely under this licence, and must not be distributed
+ under any other licence. The requirement for fonts to remain under this
+ licence does not affect any document created using the Font Software,
+ except any version of the Font Software extracted from a document
+ created using the Font Software may only be distributed under this
+ licence.
+ .
+ TERMINATION
+ This licence becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+ DEALINGS IN THE FONT SOFTWARE.
+
+License: Unicode
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Unicode data files and any associated documentation
+ (the "Data Files") or Unicode software and any associated documentation
+ (the "Software") to deal in the Data Files or Software
+ without restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, and/or sell copies of
+ the Data Files or Software, and to permit persons to whom the Data Files
+ or Software are furnished to do so, provided that either
+ (a) this copyright and permission notice appear with all copies
+ of the Data Files or Software, or
+ (b) this copyright and permission notice appear in associated
+ Documentation.
+ .
+ THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+ IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+ NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+ DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+ .
+ Except as contained in this notice, the name of a copyright holder
+ shall not be used in advertising or otherwise to promote the sale,
+ use or other dealings in these Data Files or Software without prior
+ written authorization of the copyright holder.


### PR DESCRIPTION
During packetry startup on Ubuntu `22.04.x` (and possibly others) the system will attempt to load `libharfbuzz` even though we are not linking to it directly, with the result that the system's version gets loaded instead:

```
openat(AT_FDCWD, "/tmp/.mount_packetjchMhG/usr/bin/../lib/libharfbuzz.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/lib/x86_64-linux-gnu/libharfbuzz.so.0", O_RDONLY|O_CLOEXEC) = 4
read(4, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0\0\0\0\0\0\0\0"..., 832) = 832
```

Because the version of `libharfbuzz` that ships with Ubuntu `22.04.x` is quite a lot older than the version of `libpango` we ship with the AppImage the following error results:

```
❯ ./packetry-x86_64.AppImage
/tmp/.mount_packetiCLpnp/AppRun.wrapped: symbol lookup error: /tmp/.mount_packetiCLpnp/usr/bin/../lib/libpango-1.0.so.0: undefined symbol: hb_ot_layout_get_horizontal_baseline_tag_for_script
```

This PR adds the version of `libharfbuzz` generated by our GTK `4.14.4` source build to the AppImage.

---
closes #172 