### PR TITLE
WIP: Database snapshotting

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -78,6 +78,7 @@ pub struct CaptureShared {
 pub struct CaptureWriter {
     pub counters: CounterSet,
     pub shared: Arc<CaptureShared>,
+    pub endpoint_writers: VecMap<EndpointId, EndpointWriter>,
     pub packet_data: DataWriter<u8, PACKET_DATA_BLOCK_SIZE>,
     pub packet_index: CompactWriter<PacketId, PacketByteId, 2>,
     pub packet_times: CompactWriter<PacketId, Timestamp, 3>,
@@ -144,6 +145,7 @@ pub fn create_capture()
     let writer = CaptureWriter {
         counters,
         shared: shared.clone(),
+        endpoint_writers: VecMap::new(),
         packet_data: data_writer,
         packet_index: packets_writer,
         packet_times: timestamp_writer,

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -5,13 +5,14 @@ use std::fmt::{Debug, Write};
 use std::iter::once;
 use std::num::NonZeroU32;
 use std::ops::Range;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::sync::atomic::Ordering::{Acquire, Release};
 use std::sync::Arc;
 use std::time::Duration;
 use std::mem::size_of;
 
 use crate::database::{
+    Counter,
     CompactReader,
     CompactWriter,
     compact_index,
@@ -174,7 +175,7 @@ pub fn create_capture()
 
 /// Per-endpoint state shared between readers and writers.
 pub struct EndpointShared {
-    pub total_data: AtomicU64,
+    pub total_data: Counter,
     #[allow(dead_code)]
     pub first_item_id: ArcSwapOption<TrafficItemId>,
 }
@@ -213,7 +214,7 @@ pub fn create_endpoint()
 
     // Create the shared state.
     let shared = Arc::new(EndpointShared {
-        total_data: AtomicU64::from(0),
+        total_data: Counter::new(),
         first_item_id: ArcSwapOption::const_empty(),
     });
 
@@ -1278,7 +1279,7 @@ impl EndpointReader {
         let num_data_events = self.data_byte_counts.len();
         let first_byte_count = self.data_byte_counts.get(range.start)?;
         let last_byte_count = if range.end >= num_data_events {
-            self.shared.as_ref().total_data.load(Acquire)
+            self.shared.as_ref().total_data.load()
         } else {
             self.data_byte_counts.get(range.end)?
         };

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -21,6 +21,7 @@ use crate::database::{
     DataWriter,
     data_stream,
     data_stream_with_block_size,
+    Snapshot,
 };
 use crate::usb::{self, prelude::*};
 use crate::util::{
@@ -914,6 +915,46 @@ impl CaptureWriter {
             percentage, fmt_size(overhead),
         )
     }
+
+    pub fn snapshot(&mut self) -> CaptureReader {
+        let db = &self.counters.clone();
+        let mut endpoint_readers = VecMap::<EndpointId, _>::new();
+        for writer in self.endpoint_writers.into_iter() {
+            endpoint_readers.push(writer.snapshot(db));
+        }
+        CaptureReader {
+            shared: Arc::new(CaptureShared {
+                metadata: ArcSwap::new(
+                    self.shared.metadata.load().clone()),
+                device_data: ArcSwap::new(
+                    self.shared.device_data.load().clone()),
+                endpoint_index: ArcSwap::new(
+                    self.shared.endpoint_index.load().clone()),
+                complete: AtomicBool::new(
+                    self.shared.complete.load(Acquire)),
+                endpoint_readers: ArcSwap::new(Arc::new({
+                    let mut readers = VecMap::new();
+                    for writer in self.endpoint_writers.into_iter() {
+                        readers.push(Arc::new(writer.snapshot(db)));
+                    }
+                    readers
+                })),
+            }),
+            endpoint_readers: VecMap::new(),
+            packet_data: self.packet_data.snapshot(db),
+            packet_index: self.packet_index.snapshot(db),
+            packet_times: self.packet_times.snapshot(db),
+            transaction_index: self.transaction_index.snapshot(db),
+            group_index: self.group_index.snapshot(db),
+            item_index: self.item_index.snapshot(db),
+            devices: self.devices.snapshot(db),
+            endpoints: self.endpoints.snapshot(db),
+            endpoint_states: self.endpoint_states.snapshot(db),
+            endpoint_state_index:
+                self.endpoint_state_index.snapshot(db),
+            end_index: self.end_index.snapshot(db),
+        }
+    }
 }
 
 impl CaptureReader {
@@ -1291,6 +1332,24 @@ impl EndpointReader {
             self.data_byte_counts.get(range.end)?
         };
         Ok(last_byte_count - first_byte_count)
+    }
+}
+
+impl Snapshot<EndpointReader> for EndpointWriter {
+    fn snapshot(&self, db: &CounterSet) -> EndpointReader {
+        EndpointReader {
+            shared: Arc::new(EndpointShared {
+                total_data:
+                    self.shared.total_data.snapshot(db),
+                first_item_id: ArcSwapOption::new(
+                    self.shared.first_item_id.load_full()),
+            }),
+            transaction_ids: self.transaction_ids.snapshot(db),
+            group_index: self.group_index.snapshot(db),
+            data_transactions: self.data_transactions.snapshot(db),
+            data_byte_counts: self.data_byte_counts.snapshot(db),
+            end_index: self.end_index.snapshot(db),
+        }
     }
 }
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -13,6 +13,7 @@ use std::mem::size_of;
 
 use crate::database::{
     Counter,
+    CounterSet,
     CompactReader,
     CompactWriter,
     compact_index,
@@ -75,6 +76,7 @@ pub struct CaptureShared {
 
 /// Unique handle for write access to a capture.
 pub struct CaptureWriter {
+    pub counters: CounterSet,
     pub shared: Arc<CaptureShared>,
     pub packet_data: DataWriter<u8, PACKET_DATA_BLOCK_SIZE>,
     pub packet_index: CompactWriter<PacketId, PacketByteId, 2>,
@@ -113,19 +115,21 @@ pub struct CaptureReader {
 pub fn create_capture()
     -> Result<(CaptureWriter, CaptureReader), Error>
 {
+    let mut counters = CounterSet::default();
+    let db = &mut counters;
     // Create all the required streams.
     let (data_writer, data_reader) =
-        data_stream_with_block_size::<_, PACKET_DATA_BLOCK_SIZE>()?;
-    let (packets_writer, packets_reader) = compact_index()?;
-    let (timestamp_writer, timestamp_reader) = compact_index()?;
-    let (transactions_writer, transactions_reader) = compact_index()?;
-    let (groups_writer, groups_reader) = data_stream()?;
-    let (items_writer, items_reader) = compact_index()?;
-    let (devices_writer, devices_reader) = data_stream()?;
-    let (endpoints_writer, endpoints_reader) = data_stream()?;
-    let (endpoint_state_writer, endpoint_state_reader) = data_stream()?;
-    let (state_index_writer, state_index_reader) = compact_index()?;
-    let (end_writer, end_reader) = compact_index()?;
+        data_stream_with_block_size::<_, PACKET_DATA_BLOCK_SIZE>(db)?;
+    let (packets_writer, packets_reader) = compact_index(db)?;
+    let (timestamp_writer, timestamp_reader) = compact_index(db)?;
+    let (transactions_writer, transactions_reader) = compact_index(db)?;
+    let (groups_writer, groups_reader) = data_stream(db)?;
+    let (items_writer, items_reader) = compact_index(db)?;
+    let (devices_writer, devices_reader) = data_stream(db)?;
+    let (endpoints_writer, endpoints_reader) = data_stream(db)?;
+    let (endpoint_state_writer, endpoint_state_reader) = data_stream(db)?;
+    let (state_index_writer, state_index_reader) = compact_index(db)?;
+    let (end_writer, end_reader) = compact_index(db)?;
 
     // Create the state shared by readers and writer.
     let shared = Arc::new(CaptureShared {
@@ -138,6 +142,7 @@ pub fn create_capture()
 
     // Create the write handle.
     let writer = CaptureWriter {
+        counters,
         shared: shared.clone(),
         packet_data: data_writer,
         packet_index: packets_writer,
@@ -202,19 +207,19 @@ pub struct EndpointReader {
 }
 
 /// Create a per-endpoint reader-writer pair.
-pub fn create_endpoint()
+pub fn create_endpoint(db: &mut CounterSet)
     -> Result<(EndpointWriter, EndpointReader), Error>
 {
     // Create all the required streams.
-    let (transactions_writer, transactions_reader) = compact_index()?;
-    let (groups_writer, groups_reader) = compact_index()?;
-    let (data_transaction_writer, data_transaction_reader) = compact_index()?;
-    let (data_byte_count_writer, data_byte_count_reader) = compact_index()?;
-    let (end_writer, end_reader) = compact_index()?;
+    let (transactions_writer, transactions_reader) = compact_index(db)?;
+    let (groups_writer, groups_reader) = compact_index(db)?;
+    let (data_transaction_writer, data_transaction_reader) = compact_index(db)?;
+    let (data_byte_count_writer, data_byte_count_reader) = compact_index(db)?;
+    let (end_writer, end_reader) = compact_index(db)?;
 
     // Create the shared state.
     let shared = Arc::new(EndpointShared {
-        total_data: Counter::new(),
+        total_data: db.new_counter(),
         first_item_id: ArcSwapOption::const_empty(),
     });
 

--- a/src/database/compact_index.rs
+++ b/src/database/compact_index.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Error, anyhow, bail};
 use itertools::{structs::Zip, multizip};
 
 use crate::database::{
-    counter::Counter,
+    counter::{Counter, CounterSet},
     data_stream::{data_stream, DataReader, DataWriter, DataIterator},
     index_stream::{index_stream, IndexReader, IndexWriter, IndexIterator},
 };
@@ -104,15 +104,15 @@ type CompactPair<P, V, const W: usize> =
 ///
 /// Returns a unique writer and a cloneable reader.
 ///
-pub fn compact_index<P, V, const W: usize>()
+pub fn compact_index<P, V, const W: usize>(db: &mut CounterSet)
     -> Result<CompactPair<P, V, W>, Error>
 {
-    let (segment_start_writer, segment_start_reader) = index_stream()?;
-    let (segment_base_writer, segment_base_reader) = index_stream()?;
-    let (segment_offset_writer, segment_offset_reader) = index_stream()?;
-    let (segment_width_writer, segment_width_reader) = data_stream()?;
-    let (data_writer, data_reader) = data_stream()?;
-    let shared_length = Arc::new(Counter::new());
+    let (segment_start_writer, segment_start_reader) = index_stream(db)?;
+    let (segment_base_writer, segment_base_reader) = index_stream(db)?;
+    let (segment_offset_writer, segment_offset_reader) = index_stream(db)?;
+    let (segment_width_writer, segment_width_reader) = data_stream(db)?;
+    let (data_writer, data_reader) = data_stream(db)?;
+    let shared_length = Arc::new(db.new_counter());
     let writer = CompactWriter {
         shared_length: shared_length.clone(),
         segment_start_writer,
@@ -618,7 +618,9 @@ mod tests {
 
     #[test]
     fn test_compact_index() {
-        let (mut writer, mut reader) = compact_index::<_, _, 1>().unwrap();
+        let mut db = CounterSet::default();
+        let (mut writer, mut reader) =
+            compact_index::<_, _, 1>(&mut db).unwrap();
         let mut expected = Vec::<Id<u8>>::new();
         let mut x = 10;
         let n = 4321;

--- a/src/database/compact_index.rs
+++ b/src/database/compact_index.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Error, anyhow, bail};
 use itertools::{structs::Zip, multizip};
 
 use crate::database::{
-    counter::{Counter, CounterSet},
+    Counter, CounterSet, Snapshot,
     data_stream::{data_stream, DataReader, DataWriter, DataIterator},
     index_stream::{index_stream, IndexReader, IndexWriter, IndexIterator},
 };
@@ -595,6 +595,27 @@ where
             None
         } else {
             Some(self.fetch_next())
+        }
+    }
+}
+
+impl<P, V, const W: usize> Snapshot<CompactReader<P, V>> for CompactWriter<P, V, W>
+{
+    fn snapshot(&self, db: &CounterSet) -> CompactReader<P, V> {
+        CompactReader {
+            _marker: PhantomData,
+            shared_length: Arc::new(
+                self.shared_length.snapshot(db)),
+            segment_start_reader:
+                self.segment_start_writer.snapshot(db),
+            segment_base_reader:
+                self.segment_base_writer.snapshot(db),
+            segment_offset_reader:
+                self.segment_offset_writer.snapshot(db),
+            segment_width_reader:
+                self.segment_width_writer.snapshot(db),
+            data_reader:
+                self.data_writer.snapshot(db),
         }
     }
 }

--- a/src/database/counter.rs
+++ b/src/database/counter.rs
@@ -1,19 +1,120 @@
 //! Atomic counters used in the database implementation.
 
-use std::sync::atomic::{AtomicU64, Ordering::{Acquire, Release}};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::ops::Deref;
+use std::sync::Arc;
+use std::sync::atomic::{
+    AtomicPtr, AtomicU64,
+    Ordering::{Acquire, Release, Relaxed}
+};
 
-pub struct Counter(AtomicU64);
+use arc_swap::ArcSwap;
+
+struct CounterInner {
+    buffer: ArcSwap<AtomicPtr<AtomicU64>>,
+    index: usize
+}
+
+pub struct Counter(Arc<CounterInner>);
 
 impl Counter {
-    pub fn new() -> Self {
-        Self(AtomicU64::from(0))
+    fn ptr(&self) -> &AtomicU64 {
+        let inner = self.0.deref();
+        unsafe {
+            inner.buffer
+                .load()
+                .load(Relaxed)
+                .add(inner.index)
+                .as_ref()
+                .unwrap_unchecked()
+        }
     }
 
     pub fn store(&self, value: u64) {
-        self.0.store(value, Release);
+        self.ptr().store(value, Release);
     }
 
     pub fn load(&self) -> u64 {
-        self.0.load(Acquire)
+        self.ptr().load(Acquire)
+    }
+}
+
+pub struct CounterSet {
+    length: usize,
+    capacity: usize,
+    buffer: Arc<AtomicPtr<AtomicU64>>,
+    refs: Vec<Counter>,
+}
+
+impl CounterSet {
+    fn new(capacity: usize) -> Self {
+        CounterSet {
+            length: 0,
+            capacity,
+            buffer: Arc::new(Self::allocate(capacity).into()),
+            refs: Vec::new(),
+        }
+    }
+
+    pub fn new_counter(&mut self) -> Counter {
+        if self.length == self.capacity {
+            let new_capacity = self.capacity * 2;
+            let new_buffer =
+                Arc::new(AtomicPtr::new(self.reallocate(new_capacity)));
+            for counter in self.refs.iter() {
+                counter.0.deref().buffer.swap(new_buffer.clone());
+            }
+            self.capacity = new_capacity;
+            self.buffer = new_buffer;
+        }
+        let inner = CounterInner {
+            buffer: ArcSwap::new(self.buffer.clone()),
+            index: self.length,
+        };
+        self.length += 1;
+        Counter(Arc::new(inner))
+    }
+
+    fn layout(capacity: usize) -> Layout {
+        Layout::array::<AtomicU64>(capacity)
+            .expect("Required allocation exceeds isize::MAX")
+    }
+
+    fn allocate(capacity: usize) -> *mut AtomicU64 {
+        let buffer = unsafe {
+            System.alloc_zeroed(Self::layout(capacity))
+        };
+        if buffer.is_null() {
+            panic!("Allocation failed");
+        }
+        unsafe {
+            std::mem::transmute(buffer)
+        }
+    }
+
+    fn reallocate(&self, capacity: usize) -> *mut AtomicU64 {
+        let old_buf: *const AtomicU64 = self.buffer.deref().load(Relaxed);
+        let new_buf: *mut AtomicU64 = Self::allocate(capacity);
+        unsafe {
+            core::ptr::copy_nonoverlapping(old_buf, new_buf, self.length);
+        }
+        new_buf
+    }
+}
+
+impl Default for CounterSet {
+    fn default() -> Self {
+        Self::new(512)
+    }
+}
+
+impl Clone for CounterSet {
+    fn clone(&self) -> Self {
+        CounterSet {
+            length: self.length,
+            capacity: self.capacity,
+            buffer: Arc::new(self.reallocate(self.capacity).into()),
+            refs: Vec::new()
+        }
     }
 }

--- a/src/database/counter.rs
+++ b/src/database/counter.rs
@@ -1,0 +1,19 @@
+//! Atomic counters used in the database implementation.
+
+use std::sync::atomic::{AtomicU64, Ordering::{Acquire, Release}};
+
+pub struct Counter(AtomicU64);
+
+impl Counter {
+    pub fn new() -> Self {
+        Self(AtomicU64::from(0))
+    }
+
+    pub fn store(&self, value: u64) {
+        self.0.store(value, Release);
+    }
+
+    pub fn load(&self) -> u64 {
+        self.0.load(Acquire)
+    }
+}

--- a/src/database/counter.rs
+++ b/src/database/counter.rs
@@ -10,6 +10,8 @@ use std::sync::atomic::{
 
 use arc_swap::ArcSwap;
 
+use crate::database::Snapshot;
+
 struct CounterInner {
     buffer: ArcSwap<AtomicPtr<AtomicU64>>,
     index: usize
@@ -116,5 +118,14 @@ impl Clone for CounterSet {
             buffer: Arc::new(self.reallocate(self.capacity).into()),
             refs: Vec::new()
         }
+    }
+}
+
+impl Snapshot<Counter> for Counter {
+    fn snapshot(&self, db: &CounterSet) -> Counter {
+        Counter(Arc::new(CounterInner {
+            buffer: ArcSwap::new(db.buffer.clone()),
+            index: self.0.index
+        }))
     }
 }

--- a/src/database/data_stream.rs
+++ b/src/database/data_stream.rs
@@ -10,6 +10,7 @@ use anyhow::Error;
 use bytemuck::{bytes_of, cast_slice, from_bytes, Pod};
 
 use crate::util::id::Id;
+use crate::database::counter::CounterSet;
 use crate::database::stream::{
     stream,
     StreamReader,
@@ -49,20 +50,20 @@ struct Values<Data, Value> where Data: Deref<Target=[u8]> {
 ///
 /// Returns a unique writer and a cloneable reader.
 ///
-pub fn data_stream<Value>()
+pub fn data_stream<Value>(db: &mut CounterSet)
     -> Result<(DataWriter<Value>, DataReader<Value>), Error>
 {
-    data_stream_with_block_size::<Value, MIN_BLOCK>()
+    data_stream_with_block_size::<Value, MIN_BLOCK>(db)
 }
 
 /// Construct a new data stream with a specific block size.
 ///
 /// Returns a unique writer and a cloneable reader.
 ///
-pub fn data_stream_with_block_size<Value, const S: usize>()
+pub fn data_stream_with_block_size<Value, const S: usize>(db: &mut CounterSet)
     -> Result<(DataWriter<Value, S>, DataReader<Value, S>), Error>
 {
-    let (stream_writer, stream_reader) = stream()?;
+    let (stream_writer, stream_reader) = stream(db)?;
     let data_writer = DataWriter {
         marker: PhantomData,
         stream_writer,
@@ -248,9 +249,15 @@ mod tests {
         baz: u32,
     }
 
+    fn setup<T>() -> (DataWriter::<T>, DataReader::<T>) {
+        // Create a counter set.
+        let mut db = CounterSet::default();
+        data_stream(&mut db).unwrap()
+    }
+
     #[test]
     fn test_data_stream_push() {
-        let (mut writer, mut reader) = data_stream().unwrap();
+        let (mut writer, mut reader) = setup();
         for i in 0..100 {
             let x = Foo { bar: i, baz: i };
             writer.push(&x).unwrap();
@@ -260,7 +267,7 @@ mod tests {
 
     #[test]
     fn test_data_stream_append() {
-        let (mut writer, mut reader) = data_stream().unwrap();
+        let (mut writer, mut reader) = setup();
 
         // Build a Vec of data
         let mut data = Vec::new();
@@ -282,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_data_stream_iter() {
-        let (mut writer, mut reader) = data_stream().unwrap();
+        let (mut writer, mut reader) = setup();
         for i in 0..100 {
             let x = Foo { bar: i, baz: i };
             writer.push(&x).unwrap();

--- a/src/database/data_stream.rs
+++ b/src/database/data_stream.rs
@@ -10,7 +10,7 @@ use anyhow::Error;
 use bytemuck::{bytes_of, cast_slice, from_bytes, Pod};
 
 use crate::util::id::Id;
-use crate::database::counter::CounterSet;
+use crate::database::{CounterSet, Snapshot};
 use crate::database::stream::{
     stream,
     StreamReader,
@@ -234,6 +234,15 @@ where Value: Pod
         self.range.start += 1;
         // Return the value found.
         Some(Ok(value))
+    }
+}
+
+impl<T, const S: usize> Snapshot<DataReader<T, S>> for DataWriter<T, S> {
+    fn snapshot(&self, db: &CounterSet) -> DataReader<T, S> {
+        DataReader {
+            marker: PhantomData,
+            stream_reader: self.stream_writer.snapshot(db),
+        }
     }
 }
 

--- a/src/database/index_stream.rs
+++ b/src/database/index_stream.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 use anyhow::Error;
 
 use crate::database::{
-    counter::CounterSet,
+    CounterSet, Snapshot,
     stream::MIN_BLOCK,
     data_stream::{
         data_stream,
@@ -299,6 +299,15 @@ where Position: From<u64>, Value: From<u64>
     }
 }
 
+impl<P, V, const S: usize> Snapshot<IndexReader<P, V, S>> for IndexWriter<P, V, S>
+{
+    fn snapshot(&self, db: &CounterSet) -> IndexReader<P, V, S> {
+        IndexReader {
+            marker: PhantomData,
+            data_reader: self.data_writer.snapshot(db),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/database/index_stream.rs
+++ b/src/database/index_stream.rs
@@ -9,6 +9,7 @@ use std::ops::Range;
 use anyhow::Error;
 
 use crate::database::{
+    counter::CounterSet,
     stream::MIN_BLOCK,
     data_stream::{
         data_stream,
@@ -46,8 +47,10 @@ type IndexPair<P, V> = (IndexWriter<P, V>, IndexReader<P, V>);
 ///
 /// Returns a unique writer and a cloneable reader.
 ///
-pub fn index_stream<P, V>() -> Result<IndexPair<P, V>, Error> {
-    let (data_writer, data_reader) = data_stream()?;
+pub fn index_stream<P, V>(db: &mut CounterSet)
+    -> Result<IndexPair<P, V>, Error>
+{
+    let (data_writer, data_reader) = data_stream(db)?;
     let writer = IndexWriter {
         marker: PhantomData,
         data_writer,
@@ -303,7 +306,8 @@ mod tests {
 
     #[test]
     fn test_index_stream() {
-        let (mut writer, mut reader) = index_stream().unwrap();
+        let mut db = CounterSet::default();
+        let (mut writer, mut reader) = index_stream(&mut db).unwrap();
         let mut expected = Vec::<Id<u8>>::new();
         let mut x = 10;
         let n = 4321;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,9 +1,12 @@
 //! Storage primitives for the capture database.
 
+mod counter;
 mod stream;
 mod data_stream;
 mod index_stream;
 mod compact_index;
+
+pub use counter::Counter;
 
 pub use data_stream::{
     DataReader,
@@ -11,6 +14,7 @@ pub use data_stream::{
     data_stream,
     data_stream_with_block_size,
 };
+
 pub use compact_index::{
     CompactReader,
     CompactWriter,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -6,7 +6,7 @@ mod data_stream;
 mod index_stream;
 mod compact_index;
 
-pub use counter::Counter;
+pub use counter::{Counter, CounterSet};
 
 pub use data_stream::{
     DataReader,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -20,3 +20,7 @@ pub use compact_index::{
     CompactWriter,
     compact_index,
 };
+
+pub trait Snapshot<T> {
+    fn snapshot(&self, db: &CounterSet) -> T;
+}

--- a/src/database/stream.rs
+++ b/src/database/stream.rs
@@ -15,7 +15,6 @@ use std::ops::{Deref, Range};
 use std::ptr::copy_nonoverlapping;
 use std::slice;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering::{Acquire, Release}};
 
 use anyhow::{Context, Error, bail};
 use arc_swap::{ArcSwap, ArcSwapOption};
@@ -23,13 +22,15 @@ use lrumap::{LruMap, LruBTreeMap};
 use memmap2::{Mmap, MmapOptions};
 use tempfile::tempfile;
 
+use crate::database::counter::Counter;
+
 /// Minimum block size, defined by largest minimum page size on target systems.
 pub const MIN_BLOCK: usize = 0x4000; // 16KB (Apple M1/M2)
 
 /// Private data shared by the writer and multiple readers.
 struct Shared<const S: usize> {
     /// Available length of the stream, including data in both file and buffer.
-    length: AtomicU64,
+    length: Counter,
     /// File handle used by readers to create mappings.
     file: ArcSwapOption<File>,
     /// Buffer currently in use for newly appended data.
@@ -95,7 +96,7 @@ pub fn stream<const BLOCK_SIZE: usize>()
     }
     let buffer = Arc::new(Buffer::new(0)?);
     let shared = Arc::new(Shared {
-        length: AtomicU64::from(0),
+        length: Counter::new(),
         file: ArcSwapOption::empty(),
         current_buffer: ArcSwap::new(buffer.clone()),
     });
@@ -159,7 +160,7 @@ impl<const BLOCK_SIZE: usize> StreamWriter<BLOCK_SIZE> {
             }
         }
         // Update shared length value, and return new length.
-        self.shared.length.store(self.length, Release);
+        self.shared.length.store(self.length);
         Ok(self.length)
     }
 
@@ -255,7 +256,7 @@ impl<const BLOCK_SIZE: usize> StreamWriter<BLOCK_SIZE> {
 impl<const BLOCK_SIZE: usize> StreamReader<BLOCK_SIZE> {
     /// Get the current length of the stream, in bytes.
     pub fn len(&self) -> u64 {
-        self.shared.length.load(Acquire)
+        self.shared.length.load()
     }
 
     /// Access data in the stream.
@@ -269,7 +270,7 @@ impl<const BLOCK_SIZE: usize> StreamReader<BLOCK_SIZE> {
         use Data::*;
 
         // First guarantee that the requested data exists, somewhere.
-        let available_length = self.shared.length.load(Acquire);
+        let available_length = self.shared.length.load();
         if range.end > available_length {
             bail!("Requested read of range {range:?}, \
                    but stream length is {available_length}")

--- a/src/database/stream.rs
+++ b/src/database/stream.rs
@@ -22,7 +22,7 @@ use lrumap::{LruMap, LruBTreeMap};
 use memmap2::{Mmap, MmapOptions};
 use tempfile::tempfile;
 
-use crate::database::counter::{Counter, CounterSet};
+use crate::database::{Counter, CounterSet, Snapshot};
 
 /// Minimum block size, defined by largest minimum page size on target systems.
 pub const MIN_BLOCK: usize = 0x4000; // 16KB (Apple M1/M2)
@@ -422,6 +422,23 @@ impl<const S: usize> Clone for StreamReader<S> {
                 }
                 new_mappings
             }
+        }
+    }
+}
+
+impl<const S: usize> Snapshot<StreamReader<S>> for StreamWriter<S> {
+    fn snapshot(&self, db: &CounterSet) -> StreamReader<S> {
+        StreamReader {
+            shared: Arc::new(Shared {
+                length: self.shared.length.snapshot(db),
+                file: ArcSwapOption::new(
+                    self.shared.file.load().clone()
+                ),
+                current_buffer: ArcSwap::new(
+                    self.shared.current_buffer.load().clone()
+                ),
+            }),
+            mappings: LruBTreeMap::new(MAP_CACHE_PER_READER),
         }
     }
 }

--- a/src/database/stream.rs
+++ b/src/database/stream.rs
@@ -22,7 +22,7 @@ use lrumap::{LruMap, LruBTreeMap};
 use memmap2::{Mmap, MmapOptions};
 use tempfile::tempfile;
 
-use crate::database::counter::Counter;
+use crate::database::counter::{Counter, CounterSet};
 
 /// Minimum block size, defined by largest minimum page size on target systems.
 pub const MIN_BLOCK: usize = 0x4000; // 16KB (Apple M1/M2)
@@ -86,7 +86,7 @@ type StreamPair<const S: usize> = (StreamWriter<S>, StreamReader<S>);
 ///
 /// Returns a unique writer and a cloneable reader.
 ///
-pub fn stream<const BLOCK_SIZE: usize>()
+pub fn stream<const BLOCK_SIZE: usize>(db: &mut CounterSet)
     -> Result<StreamPair<BLOCK_SIZE>, Error>
 {
     let page_size = page_size::get();
@@ -96,7 +96,7 @@ pub fn stream<const BLOCK_SIZE: usize>()
     }
     let buffer = Arc::new(Buffer::new(0)?);
     let shared = Arc::new(Shared {
-        length: Counter::new(),
+        length: db.new_counter(),
         file: ArcSwapOption::empty(),
         current_buffer: ArcSwap::new(buffer.clone()),
     });
@@ -440,7 +440,8 @@ mod tests {
         const BLOCK_SIZE: usize = 0x4000;
 
         // Create a reader-writer pair.
-        let (mut writer, reader) = stream::<BLOCK_SIZE>().unwrap();
+        let mut db = CounterSet::default();
+        let (mut writer, reader) = stream::<BLOCK_SIZE>(&mut db).unwrap();
 
         // Build a reference array with ~8MB of random data.
         let mut prng = XorShiftRng::seed_from_u64(42);

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -504,7 +504,7 @@ impl EndpointData {
                 self.writer.data_transactions.push(ep_transaction_id)?;
                 self.writer.data_byte_counts.push(self.total_data)?;
                 self.total_data += length as u64;
-                self.writer.shared.total_data.store(self.total_data, Release);
+                self.writer.shared.total_data.store(self.total_data);
             }
         };
         Ok(())

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -486,7 +486,7 @@ impl EndpointData {
 }
 
 pub struct Decoder {
-    capture: CaptureWriter,
+    pub capture: CaptureWriter,
     device_index: VecMap<DeviceAddr, DeviceId>,
     endpoint_data: VecMap<EndpointId, EndpointData>,
     last_endpoint_state: Vec<u8>,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -543,7 +543,8 @@ impl Decoder {
         // Add the special endpoints for invalid and framing packets.
         let mut endpoint_readers = VecMap::new();
         for ep_number in [INVALID_EP_NUM, FRAMING_EP_NUM] {
-            let (writer, reader) = create_endpoint()?;
+            let (writer, reader) =
+                create_endpoint(&mut decoder.capture.counters)?;
             let mut endpoint = Endpoint::default();
             endpoint.set_device_id(default_id);
             endpoint.set_device_address(default_addr);
@@ -755,7 +756,7 @@ impl Decoder {
             Some(id) => *id,
             None => self.add_device(dev_addr)?
         };
-        let (writer, reader) = create_endpoint()?;
+        let (writer, reader) = create_endpoint(&mut self.capture.counters)?;
         let mut endpoint = Endpoint::default();
         endpoint.set_device_id(device_id);
         endpoint.set_device_address(dev_addr);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -940,7 +940,7 @@ pub fn update_view() -> Result<(), Error> {
         #[cfg(feature="record-ui-test")]
         ui.recording
             .borrow_mut()
-            .log_update(ui.capture.packet_index.len());
+            .log_update(snapshot.packet_index.len());
         let mut more_updates = false;
         if ui.show_progress == Some(Save) {
             more_updates = true;
@@ -963,7 +963,7 @@ pub fn update_view() -> Result<(), Error> {
             ));
             for model in ui.traffic_models.values() {
                 let old_count = model.n_items();
-                more_updates |= model.update()?;
+                more_updates |= model.update(&mut ui.capture)?;
                 let new_count = model.n_items();
                 // If any endpoints were added, we need to redraw the rows above
                 // to add the additional columns of the connecting lines.
@@ -976,7 +976,7 @@ pub fn update_view() -> Result<(), Error> {
                 }
             }
             if let Some(model) = &ui.device_model {
-                more_updates |= model.update()?;
+                more_updates |= model.update(&mut ui.capture)?;
             }
         }
         if let Some(action) = ui.show_progress {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,14 +6,12 @@ use std::ffi::OsStr;
 use std::io::{Read, Write};
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{Sender, Receiver, channel};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
 #[cfg(feature="step-decoder")]
 use std::net::TcpListener;
-
-#[cfg(feature="record-ui-test")]
-use std::sync::Mutex;
 
 use anyhow::{Context as ErrorContext, Error, bail};
 use chrono::{DateTime, Local};
@@ -144,9 +142,7 @@ static TOTAL: AtomicU64 = AtomicU64::new(0);
 static CURRENT: AtomicU64 = AtomicU64::new(0);
 static STOP: AtomicBool = AtomicBool::new(false);
 static UPDATE_INTERVAL: Duration = Duration::from_millis(10);
-
-#[cfg(feature="record-ui-test")]
-static UPDATE_LOCK: Mutex<()> = Mutex::new(());
+static SNAPSHOT_REQ: AtomicBool = AtomicBool::new(false);
 
 thread_local!(
     static WINDOW: RefCell<Option<ApplicationWindow>> =
@@ -369,6 +365,7 @@ impl DeviceWarning {
 }
 
 pub struct UserInterface {
+    snapshot_rx: Receiver<CaptureReader>,
     pub capture: CaptureReader,
     selector: DeviceSelector,
     file_name: Option<String>,
@@ -635,11 +632,13 @@ pub fn activate(application: &Application) -> Result<(), Error> {
     window.set_child(Some(&vbox));
 
     UI.with(|cell| {
+        let (_snapshot_tx, snapshot_rx) = channel();
         cell.borrow_mut().replace(
             UserInterface {
                 #[cfg(any(test, feature="record-ui-test"))]
                 recording: Rc::new(RefCell::new(
                     Recording::new(capture.clone()))),
+                snapshot_rx,
                 capture,
                 selector,
                 file_name: None,
@@ -933,16 +932,15 @@ pub fn reset_capture() -> Result<CaptureWriter, Error> {
 
 pub fn update_view() -> Result<(), Error> {
     with_ui(|ui| {
+        SNAPSHOT_REQ.store(true, Ordering::Relaxed);
+        if let Ok(snapshot) = ui.snapshot_rx.recv() {
+            ui.capture = snapshot;
+        };
         use FileAction::*;
         #[cfg(feature="record-ui-test")]
-        let guard = {
-            let guard = UPDATE_LOCK.lock();
-            let packet_count = ui.capture.packet_index.len();
-            ui.recording
-                .borrow_mut()
-                .log_update(packet_count);
-            guard
-        };
+        ui.recording
+            .borrow_mut()
+            .log_update(ui.capture.packet_index.len());
         let mut more_updates = false;
         if ui.show_progress == Some(Save) {
             more_updates = true;
@@ -1011,8 +1009,6 @@ pub fn update_view() -> Result<(), Error> {
                 || display_error(update_view())
             );
         }
-        #[cfg(feature="record-ui-test")]
-        drop(guard);
         Ok(())
     })
 }
@@ -1092,6 +1088,7 @@ fn start_file(action: FileAction, file: gio::File) -> Result<(), Error> {
     };
     with_ui(|ui| {
         let cancel_handle = Cancellable::new();
+        let (snapshot_tx, snapshot_rx) = channel();
         #[cfg(feature="record-ui-test")]
         ui.recording.borrow_mut().log_open_file(
             &file.path().context("Cannot record UI test for non-local path")?,
@@ -1107,6 +1104,7 @@ fn start_file(action: FileAction, file: gio::File) -> Result<(), Error> {
         ui.vbox.insert_child_after(&ui.progress_bar, Some(&ui.separator));
         ui.show_progress = Some(action);
         ui.file_name = Some(basename.to_string_lossy().to_string());
+        ui.snapshot_rx = snapshot_rx;
         let capture = ui.capture.clone();
         let packet_count = capture.packet_index.len();
         CURRENT.store(0, Ordering::Relaxed);
@@ -1117,8 +1115,10 @@ fn start_file(action: FileAction, file: gio::File) -> Result<(), Error> {
         std::thread::spawn(move || {
             let start_time = Instant::now();
             let result = match action {
-                Load => load_file(file, format, writer.unwrap(), cancel_handle),
-                Save => save_file(file, format, capture, cancel_handle),
+                Load => load_file(
+                    file, format, writer.unwrap(), cancel_handle, snapshot_tx),
+                Save => save_file(
+                    file, format, capture, cancel_handle),
             };
             let duration = Instant::now().duration_since(start_time);
             if result.is_ok() {
@@ -1142,7 +1142,8 @@ fn start_file(action: FileAction, file: gio::File) -> Result<(), Error> {
 
 fn load<Source, Loader>(
     writer: CaptureWriter,
-    source: Source
+    source: Source,
+    snapshot_tx: Sender<CaptureReader>,
 ) -> Result<(), Error>
 where
     Source: Read,
@@ -1161,13 +1162,12 @@ where
                     let mut buf = [0; 1];
                     client.read(&mut buf).unwrap();
                 };
-                #[cfg(feature="record-ui-test")]
-                let guard = UPDATE_LOCK.lock();
                 decoder.handle_raw_packet(
                     packet.bytes(), packet.timestamp_ns())?;
-                #[cfg(feature="record-ui-test")]
-                drop(guard);
                 CURRENT.store(packet.total_bytes_read(), Ordering::Relaxed);
+                if SNAPSHOT_REQ.swap(false, Ordering::AcqRel) {
+                    snapshot_tx.send(decoder.capture.snapshot())?;
+                }
             },
             Metadata(meta) => decoder.handle_metadata(meta),
             LoadError(e) => return Err(e),
@@ -1186,7 +1186,8 @@ where
 fn load_file(file: gio::File,
              format: FileFormat,
              writer: CaptureWriter,
-             cancel_handle: Cancellable)
+             cancel_handle: Cancellable,
+             snapshot_tx: Sender<CaptureReader>)
     -> Result<(), Error>
 {
     use FileFormat::*;
@@ -1199,8 +1200,8 @@ fn load_file(file: gio::File,
     }
     let source = file.read(Some(&cancel_handle))?.into_read();
     match format {
-        Pcap => load::<_, PcapLoader<_>>(writer, source),
-        PcapNg => load::<_, PcapNgLoader<_>>(writer, source),
+        Pcap => load::<_, PcapLoader<_>>(writer, source, snapshot_tx),
+        PcapNg => load::<_, PcapNgLoader<_>>(writer, source, snapshot_tx),
     }
 }
 
@@ -1314,6 +1315,7 @@ pub fn start_capture() -> Result<(), Error> {
             .. device.metadata().clone()
         };
         writer.shared.metadata.swap(Arc::new(meta));
+        let (snapshot_tx, snapshot_rx) = channel();
         let (stream_handle, stop_handle) =
             device.start(speed, Box::new(display_error))?;
         ui.open_button.set_sensitive(false);
@@ -1322,12 +1324,16 @@ pub fn start_capture() -> Result<(), Error> {
         ui.capture_button.set_sensitive(false);
         ui.stop_button.set_sensitive(true);
         ui.stop_state = StopState::Backend(stop_handle);
+        ui.snapshot_rx = snapshot_rx;
         let read_packets = move || {
             let mut decoder = Decoder::new(writer)?;
             for result in stream_handle {
                 let packet = result
                     .context("Error processing raw capture data")?;
                 decoder.handle_raw_packet(&packet.bytes, packet.timestamp_ns)?;
+                if SNAPSHOT_REQ.swap(false, Ordering::AcqRel) {
+                    snapshot_tx.send(decoder.capture.snapshot())?;
+                }
             }
             let writer = decoder.finish()?;
             writer.shared.metadata.update(|meta| {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -755,8 +755,11 @@ fn create_view<Item, Model, RowData, ViewMode>(
                                       feature="record-ui-test"))]
                             recording.borrow_mut().log_item_expanded(
                                 name, position, expanded);
-                            display_error(
-                                model.set_expanded(&node_ref, position, expanded))
+                            display_error(with_ui(|ui| {
+                                model.set_expanded(
+                                    &mut ui.capture,
+                                    &node_ref, position, expanded)
+                            }))
                         }
                     )
                 );

--- a/src/ui/model.rs
+++ b/src/ui/model.rs
@@ -29,6 +29,7 @@ pub trait GenericModel<Item, ViewMode> where Self: Sized {
 
     /// Set whether a tree node is expanded.
     fn set_expanded(&self,
+                    snapshot: &mut CaptureReader,
                     node: &ItemNodeRc<Item>,
                     position: u32,
                     expanded: bool)
@@ -78,6 +79,7 @@ macro_rules! model {
             }
 
             fn set_expanded(&self,
+                            snapshot: &mut CaptureReader,
                             node: &ItemNodeRc<$item>,
                             position: u32,
                             expanded: bool)
@@ -85,7 +87,7 @@ macro_rules! model {
             {
                 let tree_opt  = self.imp().tree.borrow();
                 let tree = tree_opt.as_ref().unwrap();
-                tree.set_expanded(self, node, position as u64, expanded)
+                tree.set_expanded(self, snapshot, node, position as u64, expanded)
             }
 
             fn update(&self, snapshot: &mut CaptureReader) -> Result<bool, Error> {

--- a/src/ui/model.rs
+++ b/src/ui/model.rs
@@ -37,7 +37,7 @@ pub trait GenericModel<Item, ViewMode> where Self: Sized {
     /// Update the model with new data from the capture.
     ///
     /// Returns true if there will be further updates in future.
-    fn update(&self) -> Result<bool, Error>;
+    fn update(&self, snapshot: &mut CaptureReader) -> Result<bool, Error>;
 
     /// Fetch the description for a given item.
     fn description(&self, item: &Item, detail: bool) -> String;
@@ -88,10 +88,10 @@ macro_rules! model {
                 tree.set_expanded(self, node, position as u64, expanded)
             }
 
-            fn update(&self) -> Result<bool, Error> {
+            fn update(&self, snapshot: &mut CaptureReader) -> Result<bool, Error> {
                 let tree_opt = self.imp().tree.borrow();
                 let tree = tree_opt.as_ref().unwrap();
-                tree.update(self)
+                tree.update(self, snapshot)
             }
 
             fn description(&self, item: &$item, detail: bool) -> String {

--- a/src/ui/test_replay.rs
+++ b/src/ui/test_replay.rs
@@ -145,6 +145,10 @@ fn check_replays() {
                             End => panic!("No next loader item"),
                         };
                     }
+                    with_ui(|ui| {
+                        ui.capture = decoder.capture.snapshot();
+                        Ok(())
+                    }).unwrap();
                     update_view()
                         .expect("Failed to update view");
                 },

--- a/src/ui/test_replay.rs
+++ b/src/ui/test_replay.rs
@@ -201,7 +201,7 @@ fn set_expanded(ui: &mut UserInterface,
                 .expect("List item is not DeviceRowData")
                 .node()
                 .expect("Failed to get node from DeviceRowData");
-            model.set_expanded(&node, position, expanded)
+            model.set_expanded(&mut ui.capture, &node, position, expanded)
                 .expect("Failed to expand/collapse item");
         },
         log_name => {
@@ -215,7 +215,7 @@ fn set_expanded(ui: &mut UserInterface,
                 .expect("List item is not TrafficRowData")
                 .node()
                 .expect("Failed to get node from TrafficRowData");
-            model.set_expanded(&node, position, expanded)
+            model.set_expanded(&mut ui.capture, &node, position, expanded)
                 .expect("Failed to expand/collapse item");
         },
     }

--- a/src/ui/tree_list_model.rs
+++ b/src/ui/tree_list_model.rs
@@ -420,6 +420,7 @@ where Item: 'static + Clone + Debug,
 
     pub fn set_expanded(&self,
                         model: &Model,
+                        snapshot: &mut CaptureReader,
                         node_ref: &ItemNodeRc<Item>,
                         position: u64,
                         expanded: bool)
@@ -450,7 +451,7 @@ where Item: 'static + Clone + Debug,
             #[cfg(feature="debug-region-map")]
             println!("\nExpanding node at {}", position);
             // Update the region map for the added children.
-            self.expand(children_position, node_ref)?
+            self.expand(snapshot, children_position, node_ref)?
         } else {
             #[cfg(feature="debug-region-map")]
             println!("\nCollapsing node at {}", position);
@@ -460,10 +461,11 @@ where Item: 'static + Clone + Debug,
                 #[cfg(feature="debug-region-map")]
                 println!("\nRecursively collapsing child at {}",
                          child_position);
-                self.set_expanded(model, &child_ref, child_position, false)?;
+                self.set_expanded(
+                    model, snapshot, &child_ref, child_position, false)?;
             }
             // Update the region map for the removed children.
-            self.collapse(children_position, node_ref)?
+            self.collapse(snapshot, children_position, node_ref)?
         };
 
         // Merge adjacent regions with the same source.
@@ -496,9 +498,12 @@ where Item: 'static + Clone + Debug,
         Ok(())
     }
 
-    fn expand(&self, position: u64, node_ref: &ItemNodeRc<Item>)
-        -> Result<ModelUpdate, Error>
-    {
+    fn expand(
+        &self,
+        snapshot: &mut CaptureReader,
+        position: u64,
+        node_ref: &ItemNodeRc<Item>
+    ) -> Result<ModelUpdate, Error> {
         // Find the start of the parent region.
         let (&parent_start, _) = self.regions
             .borrow()
@@ -524,7 +529,8 @@ where Item: 'static + Clone + Debug,
             .into_iter();
 
         // Split the parent region and construct a new region between.
-        let update = self.split_parent(parent_start, &parent, node_ref,
+        let update = self.split_parent(
+            snapshot, parent_start, &parent, node_ref,
             vec![Region {
                 source: parent.source.clone(),
                 offset: parent.offset,
@@ -550,9 +556,12 @@ where Item: 'static + Clone + Debug,
         Ok(update)
     }
 
-    fn collapse(&self, position: u64, node_ref: &ItemNodeRc<Item>)
-        -> Result<ModelUpdate, Error>
-    {
+    fn collapse(
+        &self,
+        _snapshot: &mut CaptureReader,
+        position: u64,
+        node_ref: &ItemNodeRc<Item>
+    ) -> Result<ModelUpdate, Error> {
         // Clone the region starting at this position.
         let region = self.regions
             .borrow()
@@ -614,7 +623,9 @@ where Item: 'static + Clone + Debug,
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn split_parent(&self,
+                    _snapshot: &mut CaptureReader,
                     parent_start: u64,
                     parent: &Region<Item>,
                     _node_ref: &ItemNodeRc<Item>,

--- a/src/ui/tree_list_model.rs
+++ b/src/ui/tree_list_model.rs
@@ -354,7 +354,7 @@ impl std::fmt::Display for ModelUpdate {
 
 pub struct TreeListModel<Item, Model, RowData, ViewMode> {
     _marker: PhantomData<(Model, RowData)>,
-    capture: RefCell<CaptureReader>,
+    pub capture: RefCell<CaptureReader>,
     view_mode: ViewMode,
     root: RootNodeRc<Item>,
     regions: RefCell<BTreeMap<u64, Region<Item>>>,
@@ -725,10 +725,12 @@ where Item: 'static + Clone + Debug,
         self.regions.replace(new_regions);
     }
 
-    pub fn update(&self, model: &Model) -> Result<bool, Error> {
+    pub fn update(&self, model: &Model, snapshot: &mut CaptureReader)
+        -> Result<bool, Error>
+    {
         #[cfg(feature="debug-region-map")]
         let rows_before = self.row_count();
-        self.update_node(&self.root, 0, model)?;
+        self.update_node(&self.root, 0, model, snapshot)?;
         #[cfg(feature="debug-region-map")] {
             let rows_after = self.row_count();
             let rows_added = rows_after - rows_before;
@@ -749,7 +751,8 @@ where Item: 'static + Clone + Debug,
     fn update_node<T>(&self,
                    node_rc: &Rc<RefCell<T>>,
                    mut position: u64,
-                   model: &Model)
+                   model: &Model,
+                   snapshot: &mut CaptureReader)
         -> Result<u64, Error>
         where T: Node<Item> + 'static,
               Rc<RefCell<T>>: NodeRcOps<Item>,
@@ -765,9 +768,8 @@ where Item: 'static + Clone + Debug,
             .collect::<Vec<(u64, ItemNodeWeak<Item>)>>();
 
         // Check if this node had children added and/or was completed.
-        let mut cap = self.capture.borrow_mut();
         let (completion, new_direct_count) =
-            cap.item_children(node.item(), self.view_mode)?;
+            snapshot.item_children(node.item(), self.view_mode)?;
         let completed = completion.is_complete();
         let children_added = new_direct_count - old_direct_count;
         drop(node);
@@ -780,7 +782,7 @@ where Item: 'static + Clone + Debug,
             let item_updated = if children_added > 0 {
                 // Update due to added children.
                 true
-            } else if let Some(new_item) = cap.item_update(&item_node.item)? {
+            } else if let Some(new_item) = snapshot.item_update(&item_node.item)? {
                 // Update due to new version of item.
                 item_node.item = new_item;
                 true
@@ -791,7 +793,7 @@ where Item: 'static + Clone + Debug,
 
             if item_updated {
                 // The node's description may change.
-                let summary = cap.description(&item_node.item, false)?;
+                let summary = snapshot.description(&item_node.item, false)?;
                 #[cfg(any(test, feature="record-ui-test"))]
                 if let Ok(position) = u32::try_from(position) {
                     let mut on_item_update = self.on_item_update.borrow_mut();
@@ -811,8 +813,6 @@ where Item: 'static + Clone + Debug,
             position += 1;
         }
 
-        drop(cap);
-
         // If completed, remove from incomplete node list.
         if completed {
             node_rc.borrow_mut().set_completed();
@@ -830,7 +830,7 @@ where Item: 'static + Clone + Debug,
                         .rows_between(last_index, index);
                     // Recursively update this child.
                     position = self.update_node::<ItemNode<Item>>(
-                        &child_rc, position, model)?;
+                        &child_rc, position, model, snapshot)?;
                     last_index = index + 1;
                 } else {
                     // Child no longer referenced, remove it.


### PR DESCRIPTION
Work in progress.

Rather than trying to work with live data from the database during UI updates, take a snapshot of the database state and then work with that snapshot until the next update. This eliminates a lot of potential for non-determinism that's otherwise hard to test or reproduce.

The challenge is to make the snapshotting cheap; this can be achieved by grouping all the `AtomicU64` counters used by the database into a contiguous block of memory which serves as the state representation, and which can be snapshotted effectively with a `memcpy` by the writing thread, in between handling packets.

Further work is still needed to make constructing and working with snapshots more efficient.

Fixes some crashes in #150.

Probably fixes #213 and similar occasional failures.