### PR TITLE
Backend API and iCE40-usbtrace support

### DIFF
--- a/src/backend/cynthion.rs
+++ b/src/backend/cynthion.rs
@@ -22,7 +22,7 @@ use crate::util::handle_thread_panic;
 
 use super::{
     transfer_queue::TransferQueue,
-    BackendStop, DeviceUsability, InterfaceSelection, Speed, TracePacket,
+    BackendStop, DeviceUsability, InterfaceSelection, Speed, TimestampedPacket,
 };
 use super::DeviceUsability::*;
 
@@ -343,9 +343,9 @@ impl CynthionHandle {
 }
 
 impl Iterator for CynthionStream {
-    type Item = TracePacket;
+    type Item = TimestampedPacket;
 
-    fn next(&mut self) -> Option<TracePacket> {
+    fn next(&mut self) -> Option<TimestampedPacket> {
         loop {
             // Do we have another packet already in the buffer?
             match self.next_buffered_packet() {
@@ -364,7 +364,7 @@ impl Iterator for CynthionStream {
 }
 
 impl CynthionStream {
-    fn next_buffered_packet(&mut self) -> Option<TracePacket> {
+    fn next_buffered_packet(&mut self) -> Option<TimestampedPacket> {
         // Are we waiting for a padding byte?
         if self.padding_due {
             if self.buffer.is_empty() {
@@ -416,7 +416,7 @@ impl CynthionStream {
         }
 
         // Remove the rest of the packet from the buffer and return it.
-        Some(TracePacket {
+        Some(TimestampedPacket {
             timestamp_ns: clk_to_ns(self.total_clk_cycles),
             bytes: self.buffer.drain(0..packet_len).collect()
         })

--- a/src/backend/cynthion.rs
+++ b/src/backend/cynthion.rs
@@ -431,3 +431,15 @@ impl CynthionStream {
         self.total_clk_cycles += clk_cycles as u64;
     }
 }
+
+impl Speed {
+    pub fn mask(&self) -> u8 {
+        use Speed::*;
+        match self {
+            Auto => 0b0001,
+            Low  => 0b0010,
+            Full => 0b0100,
+            High => 0b1000,
+        }
+    }
+}

--- a/src/backend/cynthion.rs
+++ b/src/backend/cynthion.rs
@@ -18,14 +18,11 @@ use nusb::{
     Interface
 };
 
+use crate::util::handle_thread_panic;
+
 use super::{
     transfer_queue::TransferQueue,
-    BackendStop,
-    DeviceUsability,
-    InterfaceSelection,
-    Speed,
-    handle_thread_panic,
-    TracePacket,
+    BackendStop, DeviceUsability, InterfaceSelection, Speed, TracePacket,
 };
 use super::DeviceUsability::*;
 

--- a/src/backend/ice40usbtrace.rs
+++ b/src/backend/ice40usbtrace.rs
@@ -22,7 +22,7 @@ use super::{handle_thread_panic, BackendStop, DeviceUsability, InterfaceSelectio
 
 const VID: u16 = 0x1d50;
 const PID: u16 = 0x617e;
-
+const INTERFACE: u8 = 1;
 const ENDPOINT: u8 = 0x81;
 
 const READ_LEN: usize = 1024;
@@ -75,7 +75,7 @@ fn check_device(device_info: &DeviceInfo) -> Result<(), Error> {
 
     // Try to claim the interface.
     let _interface = device
-        .claim_interface(1)
+        .claim_interface(INTERFACE)
         .context("Failed to claim interface")?;
 
     // Now we have a usable device.
@@ -92,7 +92,7 @@ impl Ice40UsbtraceDevice {
                     device_info,
                     usability: Usable(
                         InterfaceSelection {
-                            interface_number: 1,
+                            interface_number: INTERFACE,
                             alt_setting_number: 0,
                         },
                         vec![Speed::Full],

--- a/src/backend/ice40usbtrace.rs
+++ b/src/backend/ice40usbtrace.rs
@@ -64,7 +64,9 @@ pub struct Ice40UsbtraceStream {
 /// Check whether an iCE40-usbtrace device has an accessible analyzer interface.
 fn check_device(device_info: &DeviceInfo) -> Result<(), Error> {
     // Check we can open the device.
-    let device = device_info.open().context("Failed to open device")?;
+    let device = device_info
+        .open()
+        .context("Failed to open device")?;
 
     // Read the active configuration.
     let _config = device
@@ -72,7 +74,9 @@ fn check_device(device_info: &DeviceInfo) -> Result<(), Error> {
         .context("Failed to retrieve active configuration")?;
 
     // Try to claim the interface.
-    let _interface = device.claim_interface(1).context("Failed to claim interface")?;
+    let _interface = device
+        .claim_interface(1)
+        .context("Failed to claim interface")?;
 
     // Now we have a usable device.
     Ok(())
@@ -171,7 +175,8 @@ impl Ice40UsbtraceHandle {
         let worker = spawn(move || block_on(queue.process(queue_stop_rx)));
 
         // Wait until this thread is signalled to stop.
-        block_on(stop).context("Sender was dropped")?;
+        block_on(stop)
+            .context("Sender was dropped")?;
 
         // Stop capture.
         self.stop_capture()?;
@@ -183,7 +188,8 @@ impl Ice40UsbtraceHandle {
         queue_stop_tx
             .send(())
             .or_else(|_| bail!("Failed sending stop signal to queue worker"))?;
-        handle_thread_panic(worker.join())?.context("Error in queue worker thread")?;
+        handle_thread_panic(worker.join())?
+            .context("Error in queue worker thread")?;
 
         self.flush_buffer()?;
 

--- a/src/backend/ice40usbtrace.rs
+++ b/src/backend/ice40usbtrace.rs
@@ -368,7 +368,7 @@ impl Ice40UsbtraceStream {
         quotient * 125 + TABLE[remainder as usize]
     }
 
-    fn parse_packet(&mut self) -> ParseResult<TracePacket> {
+    fn parse_packet(&mut self) -> ParseResult {
         use Pid::*;
         use ParseResult::*;
 
@@ -469,8 +469,8 @@ impl Ice40UsbtraceStream {
     }
 }
 
-pub enum ParseResult<T> {
-    Parsed(T),
+pub enum ParseResult {
+    Parsed(TracePacket),
     ParseError(Error),
     Ignored,
     NeedMoreData,

--- a/src/backend/ice40usbtrace.rs
+++ b/src/backend/ice40usbtrace.rs
@@ -350,7 +350,10 @@ impl std::fmt::Display for Pid {
 impl Ice40UsbStream {
     fn ns(&self) -> u64 {
         // 24MHz clock, a tick is 41.666...ns
-        self.ts * 1000 / 24
+        const TABLE: [u64; 3] = [0, 41, 83];
+        let quotient = self.ts / 3;
+        let remainder = self.ts % 3;
+        quotient * 125 + TABLE[remainder as usize]
     }
 
     fn parse_packet(&mut self) -> ParseResult<TracePacket> {

--- a/src/backend/ice40usbtrace.rs
+++ b/src/backend/ice40usbtrace.rs
@@ -14,11 +14,12 @@ use nusb::{
 };
 
 use crate::usb::crc5;
+use crate::util::handle_thread_panic;
 
 use super::DeviceUsability::*;
 use super::{
     transfer_queue::TransferQueue,
-    handle_thread_panic, BackendStop, DeviceUsability, InterfaceSelection, Speed, TracePacket
+    BackendStop, DeviceUsability, InterfaceSelection, Speed, TracePacket
 };
 
 const VID: u16 = 0x1d50;

--- a/src/backend/ice40usbtrace.rs
+++ b/src/backend/ice40usbtrace.rs
@@ -1,0 +1,460 @@
+use std::collections::VecDeque;
+use std::sync::mpsc;
+use std::thread::{sleep, spawn};
+use std::time::Duration;
+
+use anyhow::{bail, Context as ErrorContext, Error};
+use futures_channel::oneshot;
+use futures_lite::future::block_on;
+use futures_util::future::FusedFuture;
+use futures_util::{select_biased, FutureExt};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use nusb::{
+    self,
+    transfer::{Control, ControlType, Queue, Recipient, RequestBuffer, TransferError},
+    DeviceInfo, Interface,
+};
+
+use crate::usb::crc5;
+
+use super::DeviceUsability::*;
+use super::{handle_thread_panic, BackendStop, DeviceUsability, InterfaceSelection, Speed, TracePacket};
+
+const VID: u16 = 0x1d50;
+const PID: u16 = 0x617e;
+
+const ENDPOINT: u8 = 0x81;
+
+const READ_LEN: usize = 1024;
+const NUM_TRANSFERS: usize = 4;
+
+#[derive(Debug, Clone, Copy, IntoPrimitive)]
+#[repr(u8)]
+enum Command {
+    //CaptureStatus = 0x10,
+    CaptureStart = 0x12,
+    CaptureStop = 0x13,
+    //BufferGetLevel = 0x20,
+    BufferFlush = 0x21,
+}
+
+/// A ICE40usbtrace device attached to the system.
+pub struct Ice40UsbtraceDevice {
+    pub device_info: DeviceInfo,
+    pub usability: DeviceUsability,
+}
+
+/// A handle to an open ICE40usbtrace.
+#[derive(Clone)]
+pub struct Ice40UsbtraceHandle {
+    interface: Interface,
+}
+
+pub struct Ice40UsbtraceQueue {
+    tx: mpsc::Sender<Vec<u8>>,
+    queue: Queue<RequestBuffer>,
+}
+
+pub struct Ice40UsbStream {
+    receiver: mpsc::Receiver<Vec<u8>>,
+    buffer: VecDeque<u8>,
+    ts: u64,
+}
+
+/// Check whether a ICE40usbtrace device has an accessible analyzer interface.
+fn check_device(device_info: &DeviceInfo) -> Result<(), Error> {
+    // Check we can open the device.
+    let device = device_info.open().context("Failed to open device")?;
+
+    // Read the active configuration.
+    let _config = device
+        .active_configuration()
+        .context("Failed to retrieve active configuration")?;
+
+    // Try to claim the interface.
+    let _interface = device.claim_interface(1).context("Failed to claim interface")?;
+
+    // Now we have a usable device.
+    Ok(())
+}
+
+impl Ice40UsbtraceDevice {
+    pub fn scan() -> Result<Vec<Ice40UsbtraceDevice>, Error> {
+        Ok(nusb::list_devices()?
+            .filter(|info| info.vendor_id() == VID)
+            .filter(|info| info.product_id() == PID)
+            .map(|device_info| match check_device(&device_info) {
+                Ok(()) => Ice40UsbtraceDevice {
+                    device_info,
+                    usability: Usable(
+                        InterfaceSelection {
+                            interface_number: 1,
+                            alt_setting_number: 0,
+                        },
+                        vec![Speed::Full],
+                    ),
+                },
+                Err(err) => Ice40UsbtraceDevice {
+                    device_info,
+                    usability: Unusable(format!("{}", err)),
+                },
+            })
+            .collect())
+    }
+
+    pub fn open(&self) -> Result<Ice40UsbtraceHandle, Error> {
+        match &self.usability {
+            Usable(iface, _) => {
+                let device = self.device_info.open()?;
+                let interface = device.claim_interface(iface.interface_number)?;
+                if iface.alt_setting_number != 0 {
+                    interface.set_alt_setting(iface.alt_setting_number)?;
+                }
+                Ok(Ice40UsbtraceHandle { interface })
+            }
+            Unusable(reason) => bail!("Device not usable: {}", reason),
+        }
+    }
+}
+
+impl Ice40UsbtraceHandle {
+    pub fn start<F>(&self, speed: Speed, result_handler: F) -> Result<(Ice40UsbStream, BackendStop), Error>
+    where
+        F: FnOnce(Result<(), Error>) + Send + 'static,
+    {
+        // Channel to pass captured data to the decoder thread.
+        let (tx, rx) = mpsc::channel();
+        // Channel to stop the capture thread on request.
+        let (stop_tx, stop_rx) = oneshot::channel();
+        // Clone handle to give to the worker thread.
+        let handle = self.clone();
+        // Start worker thread.
+        let worker = spawn(move || result_handler(handle.run_capture(speed, tx, stop_rx)));
+        Ok((
+            Ice40UsbStream {
+                receiver: rx,
+                buffer: VecDeque::new(),
+                ts: 0,
+            },
+            BackendStop {
+                stop_request: stop_tx,
+                worker,
+            },
+        ))
+    }
+
+    fn run_capture(
+        mut self,
+        speed: Speed,
+        tx: mpsc::Sender<Vec<u8>>,
+        stop: oneshot::Receiver<()>,
+    ) -> Result<(), Error> {
+        // Set up a separate channel pair to stop queue processing.
+        let (queue_stop_tx, queue_stop_rx) = oneshot::channel();
+
+        // Stop the ICE40usbtrace was left running before and ignore any errors
+        let _ = self.stop_capture();
+        // Leave queue worker running briefly to receive flushed data.
+        sleep(Duration::from_millis(100));
+        let _ = self.flush_buffer();
+
+        // ICE40usbtrace only supports full-speed captures
+        assert_eq!(speed, Speed::Full);
+
+        // Start capture.
+        self.start_capture()?;
+
+        // Set up transfer queue.
+        let mut queue = Ice40UsbtraceQueue::new(&self.interface, tx);
+
+        // Spawn a worker thread to process queue until stopped.
+        let worker = spawn(move || block_on(queue.process(queue_stop_rx)));
+
+        // Wait until this thread is signalled to stop.
+        block_on(stop).context("Sender was dropped")?;
+
+        // Stop capture.
+        self.stop_capture()?;
+
+        // Leave queue worker running briefly to receive flushed data.
+        sleep(Duration::from_millis(100));
+
+        // Signal queue processing to stop, then join the worker thread.
+        queue_stop_tx
+            .send(())
+            .or_else(|_| bail!("Failed sending stop signal to queue worker"))?;
+        handle_thread_panic(worker.join())?.context("Error in queue worker thread")?;
+
+        self.flush_buffer()?;
+
+        Ok(())
+    }
+
+    fn start_capture(&mut self) -> Result<(), Error> {
+        self.write_request(Command::CaptureStart)?;
+        //println!("Capture enabled, speed: {}", speed.description());
+        Ok(())
+    }
+
+    fn stop_capture(&mut self) -> Result<(), Error> {
+        self.write_request(Command::CaptureStop)?;
+        println!("Capture disabled");
+        Ok(())
+    }
+
+    fn flush_buffer(&mut self) -> Result<(), Error> {
+        self.write_request(Command::BufferFlush)?;
+        println!("Buffer flushed");
+        Ok(())
+    }
+
+    fn write_request(&mut self, request: Command) -> Result<(), Error> {
+        let control = Control {
+            control_type: ControlType::Vendor,
+            recipient: Recipient::Interface,
+            request: request.into(),
+            value: 0,
+            index: 0,
+        };
+        let data = &[];
+        let timeout = Duration::from_secs(1);
+        self.interface
+            .control_out_blocking(control, data, timeout)
+            .context("Write request failed")?;
+        Ok(())
+    }
+}
+
+impl Ice40UsbtraceQueue {
+    fn new(interface: &Interface, tx: mpsc::Sender<Vec<u8>>) -> Ice40UsbtraceQueue {
+        let mut queue = interface.bulk_in_queue(ENDPOINT);
+        while queue.pending() < NUM_TRANSFERS {
+            queue.submit(RequestBuffer::new(READ_LEN));
+        }
+        Ice40UsbtraceQueue { queue, tx }
+    }
+
+    async fn process(&mut self, mut stop: oneshot::Receiver<()>) -> Result<(), Error> {
+        use TransferError::Cancelled;
+        loop {
+            select_biased!(
+                _ = stop => {
+                    // Stop requested. Cancel all transfers.
+                    self.queue.cancel_all();
+                }
+                completion = self.queue.next_complete().fuse() => {
+                    match completion.status {
+                        Ok(()) => {
+                            // Send data to decoder thread.
+                            self.tx.send(completion.data)
+                                .context("Failed sending capture data to channel")?;
+                            if !stop.is_terminated() {
+                                // Submit next transfer.
+                                self.queue.submit(RequestBuffer::new(READ_LEN));
+                            }
+                        },
+                        Err(Cancelled) if stop.is_terminated() => {
+                            // Transfer cancelled during shutdown. Drop it.
+                            drop(completion);
+                            if self.queue.pending() == 0 {
+                                // All cancellations now handled.
+                                return Ok(());
+                            }
+                        },
+                        Err(usb_error) => {
+                            // Transfer failed.
+                            return Err(Error::from(usb_error));
+                        }
+                    }
+                }
+            );
+        }
+    }
+}
+
+impl Iterator for Ice40UsbStream {
+    type Item = TracePacket;
+
+    fn next(&mut self) -> Option<TracePacket> {
+        loop {
+            // Do we have another packet already in the buffer?
+            match self.next_buffered_packet() {
+                // Yes; return the packet.
+                Some(packet) => return Some(packet),
+                // No; wait for more data from the capture thread.
+                None => match self.receiver.recv().ok() {
+                    // Received more data; add it to the buffer and retry.
+                    Some(bytes) => self.buffer.extend(bytes.iter()),
+                    // Capture has ended, there are no more packets.
+                    None => return None,
+                },
+            }
+        }
+    }
+}
+
+bitfield! {
+    pub struct Header(MSB0 [u8]);
+    impl Debug;
+    u16;
+    // 24MHz ticks
+    pub get_ts, _: 31, 16;
+    pub u8, get_pid, _: 3, 0;
+    pub get_ok, _: 4;
+    pub get_dat, _: 15, 5;
+}
+
+impl<T: std::convert::AsRef<[u8]>> Header<T> {
+    pub fn pid_byte(&self) -> u8 {
+        let pid = self.get_pid();
+
+        pid | ((pid ^ 0xf) << 4)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
+#[repr(u8)]
+pub enum Pid {
+    Out = 0b0001,
+    In = 0b1001,
+    Sof = 0b0101,
+    Setup = 0b1101,
+
+    Data0 = 0b0011,
+    Data1 = 0b1011,
+
+    Ack = 0b0010,
+    Nak = 0b1010,
+    Stall = 0b1110,
+    TsOverflow = 0b0000,
+}
+
+impl std::fmt::Display for Pid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Pid::Out => "OUT",
+            Pid::In => "IN",
+            Pid::Sof => "SOF",
+            Pid::Setup => "SETUP",
+            Pid::Data0 => "DATA0",
+            Pid::Data1 => "DATA1",
+            Pid::Ack => "ACK",
+            Pid::Nak => "NAK",
+            Pid::Stall => "STALL",
+            Pid::TsOverflow => "TS OVERFLOW",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl Ice40UsbStream {
+    fn ns(&self) -> u64 {
+        // 24MHz clock, a tick is 41.666...ns
+        self.ts * 1000 / 24
+    }
+
+    fn parse_packet(&mut self) -> ParseResult<TracePacket> {
+        let header: Vec<u8> = self.buffer.drain(0..4).collect();
+        let header = Header(&header);
+
+        self.ts += u64::from(header.get_ts());
+
+        let pkt = match (header.get_pid().try_into(), header.get_ok()) {
+            // The packet header could not even be decoded, skip it
+            (Ok(Pid::TsOverflow), false) => {
+                println!("Bad packet!\n{header:?}");
+                return ParseResult::Ignored;
+            }
+            // Need to increment self.ts
+            (Ok(Pid::TsOverflow), true) => ParseResult::Ignored,
+            // Handle Data packet. If the CRC16 is wrong get_ok() returns false - push broken packet regardless
+            (Ok(Pid::Data0 | Pid::Data1), data_ok) => {
+                if !data_ok {
+                    println!("Data packet with corrupt checksum:\n{header:?}");
+                }
+
+                let mut bytes = vec![header.pid_byte()];
+                let data_len: usize = header.get_dat().into();
+                if self.buffer.len() < data_len {
+                    for byte in header.0.iter().rev() {
+                        self.buffer.push_front(*byte);
+                    }
+                    return ParseResult::NeedMoreData;
+                }
+                bytes.extend(self.buffer.drain(0..data_len));
+                ParseResult::Parsed(TracePacket {
+                    timestamp_ns: self.ns(),
+                    bytes,
+                })
+            }
+            (Ok(Pid::Sof | Pid::Setup | Pid::In | Pid::Out), data_ok) => {
+                let mut bytes = vec![header.pid_byte()];
+                let mut data = header.get_dat().to_le_bytes();
+                let crc = crc5(u32::from_le_bytes([data[0], data[1], 0, 0]), 11);
+                if data_ok {
+                    data[1] |= crc << 3;
+                } else {
+                    println!("PID pattern correct, but broken CRC5:\n{header:?}");
+                    data[1] |= (!crc) << 3;
+                }
+                bytes.extend(data);
+
+                ParseResult::Parsed(TracePacket {
+                    timestamp_ns: self.ns(),
+                    bytes,
+                })
+            }
+            (Ok(Pid::Ack | Pid::Nak | Pid::Stall), data_ok) => {
+                assert!(data_ok, "PID is all there is to decode!");
+                let bytes = vec![header.pid_byte()];
+                ParseResult::Parsed(TracePacket {
+                    timestamp_ns: self.ns(),
+                    bytes,
+                })
+            }
+            (Err(_), _) => {
+                println!("Error decoding PID for header:\n{header:?}");
+                ParseResult::Ignored
+            }
+        };
+
+        pkt
+    }
+
+    fn next_buffered_packet(&mut self) -> Option<TracePacket> {
+        loop {
+            // Need more bytes for the header
+            if self.buffer.len() < 4 {
+                return None;
+            }
+
+            match self.parse_packet() {
+                ParseResult::Parsed(pkt) => return Some(pkt),
+                ParseResult::Ignored => continue,
+                ParseResult::NeedMoreData => return None,
+            }
+        }
+    }
+}
+
+pub enum ParseResult<T> {
+    Parsed(T),
+    Ignored,
+    NeedMoreData,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_header() {
+        let data: [u8; 4] = [8, 1, 255, 241];
+        let header = Header(&data);
+
+        assert_eq!(header.get_ts(), 65521);
+        assert_eq!(header.get_pid(), 0);
+        assert!(header.get_ok());
+        assert_eq!(header.get_dat(), 1);
+    }
+}

--- a/src/backend/ice40usbtrace.rs
+++ b/src/backend/ice40usbtrace.rs
@@ -366,7 +366,7 @@ impl Ice40UsbtraceStream {
 
         self.ts += u64::from(header.ts());
 
-        let pkt = match (header.pid().try_into(), header.ok()) {
+        match (header.pid().try_into(), header.ok()) {
             // The packet header could not even be decoded, skip it
             (Ok(TsOverflow), false) => {
                 println!("Bad packet!\n{header:?}");
@@ -422,9 +422,7 @@ impl Ice40UsbtraceStream {
             (Err(_), _) => ParseError(
                 anyhow!("Error decoding PID for header:\n{header:?}")
             )
-        };
-
-        pkt
+        }
     }
 
     fn next_buffered_packet(&mut self) -> Option<TracePacket> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -56,7 +56,7 @@ pub enum DeviceUsability {
 }
 
 #[derive(Debug)]
-pub struct TracePacket {
+pub struct TimestampedPacket {
     pub timestamp_ns: u64,
     pub bytes: Vec<u8>,
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,8 +5,9 @@ use futures_channel::oneshot;
 use num_enum::{FromPrimitive, IntoPrimitive};
 
 pub mod cynthion;
+pub mod ice40usbtrace;
 
-#[derive(Copy, Clone, FromPrimitive, IntoPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum Speed {
     #[default]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -30,16 +30,6 @@ impl Speed {
             Low => "Low (1.5Mbps)",
         }
     }
-
-    pub fn mask(&self) -> u8 {
-        use Speed::*;
-        match self {
-            Auto => 0b0001,
-            Low  => 0b0010,
-            Full => 0b0100,
-            High => 0b1000,
-        }
-    }
 }
 
 pub struct InterfaceSelection {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,1 +1,90 @@
+use std::thread::JoinHandle;
+
+use anyhow::{bail, Error};
+use futures_channel::oneshot;
+use num_enum::{FromPrimitive, IntoPrimitive};
+
 pub mod cynthion;
+
+#[derive(Copy, Clone, FromPrimitive, IntoPrimitive)]
+#[repr(u8)]
+pub enum Speed {
+    #[default]
+    High = 0,
+    Full = 1,
+    Low  = 2,
+    Auto = 3,
+}
+
+impl Speed {
+    pub fn description(&self) -> &'static str {
+        use Speed::*;
+        match self {
+            Auto => "Auto",
+            High => "High (480Mbps)",
+            Full => "Full (12Mbps)",
+            Low => "Low (1.5Mbps)",
+        }
+    }
+
+    pub fn mask(&self) -> u8 {
+        use Speed::*;
+        match self {
+            Auto => 0b0001,
+            Low  => 0b0010,
+            Full => 0b0100,
+            High => 0b1000,
+        }
+    }
+}
+
+pub struct InterfaceSelection {
+    interface_number: u8,
+    alt_setting_number: u8,
+}
+
+/// Whether a device is ready for use as an analyzer.
+pub enum DeviceUsability {
+    /// Device is usable via the given interface, at supported speeds.
+    Usable(InterfaceSelection, Vec<Speed>),
+    /// Device not usable, with a string explaining why.
+    Unusable(String),
+}
+
+fn handle_thread_panic<T>(result: std::thread::Result<T>) -> Result<T, Error> {
+    match result {
+        Ok(x) => Ok(x),
+        Err(panic) => {
+            let msg = match (
+                panic.downcast_ref::<&str>(),
+                panic.downcast_ref::<String>())
+            {
+                (Some(&s), _) => s,
+                (_,  Some(s)) => s,
+                (None,  None) => "<No panic message>"
+            };
+            bail!("Worker thread panic: {msg}");
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TracePacket {
+    pub timestamp_ns: u64,
+    pub bytes: Vec<u8>,
+}
+
+pub struct BackendStop {
+    stop_request: oneshot::Sender<()>,
+    worker: JoinHandle::<()>,
+}
+
+impl BackendStop {
+    pub fn stop(self) -> Result<(), Error> {
+        println!("Requesting capture stop");
+        self.stop_request.send(())
+            .or_else(|_| bail!("Failed sending stop request"))?;
+        handle_thread_panic(self.worker.join())?;
+        Ok(())
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4,6 +4,8 @@ use anyhow::{bail, Error};
 use futures_channel::oneshot;
 use num_enum::{FromPrimitive, IntoPrimitive};
 
+use crate::util::handle_thread_panic;
+
 pub mod cynthion;
 pub mod ice40usbtrace;
 mod transfer_queue;
@@ -51,23 +53,6 @@ pub enum DeviceUsability {
     Usable(InterfaceSelection, Vec<Speed>),
     /// Device not usable, with a string explaining why.
     Unusable(String),
-}
-
-fn handle_thread_panic<T>(result: std::thread::Result<T>) -> Result<T, Error> {
-    match result {
-        Ok(x) => Ok(x),
-        Err(panic) => {
-            let msg = match (
-                panic.downcast_ref::<&str>(),
-                panic.downcast_ref::<String>())
-            {
-                (Some(&s), _) => s,
-                (_,  Some(s)) => s,
-                (None,  None) => "<No panic message>"
-            };
-            bail!("Worker thread panic: {msg}");
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,15 +1,71 @@
-use std::thread::JoinHandle;
+use std::collections::BTreeMap;
+use std::sync::mpsc;
+use std::thread::{JoinHandle, spawn, sleep};
+use std::time::Duration;
 
-use anyhow::{bail, Error};
+use anyhow::{Context, Error, bail};
 use futures_channel::oneshot;
+use futures_lite::future::block_on;
+use nusb::{self, DeviceInfo};
 use num_enum::{FromPrimitive, IntoPrimitive};
+use once_cell::sync::Lazy;
 
 use crate::util::handle_thread_panic;
 
 pub mod cynthion;
 pub mod ice40usbtrace;
-mod transfer_queue;
+pub mod transfer_queue;
 
+use transfer_queue::TransferQueue;
+
+type VidPid = (u16, u16);
+type ProbeFn = fn(DeviceInfo) -> Result<Box<dyn BackendDevice>, Error>;
+
+/// Map of supported (VID, PID) pairs to device-specific probe functions.
+static SUPPORTED_DEVICES: Lazy<BTreeMap<VidPid, (&str, ProbeFn)>> = Lazy::new(||
+    BTreeMap::from_iter([
+        (cynthion::VID_PID,
+            ("Cynthion", cynthion::probe as ProbeFn)),
+        (ice40usbtrace::VID_PID,
+            ("iCE40-usbtrace", ice40usbtrace::probe as ProbeFn)),
+    ])
+);
+
+/// The result of identifying and probing a supported USB device.
+pub struct ProbeResult {
+    pub name: &'static str,
+    pub info: DeviceInfo,
+    pub result: Result<Box<dyn BackendDevice>, String>,
+}
+
+/// Scan for supported devices.
+pub fn scan() -> Result<Vec<ProbeResult>, Error> {
+    Ok(nusb::list_devices()?
+        .filter_map(|info|
+            SUPPORTED_DEVICES
+                .get(&(info.vendor_id(), info.product_id()))
+                .map(|(name, probe)| (name, probe(info.clone())))
+                .map(|(name, result)|
+                    ProbeResult {
+                        name,
+                        info,
+                        result: result.map_err(|e| format!("{e}"))
+                    }
+                ))
+        .collect()
+    )
+}
+
+/// A capture device connected to the system, not currently opened.
+pub trait BackendDevice {
+    /// Open this device to use it as a generic capture device.
+    fn open_as_generic(&self) -> Result<Box<dyn BackendHandle>, Error>;
+
+    /// Which speeds this device supports.
+    fn supported_speeds(&self) -> &[Speed];
+}
+
+/// Possible capture speed settings.
 #[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum Speed {
@@ -21,6 +77,7 @@ pub enum Speed {
 }
 
 impl Speed {
+    /// How this speed setting should be displayed in the UI.
     pub fn description(&self) -> &'static str {
         use Speed::*;
         match self {
@@ -32,34 +89,155 @@ impl Speed {
     }
 }
 
-pub struct InterfaceSelection {
-    interface_number: u8,
-    alt_setting_number: u8,
-}
-
-/// Whether a device is ready for use as an analyzer.
-pub enum DeviceUsability {
-    /// Device is usable via the given interface, at supported speeds.
-    Usable(InterfaceSelection, Vec<Speed>),
-    /// Device not usable, with a string explaining why.
-    Unusable(String),
-}
-
-#[derive(Debug)]
+/// A timestamped packet.
 pub struct TimestampedPacket {
     pub timestamp_ns: u64,
     pub bytes: Vec<u8>,
 }
 
+/// Handle used to stop an ongoing capture.
 pub struct BackendStop {
-    stop_request: oneshot::Sender<()>,
+    stop_tx: oneshot::Sender<()>,
     worker: JoinHandle::<()>,
 }
 
+pub type PacketResult = Result<TimestampedPacket, Error>;
+pub trait PacketIterator: Iterator<Item=PacketResult> + Send {}
+
+/// A handle to an open capture device.
+pub trait BackendHandle: Send + Sync {
+
+    /// Begin capture.
+    ///
+    /// This method should send whatever control requests etc are necessary to
+    /// start capture, then set up and return a `TransferQueue` that sends the
+    /// raw data from the device to `data_tx`.
+    fn begin_capture(
+        &mut self,
+        speed: Speed,
+        data_tx: mpsc::Sender<Vec<u8>>)
+    -> Result<TransferQueue, Error>;
+
+    /// End capture.
+    ///
+    /// This method should send whatever control requests etc are necessary to
+    /// stop the capture. The transfer queue will be kept running for a short
+    /// while afterwards to receive data that is still queued in the device.
+    fn end_capture(&mut self) -> Result<(), Error>;
+
+    /// Post-capture cleanup.
+    ///
+    /// This method will be called after the transfer queue has been shut down,
+    /// and should do any cleanup necessary before next use.
+    fn post_capture(&mut self) -> Result<(), Error>;
+
+    /// Construct an iterator that produces timestamped packets from raw data.
+    ///
+    /// This method must construct a suitable iterator type around `data_rx`,
+    /// which will parse the raw data from the device to produce timestamped
+    /// packets. The iterator type must be `Send` so that it can be passed to
+    /// a separate decoder thread.
+    ///
+    fn timestamped_packets(&self, data_rx: mpsc::Receiver<Vec<u8>>)
+        -> Box<dyn PacketIterator>;
+
+    /// Duplicate this handle with Box::new(self.clone())
+    ///
+    /// The device handle must be cloneable, so that one worker thread can
+    /// process the data transfer queue asynchronously, whilst another thread
+    /// does control transfers using synchronous calls.
+    ///
+    /// However, it turns out we cannot actually make `Clone` a prerequisite
+    /// of `BackendHandle`, because doing so prevents the trait from being
+    /// object safe. This method provides a workaround.
+    fn duplicate(&self) -> Box<dyn BackendHandle>;
+
+    /// Start capturing in the background.
+    ///
+    /// The `result_handler` callback will be invoked later from a worker
+    /// thread, once the capture is either stopped normally or terminates with
+    /// an error.
+    ///
+    /// Returns:
+    /// - an iterator over timestamped packets
+    /// - a handle to stop the capture
+    fn start(
+        &self,
+        speed: Speed,
+        result_handler: Box<dyn FnOnce(Result<(), Error>) + Send>
+    ) -> Result<(Box<dyn PacketIterator>, BackendStop), Error> {
+        // Channel to pass captured data to the decoder thread.
+        let (data_tx, data_rx) = mpsc::channel();
+
+        // Channel to stop the capture thread on request.
+        let (stop_tx, stop_rx) = oneshot::channel();
+
+        // Duplicate this handle to pass to the worker thread.
+        let mut handle = self.duplicate();
+
+        // Start worker thread to run the capture.
+        let worker = spawn(move || result_handler(
+            handle.run_capture(speed, data_tx, stop_rx)
+        ));
+
+        // Iterator over timestamped packets.
+        let packets = self.timestamped_packets(data_rx);
+
+        // Handle to stop the worker thread.
+        let stop_handle = BackendStop { worker, stop_tx };
+
+        Ok((packets, stop_handle))
+    }
+
+    /// Worker that runs the whole lifecycle of a capture from start to finish.
+    fn run_capture(
+        &mut self,
+        speed: Speed,
+        data_tx: mpsc::Sender<Vec<u8>>,
+        stop_rx: oneshot::Receiver<()>,
+    ) -> Result<(), Error> {
+        // Set up a separate channel pair to stop queue processing.
+        let (queue_stop_tx, queue_stop_rx) = oneshot::channel();
+
+        // Begin capture and set up transfer queue.
+        let mut transfer_queue = self.begin_capture(speed, data_tx)?;
+        println!("Capture enabled, speed: {}", speed.description());
+
+        // Spawn a worker thread to process the transfer queue until stopped.
+        let queue_worker = spawn(move ||
+            block_on(transfer_queue.process(queue_stop_rx))
+        );
+
+        // Wait until this thread is signalled to stop.
+        block_on(stop_rx)
+            .context("Sender was dropped")?;
+
+        // End capture.
+        self.end_capture()?;
+        println!("Capture disabled");
+
+        // Leave queue worker running briefly to receive flushed data.
+        sleep(Duration::from_millis(100));
+
+        // Signal queue processing to stop, then join the worker thread.
+        queue_stop_tx.send(())
+            .or_else(|_| bail!("Failed sending stop signal to queue worker"))?;
+
+        handle_thread_panic(queue_worker.join())?
+            .context("Error in queue worker thread")?;
+
+        // Run any post-capture cleanup required by the device.
+        self.post_capture()?;
+
+        Ok(())
+    }
+}
+
 impl BackendStop {
+    /// Stop the capture associated with this handle.
     pub fn stop(self) -> Result<(), Error> {
         println!("Requesting capture stop");
-        self.stop_request.send(())
+        self.stop_tx.send(())
             .or_else(|_| bail!("Failed sending stop request"))?;
         handle_thread_panic(self.worker.join())?;
         Ok(())

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -6,6 +6,7 @@ use num_enum::{FromPrimitive, IntoPrimitive};
 
 pub mod cynthion;
 pub mod ice40usbtrace;
+mod transfer_queue;
 
 #[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, IntoPrimitive)]
 #[repr(u8)]

--- a/src/backend/transfer_queue.rs
+++ b/src/backend/transfer_queue.rs
@@ -1,0 +1,73 @@
+use std::sync::mpsc;
+
+use anyhow::{Context, Error};
+use futures_channel::oneshot;
+use futures_util::{future::FusedFuture, FutureExt, select_biased};
+use nusb::{Interface, transfer::{Queue, RequestBuffer, TransferError}};
+
+/// A queue of inbound USB transfers, feeding received data to a channel.
+pub struct TransferQueue {
+    queue: Queue<RequestBuffer>,
+    data_tx: mpsc::Sender<Vec<u8>>,
+    transfer_length: usize,
+}
+
+impl TransferQueue {
+    /// Create a new transfer queue.
+    pub fn new(
+        interface: &Interface,
+        data_tx: mpsc::Sender<Vec<u8>>,
+        endpoint: u8,
+        num_transfers: usize,
+        transfer_length: usize
+    ) -> TransferQueue {
+        let mut queue = interface.bulk_in_queue(endpoint);
+        while queue.pending() < num_transfers {
+            queue.submit(RequestBuffer::new(transfer_length));
+        }
+        TransferQueue { queue, data_tx, transfer_length }
+    }
+
+    /// Process the queue, sending data to the channel until stopped.
+    pub async fn process(&mut self, mut stop_rx: oneshot::Receiver<()>)
+        -> Result<(), Error>
+    {
+        use TransferError::Cancelled;
+        loop {
+            select_biased!(
+                _ = stop_rx => {
+                    // Stop requested. Cancel all transfers.
+                    self.queue.cancel_all();
+                }
+                completion = self.queue.next_complete().fuse() => {
+                    match completion.status {
+                        Ok(()) => {
+                            // Send data to decoder thread.
+                            self.data_tx.send(completion.data)
+                                .context(
+                                    "Failed sending capture data to channel")?;
+                            if !stop_rx.is_terminated() {
+                                // Submit next transfer.
+                                self.queue.submit(
+                                    RequestBuffer::new(self.transfer_length)
+                                );
+                            }
+                        },
+                        Err(Cancelled) if stop_rx.is_terminated() => {
+                            // Transfer cancelled during shutdown. Drop it.
+                            drop(completion);
+                            if self.queue.pending() == 0 {
+                                // All cancellations now handled.
+                                return Ok(());
+                            }
+                        },
+                        Err(usb_error) => {
+                            // Transfer failed.
+                            return Err(Error::from(usb_error));
+                        }
+                    }
+                }
+            );
+        }
+    }
+}

--- a/src/test_cynthion.rs
+++ b/src/test_cynthion.rs
@@ -1,8 +1,7 @@
+use crate::backend::{DeviceUsability, Speed};
 use crate::backend::cynthion::{
     CynthionDevice,
-    CynthionUsability,
     CynthionHandle,
-    Speed
 };
 use crate::capture::{
     create_capture,
@@ -62,7 +61,8 @@ fn test(save_capture: bool,
     let mut analyzer = CynthionDevice::scan()
         .context("Failed to scan for analyzers")?
         .iter()
-        .find(|dev| matches!(dev.usability, CynthionUsability::Usable(..)))
+
+        .find(|dev| matches!(dev.usability, DeviceUsability::Usable(..)))
         .context("No usable analyzer found")?
         .open()
         .context("Failed to open analyzer")?;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -970,24 +970,7 @@ fn start_pcap(action: FileAction, file: gio::File) -> Result<(), Error> {
                 );
             }
             display_error(result);
-            gtk::glib::idle_add_once(|| {
-                STOP.store(false, Ordering::Relaxed);
-                display_error(
-                    with_ui(|ui| {
-                        ui.show_progress = None;
-                        ui.vbox.remove(&ui.separator);
-                        ui.vbox.remove(&ui.progress_bar);
-                        ui.stop_state = StopState::Disabled;
-                        ui.stop_button.set_sensitive(false);
-                        ui.open_button.set_sensitive(true);
-                        ui.save_button.set_sensitive(true);
-                        ui.scan_button.set_sensitive(true);
-                        ui.selector.set_sensitive(true);
-                        ui.capture_button.set_sensitive(ui.selector.device_available());
-                        Ok(())
-                    })
-                );
-            });
+            gtk::glib::idle_add_once(|| display_error(stop_operation()));
         });
         gtk::glib::timeout_add_once(
             UPDATE_INTERVAL,
@@ -1072,6 +1055,12 @@ pub fn stop_operation() -> Result<(), Error> {
         ui.stop_button.set_sensitive(false);
         ui.scan_button.set_sensitive(true);
         ui.save_button.set_sensitive(true);
+        ui.selector.set_sensitive(true);
+        ui.capture_button.set_sensitive(ui.selector.device_available());
+        if ui.show_progress.take().is_some() {
+            ui.vbox.remove(&ui.separator);
+            ui.vbox.remove(&ui.progress_bar);
+        }
         Ok(())
     })
 }
@@ -1118,18 +1107,7 @@ pub fn start_capture() -> Result<(), Error> {
         };
         std::thread::spawn(move || {
             display_error(read_packets());
-            gtk::glib::idle_add_once(|| {
-                display_error(
-                    with_ui(|ui| {
-                        ui.stop_state = StopState::Disabled;
-                        ui.stop_button.set_sensitive(false);
-                        ui.open_button.set_sensitive(true);
-                        ui.selector.set_sensitive(true);
-                        ui.capture_button.set_sensitive(ui.selector.device_available());
-                        Ok(())
-                    })
-                );
-            });
+            gtk::glib::idle_add_once(|| display_error(stop_operation()));
         });
         gtk::glib::timeout_add_once(
             UPDATE_INTERVAL,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -60,9 +60,9 @@ use gtk::{
 use crate::backend::cynthion::{
     CynthionDevice,
     CynthionHandle,
-    CynthionStop,
-    CynthionUsability::*,
-    Speed};
+};
+use crate::backend::{BackendStop, Speed};
+use crate::backend::DeviceUsability::*;
 
 use crate::capture::{
     create_capture,
@@ -114,7 +114,7 @@ enum FileAction {
 enum StopState {
     Disabled,
     Pcap(Cancellable),
-    Cynthion(CynthionStop),
+    Cynthion(BackendStop),
 }
 
 struct DeviceSelector {

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -19,7 +19,7 @@ fn crc16(bytes: &[u8]) -> u16 {
 // compute the CRC over either 11 or 19 bits of data, rather than
 // over an integer number of bytes.
 
-fn crc5(mut input: u32, num_bits: u32) -> u8 {
+pub fn crc5(mut input: u32, num_bits: u32) -> u8 {
     let mut state: u32 = 0x1f;
     for _ in 0..num_bits {
         let cmp = input & 1 != state & 1;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use anyhow::{Error, bail};
 use num_format::{Locale, ToFormattedString};
 use humansize::{SizeFormatter, BINARY};
 
@@ -12,5 +13,24 @@ pub fn fmt_size(size: u64) -> String {
         format!("{size} bytes")
     } else {
         format!("{}", SizeFormatter::new(size, BINARY))
+    }
+}
+
+pub fn handle_thread_panic<T>(result: std::thread::Result<T>)
+    -> Result<T, Error>
+{
+    match result {
+        Ok(x) => Ok(x),
+        Err(panic) => {
+            let msg = match (
+                panic.downcast_ref::<&str>(),
+                panic.downcast_ref::<String>())
+            {
+                (Some(&s), _) => s,
+                (_,  Some(s)) => s,
+                (None,  None) => "<No panic message>"
+            };
+            bail!("Worker thread panic: {msg}");
+        }
     }
 }


### PR DESCRIPTION
This PR defines a common backend API for USB capture devices, and adds support for the [iCE40-usbtrace](https://gitea.osmocom.org/electronics/ice40-usbtrace) device.

The changes are made on top of a rebased version of #190. Tested with Cynthion only at this stage; @asdfuser and @smunaut, please test this with iCE40-usbtrace!

I have broken the changes to the `ice40usbtrace` backend down into as many commits as possible, so if I've broken anything hopefully it's easy to bisect. However, the final commit that ports everything to the new API is still a fairly big change.

The backend API is not very generic; it assumes that capture devices will work quite similarly to the two examples we currently have. That allows for sharing a lot of code, but means we might have to revisit the design in future if we need to support devices that work substantially differently. I expect it will suffice for OpenViszla, though.