### PR TITLE
Bump vcpkg to latest release and fix caching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      VCPKG_COMMIT: a1aebfa9d5eae7cf493e0a706b43915d687bb860 # CMake 4.0.0 fix
+      VCPKG_COMMIT: ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0 # 2025.06.13 release
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg/installed
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,7 @@ jobs:
     env:
       VCPKG_COMMIT: ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0 # 2025.06.13 release
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg/installed
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg_cache,readwrite
 
     steps:
       - name: Get runner version
@@ -113,12 +114,26 @@ jobs:
           tool: cargo-license
         if: matrix.os == 'windows-latest'
 
+      - name: Restore vcpkg cache (Windows)
+        uses: actions/cache/restore@v4
+        id: vcpkg-cache
+        with:
+          path: "${{ github.workspace }}/.vcpkg_cache"
+          key: vcpkg-${{ env.VCPKG_COMMIT }}-${{ hashFiles('vcpkg.json')}}
+        if: matrix.os == 'windows-latest'
+
       - name: Install dependencies (Windows)
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
           runVcpkgInstall: true
-          doNotCache: false
+        if: matrix.os == 'windows-latest'
+
+      - name: Save vcpkg cache (Windows)
+        uses: actions/cache/save@v4
+        with:
+          path: "${{ github.workspace }}/.vcpkg_cache"
+          key: ${{ steps.vcpkg-cache.outputs.cache-primary-key }}
         if: matrix.os == 'windows-latest'
 
       - name: Set PKG_CONFIG (Windows)


### PR DESCRIPTION
This PR:

- Bumps vcpkg to the 2025-06-13 stable release.
- Fixes vcpkg caching by telling vcpkg to cache to files, then using `actions/cache@v4` to back up the file cache.