### PR TITLE
Initial support for HID descriptors

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -21,7 +21,6 @@ use arc_swap::{ArcSwap, ArcSwapOption};
 use bytemuck_derive::{Pod, Zeroable};
 use itertools::Itertools;
 use num_enum::{IntoPrimitive, FromPrimitive};
-use usb_ids::FromId;
 
 // Use 2MB block size for packet data, which is a large page size on x86_64.
 const PACKET_DATA_BLOCK_SIZE: usize = 0x200000;
@@ -2156,8 +2155,7 @@ impl ItemSource<DeviceItem, DeviceViewMode> for CaptureReader {
             Function(_conf, desc) => {
                 format!("Function {}: {}",
                     desc.function,
-                    usb_ids::Class::from_id(desc.function_class)
-                        .map_or("Unknown", |c| c.name())
+                    desc.function_class.name()
                 )
             },
             FunctionDescriptor(_) =>
@@ -2165,8 +2163,7 @@ impl ItemSource<DeviceItem, DeviceViewMode> for CaptureReader {
             FunctionDescriptorField(desc, field) => desc.field_text(*field),
             Interface(_conf, desc) => {
                 let num = desc.interface_number;
-                let class = usb_ids::Class::from_id(desc.interface_class)
-                    .map_or("Unknown", |c| c.name());
+                let class = desc.interface_class.name();
                 match desc.alternate_setting {
                     InterfaceAlt(0) => format!(
                         "Interface {num}: {class}"),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1328,8 +1328,8 @@ fn device_context_menu(
         FunctionDescriptor(desc) => bytes_of(desc),
         InterfaceDescriptor(desc) => bytes_of(desc),
         EndpointDescriptor(desc) => bytes_of(desc),
-        OtherDescriptor(Other(_, bytes)) => bytes,
-        OtherDescriptor(Truncated(_, bytes)) => bytes,
+        OtherDescriptor(Other(_, bytes), _) => bytes,
+        OtherDescriptor(Truncated(_, bytes), _) => bytes,
         _ => return Ok(None)
     }.to_vec();
     Ok(Some(context_popover(

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -177,6 +177,8 @@ impl EndpointAttr {
 }
 
 impl ClassId {
+    pub const HID: ClassId = ClassId(0x03);
+
     pub fn name(self) -> &'static str {
         usb_ids::Class::from_id(self.0)
             .map_or("Unknown", usb_ids::Class::name)
@@ -594,10 +596,10 @@ impl DescriptorType {
     }
 
     pub fn description_with_class(&self, class: ClassId) -> String {
-        if let (DescriptorType::Class(code), ClassId(class)) = (self, class) {
+        if let DescriptorType::Class(code) = self {
             let description = match (class, code) {
-                (0x03, 0x21) => "HID descriptor",
-                (0x03, 0x22) => "HID report descriptor",
+                (ClassId::HID, 0x21) => "HID descriptor",
+                (ClassId::HID, 0x22) => "HID report descriptor",
                 _ => return self.description()
             };
             description.to_string()

--- a/tests/emf2022-badge/devices-reference.txt
+++ b/tests/emf2022-badge/devices-reference.txt
@@ -204,7 +204,7 @@
              Subclass: 0x01: Boot Interface Subclass
              Protocol: 0x01: Keyboard
              Interface string: #5 'TiDAL badge'
-          Class descriptor 0x21, 9 bytes
+          HID descriptor, 9 bytes
           Endpoint 3 IN (interrupt)
              Endpoint descriptor
                 Length: 7 bytes

--- a/tests/emf2022-badge/devices-reference.txt
+++ b/tests/emf2022-badge/devices-reference.txt
@@ -204,7 +204,13 @@
              Subclass: 0x01: Boot Interface Subclass
              Protocol: 0x01: Keyboard
              Interface string: #5 'TiDAL badge'
-          HID descriptor, 9 bytes
+          HID descriptor
+             Length: 9 bytes
+             Type: 0x21
+             HID Version: 1.11
+             Country code: 0x00: Not supported
+             Available descriptors
+                HID report descriptor, 144 bytes
           Endpoint 3 IN (interrupt)
              Endpoint descriptor
                 Length: 7 bytes

--- a/tests/emf2022-badge/reference.txt
+++ b/tests/emf2022-badge/reference.txt
@@ -4246,7 +4246,7 @@
  │        ├── IN packet on 2.0, CRC 15
  │        ├── DATA1 packet with CRC 0000 and no data
  │        └── ACK packet
- │  ○── Getting class descriptor 0x22 #0 for interface 2.2, reading 144 bytes
+ │  ○── Getting HID report descriptor #0 for interface 2.2, reading 144 bytes
  │  ├──── SETUP transaction on 2.0 with 8 data bytes, ACK: [81, 06, 00, 22, 02, 00, 90, 00]
  │  │     ├── SETUP packet on 2.0, CRC 15
  │  │     ├── DATA0 packet with CRC E785 and 8 data bytes: [81, 06, 00, 22, 02, 00, 90, 00]

--- a/tests/emf2022-badge/reference.txt
+++ b/tests/emf2022-badge/reference.txt
@@ -4246,7 +4246,7 @@
  │        ├── IN packet on 2.0, CRC 15
  │        ├── DATA1 packet with CRC 0000 and no data
  │        └── ACK packet
- │  ○── Getting unknown descriptor #0 for interface 2.2, reading 144 bytes
+ │  ○── Getting class descriptor 0x22 #0 for interface 2.2, reading 144 bytes
  │  ├──── SETUP transaction on 2.0 with 8 data bytes, ACK: [81, 06, 00, 22, 02, 00, 90, 00]
  │  │     ├── SETUP packet on 2.0, CRC 15
  │  │     ├── DATA0 packet with CRC E785 and 8 data bytes: [81, 06, 00, 22, 02, 00, 90, 00]

--- a/tests/mouse/devices-reference.txt
+++ b/tests/mouse/devices-reference.txt
@@ -34,7 +34,13 @@
              Subclass: 0x01: Boot Interface Subclass
              Protocol: 0x02: Mouse
              Interface string: (none)
-          HID descriptor, 9 bytes
+          HID descriptor
+             Length: 9 bytes
+             Type: 0x21
+             HID Version: 1.10
+             Country code: 0x00: Not supported
+             Available descriptors
+                HID report descriptor, 75 bytes
           Endpoint 1 IN (interrupt)
              Endpoint descriptor
                 Length: 7 bytes

--- a/tests/mouse/devices-reference.txt
+++ b/tests/mouse/devices-reference.txt
@@ -34,7 +34,7 @@
              Subclass: 0x01: Boot Interface Subclass
              Protocol: 0x02: Mouse
              Interface string: (none)
-          Class descriptor 0x21, 9 bytes
+          HID descriptor, 9 bytes
           Endpoint 1 IN (interrupt)
              Endpoint descriptor
                 Length: 7 bytes

--- a/tests/mouse/reference.txt
+++ b/tests/mouse/reference.txt
@@ -221,7 +221,7 @@
          ├── IN packet on 4.0, CRC 05
          ├── DATA1 packet with CRC 0000 and no data
          └── ACK packet
-   ○── Getting class descriptor 0x22 #0 for interface 4.0, reading 75 bytes
+   ○── Getting HID report descriptor #0 for interface 4.0, reading 75 bytes
    ├──── SETUP transaction on 4.0 with 8 data bytes, ACK: [81, 06, 00, 22, 00, 00, 4B, 00]
    │     ├── SETUP packet on 4.0, CRC 05
    │     ├── DATA0 packet with CRC AFDE and 8 data bytes: [81, 06, 00, 22, 00, 00, 4B, 00]

--- a/tests/mouse/reference.txt
+++ b/tests/mouse/reference.txt
@@ -221,7 +221,7 @@
          ├── IN packet on 4.0, CRC 05
          ├── DATA1 packet with CRC 0000 and no data
          └── ACK packet
-   ○── Getting unknown descriptor #0 for interface 4.0, reading 75 bytes
+   ○── Getting class descriptor 0x22 #0 for interface 4.0, reading 75 bytes
    ├──── SETUP transaction on 4.0 with 8 data bytes, ACK: [81, 06, 00, 22, 00, 00, 4B, 00]
    │     ├── SETUP packet on 4.0, CRC 05
    │     ├── DATA0 packet with CRC AFDE and 8 data bytes: [81, 06, 00, 22, 00, 00, 4B, 00]

--- a/tests/split-enum/devices-reference.txt
+++ b/tests/split-enum/devices-reference.txt
@@ -36,7 +36,7 @@
              Subclass: 0x01: Boot Interface Subclass
              Protocol: 0x01: Keyboard
              Interface string: (none)
-          Class descriptor 0x21, 9 bytes
+          HID descriptor, 9 bytes
           Endpoint 1 IN (interrupt)
              Endpoint descriptor
                 Length: 7 bytes
@@ -56,7 +56,7 @@
              Subclass: 0x01: Boot Interface Subclass
              Protocol: 0x02: Mouse
              Interface string: (none)
-          Class descriptor 0x21, 9 bytes
+          HID descriptor, 9 bytes
           Endpoint 2 IN (interrupt)
              Endpoint descriptor
                 Length: 7 bytes

--- a/tests/split-enum/devices-reference.txt
+++ b/tests/split-enum/devices-reference.txt
@@ -36,7 +36,13 @@
              Subclass: 0x01: Boot Interface Subclass
              Protocol: 0x01: Keyboard
              Interface string: (none)
-          HID descriptor, 9 bytes
+          HID descriptor
+             Length: 9 bytes
+             Type: 0x21
+             HID Version: 1.00
+             Country code: 0x00: Not supported
+             Available descriptors
+                HID report descriptor, 77 bytes
           Endpoint 1 IN (interrupt)
              Endpoint descriptor
                 Length: 7 bytes
@@ -56,7 +62,13 @@
              Subclass: 0x01: Boot Interface Subclass
              Protocol: 0x02: Mouse
              Interface string: (none)
-          HID descriptor, 9 bytes
+          HID descriptor
+             Length: 9 bytes
+             Type: 0x21
+             HID Version: 1.00
+             Country code: 0x00: Not supported
+             Available descriptors
+                HID report descriptor, 91 bytes
           Endpoint 2 IN (interrupt)
              Endpoint descriptor
                 Length: 7 bytes

--- a/tests/ui/emf2022-badge/reference.txt
+++ b/tests/ui/emf2022-badge/reference.txt
@@ -30,7 +30,7 @@ At traffic-hierarchical row 0:
 + Getting string descriptor #5, language 0x0409 (English/US) for device 2, reading 24 of 255 requested bytes: 'TiDAL badge'
 + Getting string descriptor #3, language 0x0409 (English/US) for device 2, reading 14 of 255 requested bytes: '123456'
 + Class request #10, index 0, value 0 for interface 2.2
-+ Getting class descriptor 0x22 #0 for interface 2.2, reading 144 bytes
++ Getting HID report descriptor #0 for interface 2.2, reading 144 bytes
 + Class request #9, index 0, value 513 for interface 2.2, writing 2 bytes
 + Polling 194 times for interrupt transfer on endpoint 2.3 IN
 At traffic-transactions row 0:

--- a/tests/ui/emf2022-badge/reference.txt
+++ b/tests/ui/emf2022-badge/reference.txt
@@ -30,7 +30,7 @@ At traffic-hierarchical row 0:
 + Getting string descriptor #5, language 0x0409 (English/US) for device 2, reading 24 of 255 requested bytes: 'TiDAL badge'
 + Getting string descriptor #3, language 0x0409 (English/US) for device 2, reading 14 of 255 requested bytes: '123456'
 + Class request #10, index 0, value 0 for interface 2.2
-+ Getting unknown descriptor #0 for interface 2.2, reading 144 bytes
++ Getting class descriptor 0x22 #0 for interface 2.2, reading 144 bytes
 + Class request #9, index 0, value 513 for interface 2.2, writing 2 bytes
 + Polling 194 times for interrupt transfer on endpoint 2.3 IN
 At traffic-transactions row 0:


### PR DESCRIPTION
This PR adds some groundwork for supporting class-specific descriptors, where the meaning of the `bDescriptorType` depends on the context of the relevant interface class.

This is then used to identify and decode HID descriptors attached to an interface, where the interface class provides the context:

![image](https://github.com/user-attachments/assets/c765089d-4dbd-4db2-97d5-610d895b4ff8)

And to recognise requests for HID report descriptors, where the class of the recipient is known from previous traffic:

![image](https://github.com/user-attachments/assets/905b923a-5bac-4d58-8665-518228799c9b)

Note that HID report descriptors are not yet decoded or added to the device tree, that will come later.