### PR TITLE
ci: disable rustup self-update to workaround a Windows build issue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,11 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      # Workaround for https://github.com/rust-lang/rustup/issues/3709
+      - name: Disable rustup self-update
+        run: rustup set auto-self-update disable
+        if: runner.os == 'Windows'
+
       - name: Install toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}


### PR DESCRIPTION
This disables rustup self-update on the Windows CI build to work around a weird issue with GitHub's runner described here: https://github.com/rust-lang/rustup/issues/3709