### PR TITLE
Pin gtk-4.14.4 subproject revisions for appimage builds.

### DIFF
--- a/appimage/README.md
+++ b/appimage/README.md
@@ -117,7 +117,14 @@ We use a minimal build configuration as many of the options are not available on
 
 The effect of these flags can vary wildly between gtk releases so this may require some fiddling if updating to a newer gtk version.
 
-For the 4.14.4 release a small [patch](docker/patches/) needs to be applied after configuration and is unlikely to have the required effect on other releases.
+For the 4.14.4 release a number of small [patches](docker/patches/) need to be applied after configuration which are unlikely to have the desired effect on other releases:
+
+   * `gtk-4.14.4-gcc-lt-9.patch`      - fixes build for gcc < 9.1
+   * `gtk-4.14.4-pin-fribidi.patch`   - pins fribidi to a specific release.
+   * `gtk-4.14.4-pin-gi-docgen.patch` - pins gi-docgen to a specific release.
+   * `gtk-4.14.4-pin-libsass.patch`   - pins libsass to a specific release.
+   * `gtk-4.14.4-pin-pango.patch`     - pins pango to a specific release.
+   * `gtk-4.14.4-pin-sysprof.patch`   - pins sysprof to a specific release.
 
 Finally, gtk4 is installed to the /opt/gtk-$GTK_VERSION directory. It's quite important that it _not_ be installed to `/usr` as gtk4 ships with newer versions of some system libraries which can horribly confuse both the Rust compiler and the AppImage tools.
 

--- a/appimage/docker/Dockerfile
+++ b/appimage/docker/Dockerfile
@@ -27,6 +27,7 @@ RUN apt update && apt upgrade -y && apt install -y \
     cmake \
     curl \
     desktop-file-utils \
+    dos2unix \
     fdupes \
     flex \
     git \
@@ -126,6 +127,19 @@ RUN A=`echo $GTK_VERSION | cut -d. -f1,2` B=$GTK_VERSION && \
 
 # setup gtk-4 build
 WORKDIR $GTK_SOURCE
+
+# patch gtk-4 to use specific subproject releases rather than main
+ADD patches/gtk-4.14.4-pin-fribidi.patch .
+RUN patch -p1 < ./gtk-4.14.4-pin-fribidi.patch
+ADD patches/gtk-4.14.4-pin-gi-docgen.patch .
+RUN patch -p1 < ./gtk-4.14.4-pin-gi-docgen.patch
+ADD patches/gtk-4.14.4-pin-libsass.patch .
+RUN dos2unix ./subprojects/libsass.wrap # buster's patch does not support --ignore-white-space
+RUN patch -p1 < ./gtk-4.14.4-pin-libsass.patch
+ADD patches/gtk-4.14.4-pin-pango.patch .
+RUN patch -p1 < ./gtk-4.14.4-pin-pango.patch
+ADD patches/gtk-4.14.4-pin-sysprof.patch .
+RUN patch -p1 < ./gtk-4.14.4-pin-sysprof.patch
 
 RUN meson setup --prefix /opt/gtk-$GTK_VERSION builddir \
         -Dbuildtype=release \

--- a/appimage/docker/patches/gtk-4.14.4-pin-fribidi.patch
+++ b/appimage/docker/patches/gtk-4.14.4-pin-fribidi.patch
@@ -1,0 +1,13 @@
+diff --git a/subprojects/fribidi.wrap b/subprojects/fribidi.wrap
+index 20ba8ed..7ea197e 100644
+--- a/subprojects/fribidi.wrap
++++ b/subprojects/fribidi.wrap
+@@ -2,7 +2,7 @@
+ directory = fribidi
+ url = https://github.com/fribidi/fribidi.git
+ push-url = git@github.com:fribidi/fribidi.git
+-revision = master
++revision = v1.0.16
+ depth = 1
+ 
+ [provide]

--- a/appimage/docker/patches/gtk-4.14.4-pin-gi-docgen.patch
+++ b/appimage/docker/patches/gtk-4.14.4-pin-gi-docgen.patch
@@ -1,0 +1,13 @@
+diff --git a/subprojects/gi-docgen.wrap b/subprojects/gi-docgen.wrap
+index 85c85da..2d71071 100644
+--- a/subprojects/gi-docgen.wrap
++++ b/subprojects/gi-docgen.wrap
+@@ -2,7 +2,7 @@
+ directory = gi-docgen
+ url = https://gitlab.gnome.org/GNOME/gi-docgen.git
+ push-url = ssh://git@ssh.gitlab.gnome.org:GNOME/gi-docgen.git
+-revision = main
++revision = 2025.3
+ depth = 1
+ 
+ [provide]

--- a/appimage/docker/patches/gtk-4.14.4-pin-libsass.patch
+++ b/appimage/docker/patches/gtk-4.14.4-pin-libsass.patch
@@ -1,0 +1,11 @@
+diff --git a/subprojects/libsass.wrap b/subprojects/libsass.wrap
+index 0e52fb4..3507404 100644
+--- a/subprojects/libsass.wrap
++++ b/subprojects/libsass.wrap
+@@ -1,5 +1,5 @@
+ [wrap-git]
+ directory=libsass
+ url=https://github.com/lazka/libsass.git
+-revision=meson
++revision=aac79dccd3c8f7e8f22125f87a119f3b1ee9d487
+ depth=1

--- a/appimage/docker/patches/gtk-4.14.4-pin-pango.patch
+++ b/appimage/docker/patches/gtk-4.14.4-pin-pango.patch
@@ -1,0 +1,15 @@
+diff --git a/subprojects/pango.wrap b/subprojects/pango.wrap
+index 7156644..fa6715b 100644
+--- a/subprojects/pango.wrap
++++ b/subprojects/pango.wrap
+@@ -2,8 +2,8 @@
+ directory = pango
+ url = https://gitlab.gnome.org/GNOME/pango.git
+ push-url = ssh://git@ssh.gitlab.gnome.org:GNOME/pango.git
+-# needs to be main, because we build the nightly docs from the subproject
+-revision = main
++# needs to be 1.54.0 because later versions require versions of glib and fontconfig that are not supplied by gtk-4.14.4
++revision = 1.54.0
+ depth = 1
+ 
+ [provide]

--- a/appimage/docker/patches/gtk-4.14.4-pin-sysprof.patch
+++ b/appimage/docker/patches/gtk-4.14.4-pin-sysprof.patch
@@ -1,0 +1,13 @@
+diff --git a/subprojects/sysprof.wrap b/subprojects/sysprof.wrap
+index 29dcbdc..04daedd 100644
+--- a/subprojects/sysprof.wrap
++++ b/subprojects/sysprof.wrap
+@@ -1,7 +1,7 @@
+ [wrap-git]
+ directory = sysprof
+ url = https://gitlab.gnome.org/GNOME/sysprof.git
+-revision = master
++revision = 47.2
+ depth = 1
+ 
+ [provide]


### PR DESCRIPTION
Recently, when appimage builds started to fail, it came to light that some of the sub-projects used by the gtk-4.14.4 source distribution were pointed at main branches.

Things began to break when the pango main branch dropped support for glib 2.76 in favor of 2.80.

This PR will apply patches during the docker image build that ensures all gtk-4.14.4 sub-projects use a fixed revision.