### PR TITLE
Add support for dumping & restoring capture database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /docs/build/
 /target
+/tests/*/dump
 /tests/*/output.txt
 /tests/*/devices-output.txt
 /tests/ui/*/output.txt

--- a/src/database/index_stream.rs
+++ b/src/database/index_stream.rs
@@ -17,7 +17,7 @@ use crate::database::{
         DataIterator
     },
 };
-use crate::util::{id::Id, fmt_count, fmt_size};
+use crate::util::{dump::{Dump, restore}, id::Id, fmt_count, fmt_size};
 
 /// Unique handle for append-only write access to an index.
 pub struct IndexWriter<Position, Value, const S: usize = MIN_BLOCK> {
@@ -296,6 +296,18 @@ where Position: From<u64>, Value: From<u64>
     }
 }
 
+impl<P, V, const S: usize> Dump for IndexReader<P, V, S> {
+    fn dump(&self, dest: &std::path::Path) -> Result<(), Error> {
+        self.data_reader.dump(dest)
+    }
+
+    fn restore(src: &std::path::Path) -> Result<Self, anyhow::Error> {
+        Ok(IndexReader {
+            marker: PhantomData,
+            data_reader: restore(src)?
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/item.rs
+++ b/src/item.rs
@@ -1096,18 +1096,12 @@ mod tests {
         let list_file = File::open(list_path).unwrap();
         let mode = TrafficViewMode::Hierarchical;
         for test_name in BufReader::new(list_file).lines() {
-            let mut test_path = test_dir.clone();
-            test_path.push(test_name.unwrap());
-            let mut cap_path = test_path.clone();
-            let mut traf_ref_path = test_path.clone();
-            let mut traf_out_path = test_path.clone();
-            let mut dev_ref_path = test_path.clone();
-            let mut dev_out_path = test_path.clone();
-            cap_path.push("capture.pcap");
-            traf_ref_path.push("reference.txt");
-            traf_out_path.push("output.txt");
-            dev_ref_path.push("devices-reference.txt");
-            dev_out_path.push("devices-output.txt");
+            let test_path = test_dir.join(test_name.unwrap());
+            let cap_path = test_path.join("capture.pcap");
+            let traf_ref_path = test_path.join("reference.txt");
+            let traf_out_path = test_path.join("output.txt");
+            let dev_ref_path = test_path.join("devices-reference.txt");
+            let dev_out_path = test_path.join("devices-output.txt");
             {
                 let file = File::open(cap_path).unwrap();
                 let mut loader = PcapLoader::new(file).unwrap();

--- a/src/item.rs
+++ b/src/item.rs
@@ -1041,6 +1041,7 @@ mod tests {
     use crate::capture::create_capture;
     use crate::decoder::Decoder;
     use crate::file::{GenericLoader, GenericPacket, LoaderItem, PcapLoader};
+    use crate::util::dump::Dump;
 
     fn summarize_item<Item, ViewMode>(
         cap: &mut CaptureReader,
@@ -1102,6 +1103,7 @@ mod tests {
             let traf_out_path = test_path.join("output.txt");
             let dev_ref_path = test_path.join("devices-reference.txt");
             let dev_out_path = test_path.join("devices-output.txt");
+            let dump_path = test_path.join("dump");
             {
                 let file = File::open(cap_path).unwrap();
                 let mut loader = PcapLoader::new(file).unwrap();
@@ -1121,6 +1123,8 @@ mod tests {
                     }
                 }
                 decoder.finish().unwrap();
+                reader.dump(&dump_path).unwrap();
+                reader = CaptureReader::restore(&dump_path).unwrap();
                 let traf_out_file = File::create(traf_out_path.clone()).unwrap();
                 let mut traf_out_writer = BufWriter::new(traf_out_file);
                 let num_items = reader.item_index.len();

--- a/src/util/dump.rs
+++ b/src/util/dump.rs
@@ -1,0 +1,178 @@
+use std::fs::File;
+use std::io::{Read, Write};
+use std::ops::Deref;
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::{
+    atomic::{AtomicU64, AtomicU32, Ordering},
+    Arc,
+};
+
+use anyhow::Error;
+use arc_swap::{ArcSwap, ArcSwapOption};
+
+use crate::util::id::Id;
+use crate::util::vec_map::{Key, VecMap};
+
+pub trait Dump : Sized {
+    /// Dump the contents of this data structure to the specified path.
+    fn dump(&self, dest: &Path) -> Result<(), Error>;
+
+    /// Restore a data structure of this type from the specified path.
+    fn restore(src: &Path) -> Result<Self, Error>;
+}
+
+/// Standalone function to restore any type that supports Dump.
+pub fn restore<T>(src: &Path) -> Result<T, Error> where T: Dump {
+    T::restore(src)
+}
+
+impl Dump for String {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        let mut file = File::create(dest)?;
+        writeln!(file, "{}", self)?;
+        Ok(())
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        let mut string = String::new();
+        File::open(src)?.read_to_string(&mut string)?;
+        Ok(string.trim_end_matches("\n").to_string())
+    }
+}
+
+impl Dump for usize {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        self.to_string().dump(dest)
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        Ok(Self::from_str(&String::restore(src)?)?)
+    }
+}
+
+impl Dump for u64 {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        self.to_string().dump(dest)
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        Ok(Self::from_str(&String::restore(src)?)?)
+    }
+}
+
+impl Dump for u32 {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        self.to_string().dump(dest)
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        Ok(Self::from_str(&String::restore(src)?)?)
+    }
+}
+
+impl Dump for AtomicU64 {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        self.load(Ordering::Acquire).dump(dest)
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        Ok(AtomicU64::from(u64::restore(src)?))
+    }
+}
+
+impl Dump for AtomicU32 {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        self.load(Ordering::Acquire).dump(dest)
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        Ok(AtomicU32::from(u32::restore(src)?))
+    }
+}
+
+impl<T> Dump for Id<T> {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        self.value.dump(dest)
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        Ok(Self::from(u64::restore(src)?))
+    }
+}
+
+impl<T> Dump for Option<T> where T: Dump {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        if let Some(value) = self {
+            value.dump(dest)?
+        }
+        Ok(())
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        match T::restore(src) {
+            Ok(value) => Ok(Some(value)),
+            Err(e) => match e.root_cause().downcast_ref::<std::io::Error>() {
+                Some(io_error) => match io_error.kind() {
+                    std::io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(e)
+                },
+                _ => Err(e)
+            }
+        }
+    }
+}
+
+impl<T> Dump for Arc<T> where T: Dump {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        self.deref().dump(dest)
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        Ok(Arc::new(T::restore(src)?))
+    }
+}
+
+impl<T> Dump for ArcSwapOption<T> where T: Dump {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        self.load_full().dump(dest)
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        Ok(ArcSwapOption::new(
+            Option::<T>::restore(src)?.map(|value| Arc::new(value))
+        ))
+    }
+}
+
+impl<T> Dump for ArcSwap<T> where T: Dump {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        self.load_full().dump(dest)
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        Ok(ArcSwap::new(Arc::new(T::restore(src)?)))
+    }
+}
+
+impl<K, V> Dump for VecMap<K, V> where K: Key, V: Dump {
+    fn dump(&self, dest: &Path) -> Result<(), Error> {
+        std::fs::create_dir_all(dest)?;
+        for (key, value) in self.iter_pairs() {
+            value.dump(&dest.join(format!("{}", key.id())))?;
+        }
+        Ok(())
+    }
+
+    fn restore(src: &Path) -> Result<Self, Error> {
+        let mut map = VecMap::new();
+        for dir_entry in std::fs::read_dir(src)? {
+            let key_os_str = dir_entry?.file_name();
+            let key_str = key_os_str.to_string_lossy();
+            let key = K::key(usize::from_str(&key_str)?);
+            let value = restore(&src.join(key_os_str))?;
+            map.set(key, value);
+        }
+        Ok(map)
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,6 +8,7 @@ use humansize::{SizeFormatter, BINARY};
 use itertools::Itertools;
 
 pub mod id;
+pub mod dump;
 pub mod vec_map;
 pub mod rcu;
 

--- a/src/util/vec_map.rs
+++ b/src/util/vec_map.rs
@@ -71,6 +71,11 @@ impl<K, V> VecMap<K, V> where K: Key {
         }
         self.vec[id] = Some(value);
     }
+
+    pub fn iter_pairs(&self) -> impl Iterator<Item=(K, &V)> {
+        let range = 0..self.vec.len();
+        range.filter_map(|i| self.vec[i].as_ref().map(|j| (K::key(i), j)))
+    }
 }
 
 impl<K, V> Default for VecMap<K, V> where K: Key {


### PR DESCRIPTION
This PR adds code to support dumping the capture database to disk, and restoring it back.

This is intended for debugging purposes only. The dump format is hierarchical, with data structures mapped to directories and files.

To verify that this works correctly, the `test_captures` test is modified to dump and restore the capture database in between decoding each capture and querying it for expected results.