### PR TITLE
Make traffic and device windows display correctly

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -369,8 +369,6 @@ pub fn activate(application: &Application) -> Result<(), Error> {
     use FileAction::*;
 
     let window = gtk::ApplicationWindow::builder()
-        .default_width(320)
-        .default_height(480)
         .application(application)
         .title("Packetry")
         .build();
@@ -468,15 +466,13 @@ pub fn activate(application: &Application) -> Result<(), Error> {
     let (_, capture) = create_capture()?;
 
     let traffic_window = gtk::ScrolledWindow::builder()
-        .hscrollbar_policy(gtk::PolicyType::Automatic)
-        .min_content_height(480)
         .min_content_width(640)
+        .min_content_height(480)
         .build();
 
     let device_window = gtk::ScrolledWindow::builder()
-        .hscrollbar_policy(gtk::PolicyType::Automatic)
-        .min_content_height(480)
         .min_content_width(240)
+        .min_content_height(480)
         .build();
 
     let detail_text = gtk::TextBuffer::new(None);
@@ -489,8 +485,6 @@ pub fn activate(application: &Application) -> Result<(), Error> {
         .build();
 
     let detail_window = gtk::ScrolledWindow::builder()
-        .hscrollbar_policy(gtk::PolicyType::Automatic)
-        .min_content_width(640)
         .min_content_height(120)
         .child(&detail_view)
         .build();
@@ -500,15 +494,17 @@ pub fn activate(application: &Application) -> Result<(), Error> {
         .wide_handle(true)
         .start_child(&traffic_window)
         .end_child(&device_window)
-        .vexpand(true)
-        .build();
+        .shrink_start_child(false)
+        .shrink_end_child(false)
+       .build();
 
     let vertical_panes = gtk::Paned::builder()
         .orientation(Orientation::Vertical)
         .wide_handle(true)
         .start_child(&horizontal_panes)
         .end_child(&detail_window)
-        .hexpand(true)
+        .shrink_start_child(false)
+        .shrink_end_child(false)
         .build();
 
     let separator = gtk::Separator::new(Orientation::Horizontal);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -368,7 +368,23 @@ macro_rules! button_action {
 pub fn activate(application: &Application) -> Result<(), Error> {
     use FileAction::*;
 
+    // These are used to set initial size of the main application window,
+    // as well as the positions for the window pane dividers.
+    // "non_pane_height" is the approx height of non Paned widgets,
+    // eg action_bar + status bar.
+    // These don't need to be pixel perfect, just close enough to just generate
+    // acceptable values.
+    let app_width = 800;
+    let app_height = 600;
+    let non_pane_height = 100;
+    let hori_pane_width = app_width;
+    let vert_pane_height = app_height - non_pane_height;
+    let traffic_width_percent = 70;
+    let traffic_height_percent = 75;
+
     let window = gtk::ApplicationWindow::builder()
+        .default_width(app_width)
+        .default_height(app_height)
         .application(application)
         .title("Packetry")
         .build();
@@ -466,13 +482,9 @@ pub fn activate(application: &Application) -> Result<(), Error> {
     let (_, capture) = create_capture()?;
 
     let traffic_window = gtk::ScrolledWindow::builder()
-        .min_content_width(640)
-        .min_content_height(480)
-        .build();
+       .build();
 
     let device_window = gtk::ScrolledWindow::builder()
-        .min_content_width(240)
-        .min_content_height(480)
         .build();
 
     let detail_text = gtk::TextBuffer::new(None);
@@ -485,7 +497,6 @@ pub fn activate(application: &Application) -> Result<(), Error> {
         .build();
 
     let detail_window = gtk::ScrolledWindow::builder()
-        .min_content_height(120)
         .child(&detail_view)
         .build();
 
@@ -496,6 +507,9 @@ pub fn activate(application: &Application) -> Result<(), Error> {
         .end_child(&device_window)
         .shrink_start_child(false)
         .shrink_end_child(false)
+        .hexpand(true)
+        .vexpand(true)
+        .position((hori_pane_width * traffic_width_percent) / 100)
        .build();
 
     let vertical_panes = gtk::Paned::builder()
@@ -505,6 +519,9 @@ pub fn activate(application: &Application) -> Result<(), Error> {
         .end_child(&detail_window)
         .shrink_start_child(false)
         .shrink_end_child(false)
+        .hexpand(true)
+        .vexpand(true)
+        .position((vert_pane_height * traffic_height_percent) / 100)
         .build();
 
     let separator = gtk::Separator::new(Orientation::Horizontal);


### PR DESCRIPTION
This PR fixes the below listed issues, which includes issue #132 from the issue tracker:
I have only tested these fixes in windows 11.

* The traffic window and device windows were currently displaying smaller than their requested "minimum content sizes", and these minimum sizes were not enforced when resizing the window..
* The traffic window and device windows were not always showing the top and left sides of the content in these windows.
* The "titles" at the top of the traffic window and device windows were only displayed when you scrolled to the top of the list.
* The details window didn't get a vertical scroll bar when needed.
* The details window minimum size wasnt enforced.


This does not fix:
* The traffic and device windows do not support horizontal scrolling.
I think this might be due to an issue in the 'traffic_view' and 'device_view' related code, rather than the UI init code that was changed here. My reason for this thinking is that when I set the horizontal scrollbar to "always" be displayed for traffic and device windows, it shows the scroll bar as taking up the full space and so unable to be moved left or right. This is the scrollbar behaviour you get when it thinks the contents already fits into the scrollable window, and so doesn't need scrolling. So it seems like 'traffic_view' and 'device_view' are maybe misrepresenting the size of their rows.