### PR TITLE
Clippy fixes for Rust 1.88

### DIFF
--- a/src/backend/ice40usbtrace.rs
+++ b/src/backend/ice40usbtrace.rs
@@ -256,7 +256,7 @@ impl std::fmt::Display for Pid {
             Stall => "STALL",
             TsOverflow => "TS OVERFLOW",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -177,7 +177,7 @@ fn test(save_capture: bool,
             }
         }
 
-        println!("Found {} SOF packets with expected interval range", sof_count);
+        println!("Found {sof_count} SOF packets with expected interval range");
 
         ensure!(gaps.len() <= 1, "More than one gap in SOF packets seen");
 

--- a/src/ui/record_ui.rs
+++ b/src/ui/record_ui.rs
@@ -29,11 +29,11 @@ impl std::fmt::Display for UiAction {
             Open(path) =>
                 write!(f, "Opening file {}", path.display()),
             Update(count) =>
-                write!(f, "Updating after {} packets decoded", count),
+                write!(f, "Updating after {count} packets decoded"),
             SetExpanded(name, position, true) =>
-                write!(f, "Expanding {} view, row {}", name, position),
+                write!(f, "Expanding {name} view, row {position}"),
             SetExpanded(name, position, false) =>
-                write!(f, "Collapsing {} view, row {}", name, position),
+                write!(f, "Collapsing {name} view, row {position}"),
         }
     }
 }
@@ -92,9 +92,9 @@ impl Recording {
 
         if let UiAction::SetExpanded(ref name, position, _) = action {
             let summary = self.summary(name, position);
-            self.log_output(format!("{}: {}\n", action, summary));
+            self.log_output(format!("{action}: {summary}\n"));
         } else {
-            self.log_output(format!("{}\n", action));
+            self.log_output(format!("{action}\n"));
         }
     }
 
@@ -146,9 +146,9 @@ impl Recording {
     {
         let old_summary = self.summary(name, position).to_string();
         if new_summary != old_summary {
-            self.log_output(format!("At {} row {}:\n", name, position));
-            self.log_output(format!("- {}\n", old_summary));
-            self.log_output(format!("+ {}\n", new_summary));
+            self.log_output(format!("At {name} row {position}:\n"));
+            self.log_output(format!("- {old_summary}\n"));
+            self.log_output(format!("+ {new_summary}\n"));
         }
     }
 
@@ -182,19 +182,19 @@ impl Recording {
             .or_default()
             .splice(removed_range, added_items.clone())
             .collect();
-        self.log_output(format!("At {} row {}:\n", name, position));
+        self.log_output(format!("At {name} row {position}:\n"));
         for (n, string) in removed_items.iter().dedup_with_count() {
             if n == 1 {
-                self.log_output(format!("- {}\n", string));
+                self.log_output(format!("- {string}\n"));
             } else {
-                self.log_output(format!("- {} times: {}\n", n, string));
+                self.log_output(format!("- {n} times: {string}\n"));
             }
         }
         for (n, string) in added_items.iter().dedup_with_count() {
             if n == 1 {
-                self.log_output(format!("+ {}\n", string));
+                self.log_output(format!("+ {string}\n"));
             } else {
-                self.log_output(format!("+ {} times: {}\n", n, string));
+                self.log_output(format!("+ {n} times: {string}\n"));
             }
         }
     }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -650,13 +650,13 @@ impl DescriptorType {
             BinaryObjectStore => "BOS",
             DeviceCapability => "device capability",
             UnknownStandard(code) =>
-                return format!("standard descriptor 0x{:02X}", code),
+                return format!("standard descriptor 0x{code:02X}"),
             Class(code) =>
-                return format!("class descriptor 0x{:02X}", code),
+                return format!("class descriptor 0x{code:02X}"),
             Custom(code) =>
-                return format!("custom descriptor 0x{:02X}", code),
+                return format!("custom descriptor 0x{code:02X}"),
             Reserved(code) =>
-                return format!("reserved descriptor 0x{:02X}", code),
+                return format!("reserved descriptor 0x{code:02X}"),
             Unknown => "unknown",
         })
     }
@@ -1018,8 +1018,7 @@ impl Descriptor {
                 let expected = desc_type
                     .expected_length()
                     .unwrap_or(desc_length);
-                format!("Truncated {} ({} of {} bytes)",
-                    description, length, expected)
+                format!("Truncated {description} ({length} of {expected} bytes)")
             }
         }
     }
@@ -1332,8 +1331,8 @@ impl ControlTransfer {
         let summary = parts.concat();
         match self.result {
             ControlResult::Completed => summary,
-            ControlResult::Incomplete => format!("{}, incomplete", summary),
-            ControlResult::Stalled => format!("{}, stalled", summary),
+            ControlResult::Incomplete => format!("{summary}, incomplete"),
+            ControlResult::Stalled => format!("{summary}, stalled"),
         }
     }
 }
@@ -1557,7 +1556,7 @@ mod tests {
             assert!(sof.frame_number() == 1758);
             assert!(sof.crc() == 0x03);
         } else {
-            panic!("Expected SOF but got {:?}", p);
+            panic!("Expected SOF but got {p:?}");
         }
 
     }
@@ -1572,7 +1571,7 @@ mod tests {
             assert!(tok.endpoint_number() == EndpointNum(0));
             assert!(tok.crc() == 0x15);
         } else {
-            panic!("Expected Token but got {:?}", p);
+            panic!("Expected Token but got {p:?}");
         }
 
     }
@@ -1587,7 +1586,7 @@ mod tests {
             assert!(tok.endpoint_number() == EndpointNum(1));
             assert!(tok.crc() == 0x03);
         } else {
-            panic!("Expected Token but got {:?}", p);
+            panic!("Expected Token but got {p:?}");
         }
 
     }
@@ -1600,7 +1599,7 @@ mod tests {
         if let PacketFields::Data(data) = p {
             assert!(data.crc == 0xd5aa);
         } else {
-            panic!("Expected Data but got {:?}", p);
+            panic!("Expected Data but got {p:?}");
         }
     }
 

--- a/src/util/dump.rs
+++ b/src/util/dump.rs
@@ -30,7 +30,7 @@ pub fn restore<T>(src: &Path) -> Result<T, Error> where T: Dump {
 impl Dump for String {
     fn dump(&self, dest: &Path) -> Result<(), Error> {
         let mut file = File::create(dest)?;
-        writeln!(file, "{}", self)?;
+        writeln!(file, "{self}")?;
         Ok(())
     }
 


### PR DESCRIPTION
The paperclip demands we inline all our `format!` arguments. We shall obey. All hail the paperclip.