### PR TITLE
Update vcpkg to fix build failures with CMake 4.0.0 on runners.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      VCPKG_COMMIT: 01f602195983451bc83e72f4214af2cbc495aa94 # 2024.05.24 release
+      VCPKG_COMMIT: a1aebfa9d5eae7cf493e0a706b43915d687bb860 # CMake 4.0.0 fix
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg/installed
 
     steps:


### PR DESCRIPTION
GitHub Actions runners have been updated to CMake 4.0.0, and this breaks some packages in our dependencies, which were locked to the 2024.05.24 vcpkg release.

There isn't a new vcpkg release with the fix yet, so this bumps us to the [commit](https://github.com/microsoft/vcpkg/commit/a1aebfa9d5eae7cf493e0a706b43915d687bb860) that fixed it, from https://github.com/microsoft/vcpkg/pull/44712.