### PR TITLE
Reimplement main window as a subclass with UI loaded from file

### DIFF
--- a/src/ui/device.rs
+++ b/src/ui/device.rs
@@ -1,0 +1,193 @@
+//! UI for selecting and displaying info about capture devices.
+
+use gtk::{
+    prelude::*,
+    glib::SignalHandlerId,
+    DropDown,
+    InfoBar,
+    Label,
+    MessageType,
+    ResponseType,
+    StringList,
+};
+
+use anyhow::{bail, Error};
+
+use crate::backend::{BackendHandle, ProbeResult, scan};
+use crate::ui::{display_error, device_selection_changed};
+use crate::usb::Speed;
+
+pub struct DeviceSelector {
+    devices: Vec<ProbeResult>,
+    dev_strings: Vec<String>,
+    dev_speeds: Vec<Vec<&'static str>>,
+    dev_dropdown: DropDown,
+    speed_dropdown: DropDown,
+    change_handler: Option<SignalHandlerId>,
+}
+
+impl DeviceSelector {
+    pub fn new(dev_dropdown: DropDown, speed_dropdown: DropDown)
+        -> Result<Self, Error>
+    {
+        dev_dropdown.set_model(Some(&StringList::new(&[])));
+        speed_dropdown.set_model(Some(&StringList::new(&[])));
+        Ok(DeviceSelector {
+            devices: vec![],
+            dev_strings: vec![],
+            dev_speeds: vec![],
+            dev_dropdown,
+            speed_dropdown,
+            change_handler: None,
+        })
+    }
+
+    pub fn current_device(&self) -> Option<&ProbeResult> {
+        if self.devices.is_empty() {
+            None
+        } else {
+            Some(&self.devices[self.dev_dropdown.selected() as usize])
+        }
+    }
+
+    pub fn device_available(&self) -> bool {
+        match self.current_device() {
+            None => false,
+            Some(probe) => probe.result.is_ok()
+        }
+    }
+
+    pub fn device_unusable(&self) -> Option<&str> {
+        match self.current_device() {
+            Some(ProbeResult {result: Err(msg), ..}) => Some(msg),
+            _ => None
+        }
+    }
+
+    pub fn set_sensitive(&mut self, sensitive: bool) {
+        if sensitive {
+            self.dev_dropdown.set_sensitive(!self.devices.is_empty());
+            self.speed_dropdown.set_sensitive(self.device_available());
+        } else {
+            self.dev_dropdown.set_sensitive(false);
+            self.speed_dropdown.set_sensitive(false);
+        }
+    }
+
+    pub fn scan(&mut self) -> Result<(), Error> {
+        if let Some(handler) = self.change_handler.take() {
+            self.dev_dropdown.disconnect(handler);
+        }
+        self.devices = scan()?;
+        let count = self.devices.len();
+        self.dev_strings = Vec::with_capacity(count);
+        self.dev_speeds = Vec::with_capacity(count);
+        for probe in self.devices.iter() {
+            self.dev_strings.push(
+                if count <= 1 {
+                    probe.name.to_string()
+                } else {
+                    let info = &probe.info;
+                    if let Some(serial) = info.serial_number() {
+                        format!("{} #{}", probe.name, serial)
+                    } else {
+                        format!("{} (bus {}, device {})",
+                            probe.name,
+                            info.bus_number(),
+                            info.device_address())
+                    }
+                }
+            );
+            if let Ok(device) = &probe.result {
+                self.dev_speeds.push(
+                    device
+                        .supported_speeds()
+                        .iter()
+                        .map(Speed::description)
+                        .collect()
+                );
+            } else {
+                self.dev_speeds.push(vec![]);
+            }
+        }
+        let no_speeds = vec![];
+        let speed_strings = self.dev_speeds.first().unwrap_or(&no_speeds);
+        self.replace_dropdown(&self.dev_dropdown, &self.dev_strings);
+        self.replace_dropdown(&self.speed_dropdown, speed_strings);
+        self.dev_dropdown.set_sensitive(!self.devices.is_empty());
+        self.speed_dropdown.set_sensitive(!speed_strings.is_empty());
+        self.change_handler = Some(
+            self.dev_dropdown.connect_selected_notify(
+                |_| display_error(device_selection_changed())));
+        Ok(())
+    }
+
+    pub fn update_speeds(&self) {
+        let index = self.dev_dropdown.selected() as usize;
+        let speed_strings = &self.dev_speeds[index];
+        self.replace_dropdown(&self.speed_dropdown, speed_strings);
+        self.speed_dropdown.set_sensitive(!speed_strings.is_empty());
+    }
+
+    pub fn open(&self) -> Result<(Box<dyn BackendHandle>, Speed), Error> {
+        let device_id = self.dev_dropdown.selected();
+        let probe = &self.devices[device_id as usize];
+        match &probe.result {
+            Ok(device) => {
+                let speeds = device.supported_speeds();
+                let speed_id = self.speed_dropdown.selected() as usize;
+                let speed = speeds[speed_id];
+                let handle = device.open_as_generic()?;
+                Ok((handle, speed))
+            },
+            Err(reason) => {
+                bail!("Device not usable: {}", reason)
+            }
+        }
+    }
+
+    fn replace_dropdown<T: AsRef<str>>(
+        &self, dropdown: &DropDown, strings: &[T])
+    {
+        let strings = strings
+            .iter()
+            .map(T::as_ref)
+            .collect::<Vec<_>>();
+        if let Some(model) = dropdown.model() {
+            let num_items = model.n_items();
+            if let Ok(list) = model.downcast::<StringList>() {
+                list.splice(0, num_items, strings.as_slice());
+            }
+        }
+    }
+}
+
+pub struct DeviceWarning {
+    info_bar: InfoBar,
+    label: Label,
+}
+
+impl DeviceWarning {
+    pub fn new(info_bar: InfoBar, label: Label) -> DeviceWarning {
+        info_bar.connect_response(|info_bar, response| {
+            if response == ResponseType::Close {
+                info_bar.set_revealed(false);
+            }
+        });
+        DeviceWarning {
+            info_bar,
+            label,
+        }
+    }
+
+    pub fn update(&self, warning: Option<&str>) {
+        if let Some(reason) = warning {
+            self.info_bar.set_message_type(MessageType::Warning);
+            self.label.set_text(&format!(
+                "This device is not usable because: {reason}"));
+            self.info_bar.set_revealed(true);
+        } else {
+            self.info_bar.set_revealed(false);
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -37,7 +37,6 @@ use gtk::{
     AboutDialog,
     Align,
     Application,
-    ApplicationWindow,
     Button,
     Dialog,
     DialogFlags,
@@ -49,7 +48,6 @@ use gtk::{
     Grid,
     ColumnView,
     ColumnViewColumn,
-    MenuButton,
     MessageType,
     PopoverMenu,
     ProgressBar,
@@ -58,13 +56,10 @@ use gtk::{
     Separator,
     SignalListItemFactory,
     SingleSelection,
-    Stack,
-    StackSwitcher,
     StringList,
     TextBuffer,
     TextView,
     Orientation,
-    WrapMode,
 };
 
 #[cfg(not(test))]
@@ -117,6 +112,7 @@ pub mod item_widget;
 pub mod model;
 pub mod row_data;
 pub mod tree_list_model;
+pub mod window;
 #[cfg(any(test, feature="record-ui-test"))]
 pub mod record_ui;
 #[cfg(test)]
@@ -130,6 +126,7 @@ use row_data::{
     TrafficRowData,
     DeviceRowData,
 };
+use window::PacketryWindow;
 
 #[cfg(any(test, feature="record-ui-test"))]
 use {
@@ -149,7 +146,7 @@ static UPDATE_INTERVAL: Duration = Duration::from_millis(10);
 static UPDATE_LOCK: Mutex<()> = Mutex::new(());
 
 thread_local!(
-    static WINDOW: RefCell<Option<ApplicationWindow>> =
+    static WINDOW: RefCell<Option<PacketryWindow>> =
         const { RefCell::new(None) };
     static UI: RefCell<Option<UserInterface>> =
         const { RefCell::new(None) };
@@ -408,263 +405,16 @@ pub fn with_ui<F>(f: F) -> Result<(), Error>
     })
 }
 
-macro_rules! button_action {
-    ($name:literal, $button:ident, $body:expr) => {
-        ActionEntry::builder($name)
-            .activate(|_: &ApplicationWindow, _, _| {
-                let mut enabled = false;
-                display_error(with_ui(|ui| { enabled = ui.$button.get_sensitive(); Ok(()) }));
-                if enabled {
-                    display_error($body);
-                }
-            })
-            .build()
-    }
-}
-
 pub fn activate(application: &Application) -> Result<(), Error> {
-    use FileAction::*;
 
-    let window = gtk::ApplicationWindow::builder()
-        .default_width(320)
-        .default_height(480)
-        .application(application)
-        .title("Packetry")
-        .build();
-
-    window.add_action_entries([
-        button_action!("open", open_button, choose_capture_file(Load)),
-        button_action!("save", save_button, choose_capture_file(Save)),
-        button_action!("scan", scan_button, detect_hardware()),
-        button_action!("capture", capture_button, start_capture()),
-        button_action!("stop", stop_button, stop_operation()),
-    ]);
-
-    #[cfg(not(target_os="macos"))]
-    {
-        application.set_accels_for_action("win.open", &["<Ctrl>o"]);
-        application.set_accels_for_action("win.save", &["<Ctrl>s"]);
-        application.set_accels_for_action("win.scan", &["<Ctrl>r", "F5"]);
-        application.set_accels_for_action("win.capture", &["<Ctrl>b"]);
-        application.set_accels_for_action("win.stop", &["<Ctrl>e"]);
-    }
-
-    #[cfg(target_os="macos")]
-    {
-        application.set_accels_for_action("win.open", &["<Meta>o"]);
-        application.set_accels_for_action("win.save", &["<Meta>s"]);
-        application.set_accels_for_action("win.scan", &["<Meta>r", "F5"]);
-        application.set_accels_for_action("win.capture", &["<Meta>b"]);
-        application.set_accels_for_action("win.stop", &["<Meta>e"]);
-    }
-
-    let action_bar = gtk::ActionBar::new();
-
-    let open_button = gtk::Button::builder()
-        .icon_name("document-open")
-        .tooltip_text("Open")
-        .action_name("win.open")
-        .build();
-    let save_button = gtk::Button::builder()
-        .icon_name("document-save")
-        .tooltip_text("Save")
-        .action_name("win.save")
-        .build();
-    let scan_button = gtk::Button::builder()
-        .icon_name("view-refresh")
-        .tooltip_text("Scan for devices")
-        .action_name("win.scan")
-        .build();
-    let capture_button = gtk::Button::builder()
-        .icon_name("media-record")
-        .tooltip_text("Capture")
-        .action_name("win.capture")
-        .build();
-    let stop_button = gtk::Button::builder()
-        .icon_name("media-playback-stop")
-        .tooltip_text("Stop")
-        .action_name("win.stop")
-        .build();
-
-    open_button.set_sensitive(true);
-    save_button.set_sensitive(false);
-    scan_button.set_sensitive(true);
-
-    let selector = DeviceSelector::new()?;
-    capture_button.set_sensitive(selector.device_available());
-
-    let menu = Menu::new();
-    let meta_item = MenuItem::new(Some("Metadata..."), Some("actions.metadata"));
-    let about_item = MenuItem::new(Some("About..."), Some("actions.about"));
-    menu.append_item(&meta_item);
-    menu.append_item(&about_item);
-    let menu_button = MenuButton::builder()
-        .menu_model(&menu)
-        .build();
-    let action_group = SimpleActionGroup::new();
-    let action_metadata = ActionEntry::builder("metadata")
-        .activate(|_, _, _| display_error(show_metadata()))
-        .build();
-    let action_about = ActionEntry::builder("about")
-        .activate(|_, _, _| display_error(show_about()))
-        .build();
-    action_group.add_action_entries([action_metadata, action_about]);
-    window.insert_action_group("actions", Some(&action_group));
-    let metadata_action = action_group.lookup_action("metadata").unwrap();
-    metadata_action.set_property("enabled", false);
-
-    action_bar.pack_start(&open_button);
-    action_bar.pack_start(&save_button);
-    action_bar.pack_start(&gtk::Separator::new(Orientation::Vertical));
-    action_bar.pack_start(&scan_button);
-    action_bar.pack_start(&capture_button);
-    action_bar.pack_start(&stop_button);
-    action_bar.pack_start(&selector.container);
-    action_bar.pack_end(&menu_button);
-
-    let warning = DeviceWarning::new();
-    warning.update(selector.device_unusable());
+    let (window, ui) = PacketryWindow::setup(application)?;
 
     #[cfg(not(test))]
     window.show();
     WINDOW.with(|win_opt| win_opt.replace(Some(window.clone())));
 
-    let (_, capture) = create_capture()?;
-
-    let mut traffic_windows = BTreeMap::new();
-
-    let traffic_stack = Stack::builder()
-        .vexpand(true)
-        .build();
-
-    for mode in TRAFFIC_MODES {
-        let window = gtk::ScrolledWindow::builder()
-            .hscrollbar_policy(gtk::PolicyType::Automatic)
-            .min_content_height(480)
-            .min_content_width(640)
-            .build();
-        traffic_windows
-            .insert(mode, window.clone());
-        traffic_stack
-            .add_child(&window)
-            .set_title(mode.display_name());
-    }
-
-    let traffic_stack_switcher = StackSwitcher::builder()
-        .stack(&traffic_stack)
-        .build();
-
-    let traffic_box = gtk::Box::builder()
-        .orientation(Orientation::Vertical)
-        .vexpand(true)
-        .build();
-
-    traffic_box.append(&traffic_stack_switcher);
-    traffic_box.append(&traffic_stack);
-
-    let device_window = gtk::ScrolledWindow::builder()
-        .hscrollbar_policy(gtk::PolicyType::Automatic)
-        .min_content_height(480)
-        .min_content_width(240)
-        .build();
-
-    let detail_text = gtk::TextBuffer::new(None);
-    let detail_view = gtk::TextView::builder()
-        .buffer(&detail_text)
-        .editable(false)
-        .wrap_mode(WrapMode::Word)
-        .vexpand(true)
-        .left_margin(5)
-        .build();
-
-    let detail_window = gtk::ScrolledWindow::builder()
-        .hscrollbar_policy(gtk::PolicyType::Automatic)
-        .min_content_width(640)
-        .min_content_height(120)
-        .child(&detail_view)
-        .build();
-
-    let horizontal_panes = gtk::Paned::builder()
-        .orientation(Orientation::Horizontal)
-        .wide_handle(true)
-        .start_child(&traffic_box)
-        .end_child(&device_window)
-        .vexpand(true)
-        .build();
-
-    let vertical_panes = gtk::Paned::builder()
-        .orientation(Orientation::Vertical)
-        .wide_handle(true)
-        .start_child(&horizontal_panes)
-        .end_child(&detail_window)
-        .hexpand(true)
-        .build();
-
-    let separator = gtk::Separator::new(Orientation::Horizontal);
-
-    let progress_bar = gtk::ProgressBar::builder()
-        .show_text(true)
-        .text("")
-        .hexpand(true)
-        .build();
-
-    let status_label = gtk::Label::builder()
-        .label("Ready")
-        .single_line_mode(true)
-        .halign(Align::Start)
-        .hexpand(true)
-        .margin_top(2)
-        .margin_bottom(2)
-        .margin_start(3)
-        .margin_end(3)
-        .build();
-
-    let vbox = gtk::Box::builder()
-        .orientation(Orientation::Vertical)
-        .build();
-
-    vbox.append(&action_bar);
-    vbox.append(&gtk::Separator::new(Orientation::Horizontal));
-    vbox.append(&warning.info_bar);
-    vbox.append(&gtk::Separator::new(Orientation::Horizontal));
-    vbox.append(&vertical_panes);
-    vbox.append(&gtk::Separator::new(Orientation::Horizontal));
-    vbox.append(&status_label);
-    vbox.append(&gtk::Separator::new(Orientation::Horizontal));
-
-    window.set_child(Some(&vbox));
-
     UI.with(|cell| {
-        cell.borrow_mut().replace(
-            UserInterface {
-                #[cfg(any(test, feature="record-ui-test"))]
-                recording: Rc::new(RefCell::new(
-                    Recording::new(capture.clone()))),
-                capture,
-                selector,
-                file_name: None,
-                stop_state: StopState::Disabled,
-                traffic_windows,
-                device_window,
-                traffic_models: BTreeMap::new(),
-                device_model: None,
-                detail_text,
-                endpoint_count: 2,
-                show_progress: None,
-                progress_bar,
-                separator,
-                vbox,
-                vertical_panes,
-                scan_button,
-                open_button,
-                save_button,
-                capture_button,
-                stop_button,
-                status_label,
-                warning,
-                metadata_action,
-            }
-        )
+        cell.borrow_mut().replace(ui);
     });
 
     reset_capture()?;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -31,7 +31,7 @@ use gtk::gio::{
     MenuItem,
     SimpleActionGroup
 };
-use gtk::glib::{Object, SignalHandlerId, clone};
+use gtk::glib::{Object, clone};
 use gtk::{
     prelude::*,
     AboutDialog,
@@ -40,8 +40,6 @@ use gtk::{
     Button,
     Dialog,
     DialogFlags,
-    DropDown,
-    InfoBar,
     Label,
     License,
     ListItem,
@@ -57,7 +55,6 @@ use gtk::{
     Separator,
     SignalListItemFactory,
     SingleSelection,
-    StringList,
     TextBuffer,
     TextView,
 };
@@ -69,10 +66,7 @@ use gtk::{
 };
 
 use crate::backend::{
-    BackendHandle,
     BackendStop,
-    ProbeResult,
-    scan
 };
 
 use crate::capture::{
@@ -108,6 +102,7 @@ use crate::usb::{Descriptor, PacketFields, Speed, validate_packet};
 use crate::util::{rcu::SingleWriterRcu, fmt_count, fmt_size};
 use crate::version::{version, version_info};
 
+pub mod device;
 pub mod item_widget;
 pub mod model;
 pub mod row_data;
@@ -118,6 +113,7 @@ pub mod record_ui;
 #[cfg(test)]
 mod test_replay;
 
+use device::{DeviceSelector, DeviceWarning};
 use item_widget::ItemWidget;
 use model::{GenericModel, TrafficModel, DeviceModel};
 use row_data::{
@@ -166,181 +162,6 @@ enum StopState {
     Disabled,
     File(Cancellable),
     Backend(BackendStop),
-}
-
-struct DeviceSelector {
-    devices: Vec<ProbeResult>,
-    dev_strings: Vec<String>,
-    dev_speeds: Vec<Vec<&'static str>>,
-    dev_dropdown: DropDown,
-    speed_dropdown: DropDown,
-    change_handler: Option<SignalHandlerId>,
-}
-
-impl DeviceSelector {
-    fn new(dev_dropdown: DropDown, speed_dropdown: DropDown)
-        -> Result<Self, Error>
-    {
-        dev_dropdown.set_model(Some(&StringList::new(&[])));
-        speed_dropdown.set_model(Some(&StringList::new(&[])));
-        Ok(DeviceSelector {
-            devices: vec![],
-            dev_strings: vec![],
-            dev_speeds: vec![],
-            dev_dropdown,
-            speed_dropdown,
-            change_handler: None,
-        })
-    }
-
-    fn current_device(&self) -> Option<&ProbeResult> {
-        if self.devices.is_empty() {
-            None
-        } else {
-            Some(&self.devices[self.dev_dropdown.selected() as usize])
-        }
-    }
-
-    fn device_available(&self) -> bool {
-        match self.current_device() {
-            None => false,
-            Some(probe) => probe.result.is_ok()
-        }
-    }
-
-    fn device_unusable(&self) -> Option<&str> {
-        match self.current_device() {
-            Some(ProbeResult {result: Err(msg), ..}) => Some(msg),
-            _ => None
-        }
-    }
-
-    fn set_sensitive(&mut self, sensitive: bool) {
-        if sensitive {
-            self.dev_dropdown.set_sensitive(!self.devices.is_empty());
-            self.speed_dropdown.set_sensitive(self.device_available());
-        } else {
-            self.dev_dropdown.set_sensitive(false);
-            self.speed_dropdown.set_sensitive(false);
-        }
-    }
-
-    fn scan(&mut self) -> Result<(), Error> {
-        if let Some(handler) = self.change_handler.take() {
-            self.dev_dropdown.disconnect(handler);
-        }
-        self.devices = scan()?;
-        let count = self.devices.len();
-        self.dev_strings = Vec::with_capacity(count);
-        self.dev_speeds = Vec::with_capacity(count);
-        for probe in self.devices.iter() {
-            self.dev_strings.push(
-                if count <= 1 {
-                    probe.name.to_string()
-                } else {
-                    let info = &probe.info;
-                    if let Some(serial) = info.serial_number() {
-                        format!("{} #{}", probe.name, serial)
-                    } else {
-                        format!("{} (bus {}, device {})",
-                            probe.name,
-                            info.bus_number(),
-                            info.device_address())
-                    }
-                }
-            );
-            if let Ok(device) = &probe.result {
-                self.dev_speeds.push(
-                    device
-                        .supported_speeds()
-                        .iter()
-                        .map(Speed::description)
-                        .collect()
-                )
-            } else {
-                self.dev_speeds.push(vec![]);
-            }
-        }
-        let no_speeds = vec![];
-        let speed_strings = self.dev_speeds.first().unwrap_or(&no_speeds);
-        self.replace_dropdown(&self.dev_dropdown, &self.dev_strings);
-        self.replace_dropdown(&self.speed_dropdown, speed_strings);
-        self.dev_dropdown.set_sensitive(!self.devices.is_empty());
-        self.speed_dropdown.set_sensitive(!speed_strings.is_empty());
-        self.change_handler = Some(
-            self.dev_dropdown.connect_selected_notify(
-                |_| display_error(device_selection_changed())));
-        Ok(())
-    }
-
-    fn update_speeds(&self) {
-        let index = self.dev_dropdown.selected() as usize;
-        let speed_strings = &self.dev_speeds[index];
-        self.replace_dropdown(&self.speed_dropdown, speed_strings);
-        self.speed_dropdown.set_sensitive(!speed_strings.is_empty());
-    }
-
-    fn open(&self) -> Result<(Box<dyn BackendHandle>, Speed), Error> {
-        let device_id = self.dev_dropdown.selected();
-        let probe = &self.devices[device_id as usize];
-        match &probe.result {
-            Ok(device) => {
-                let speeds = device.supported_speeds();
-                let speed_id = self.speed_dropdown.selected() as usize;
-                let speed = speeds[speed_id];
-                let handle = device.open_as_generic()?;
-                Ok((handle, speed))
-            },
-            Err(reason) => {
-                bail!("Device not usable: {}", reason)
-            }
-        }
-    }
-
-    fn replace_dropdown<T: AsRef<str>>(
-        &self, dropdown: &DropDown, strings: &[T])
-    {
-        let strings = strings
-            .iter()
-            .map(T::as_ref)
-            .collect::<Vec<_>>();
-        if let Some(model) = dropdown.model() {
-            let num_items = model.n_items();
-            if let Ok(list) = model.downcast::<StringList>() {
-                list.splice(0, num_items, strings.as_slice());
-            }
-        }
-    }
-}
-
-struct DeviceWarning {
-    info_bar: InfoBar,
-    label: Label,
-}
-
-impl DeviceWarning {
-    fn new(info_bar: InfoBar, label: Label) -> DeviceWarning {
-        info_bar.connect_response(|info_bar, response| {
-            if response == ResponseType::Close {
-                info_bar.set_revealed(false);
-            }
-        });
-        DeviceWarning {
-            info_bar,
-            label,
-        }
-    }
-
-    fn update(&self, warning: Option<&str>) {
-        if let Some(reason) = warning {
-            self.info_bar.set_message_type(MessageType::Warning);
-            self.label.set_text(&format!(
-                "This device is not usable because: {reason}"));
-            self.info_bar.set_revealed(true);
-        } else {
-            self.info_bar.set_revealed(false);
-        }
-    }
 }
 
 pub struct UserInterface {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -49,6 +49,7 @@ use gtk::{
     ColumnView,
     ColumnViewColumn,
     MessageType,
+    Paned,
     PopoverMenu,
     ProgressBar,
     ResponseType,
@@ -59,7 +60,6 @@ use gtk::{
     StringList,
     TextBuffer,
     TextView,
-    Orientation,
 };
 
 #[cfg(not(test))]
@@ -177,37 +177,22 @@ struct DeviceSelector {
     dev_dropdown: DropDown,
     speed_dropdown: DropDown,
     change_handler: Option<SignalHandlerId>,
-    container: gtk::Box,
 }
 
 impl DeviceSelector {
-    fn new() -> Result<Self, Error> {
-        let selector = DeviceSelector {
+    fn new(dev_dropdown: DropDown, speed_dropdown: DropDown)
+        -> Result<Self, Error>
+    {
+        dev_dropdown.set_model(Some(&StringList::new(&[])));
+        speed_dropdown.set_model(Some(&StringList::new(&[])));
+        Ok(DeviceSelector {
             devices: vec![],
             dev_strings: vec![],
             dev_speeds: vec![],
-            dev_dropdown: DropDown::from_strings(&[]),
-            speed_dropdown: DropDown::from_strings(&[]),
+            dev_dropdown,
+            speed_dropdown,
             change_handler: None,
-            container: gtk::Box::builder()
-                .orientation(Orientation::Horizontal)
-                .build()
-        };
-        let device_label = Label::builder()
-            .label("Device: ")
-            .margin_start(2)
-            .margin_end(2)
-            .build();
-        let speed_label = Label::builder()
-            .label(" Speed: ")
-            .margin_start(2)
-            .margin_end(2)
-            .build();
-        selector.container.append(&device_label);
-        selector.container.append(&selector.dev_dropdown);
-        selector.container.append(&speed_label);
-        selector.container.append(&selector.speed_dropdown);
-        Ok(selector)
+        })
     }
 
     fn current_device(&self) -> Option<&ProbeResult> {
@@ -336,17 +321,12 @@ struct DeviceWarning {
 }
 
 impl DeviceWarning {
-    fn new() -> DeviceWarning {
-        let info_bar = InfoBar::new();
-        info_bar.set_show_close_button(true);
+    fn new(info_bar: InfoBar, label: Label) -> DeviceWarning {
         info_bar.connect_response(|info_bar, response| {
             if response == ResponseType::Close {
                 info_bar.set_revealed(false);
             }
         });
-        let label = Label::new(None);
-        label.set_wrap(true);
-        info_bar.add_child(&label);
         DeviceWarning {
             info_bar,
             label,
@@ -380,7 +360,7 @@ pub struct UserInterface {
     progress_bar: ProgressBar,
     separator: Separator,
     vbox: gtk::Box,
-    vertical_panes: gtk::Paned,
+    vertical_panes: Paned,
     open_button: Button,
     save_button: Button,
     scan_button: Button,

--- a/src/ui/packetry.ui
+++ b/src/ui/packetry.ui
@@ -1,0 +1,197 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Created with Cambalache 0.96.1 -->
+<interface>
+  <!-- interface-name packetry.ui -->
+  <requires lib="gtk" version="4.12"/>
+  <template class="PacketryWindow" parent="GtkApplicationWindow">
+    <property name="height-request">480</property>
+    <property name="title">Packetry</property>
+    <property name="width-request">720</property>
+    <child>
+      <object class="GtkBox" id="vbox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkActionBar">
+            <child type="start">
+              <object class="GtkButton" id="open_button">
+                <property name="action-name">win.open</property>
+                <property name="icon-name">document-open</property>
+                <property name="tooltip-text">Open</property>
+              </object>
+            </child>
+            <child type="start">
+              <object class="GtkButton" id="save_button">
+                <property name="action-name">win.save</property>
+                <property name="icon-name">document-save</property>
+                <property name="tooltip-text">Save</property>
+              </object>
+            </child>
+            <child type="start">
+              <object class="GtkSeparator"/>
+            </child>
+            <child type="start">
+              <object class="GtkButton" id="scan_button">
+                <property name="action-name">win.scan</property>
+                <property name="icon-name">view-refresh</property>
+                <property name="tooltip-text">Scan for devices</property>
+              </object>
+            </child>
+            <child type="start">
+              <object class="GtkButton" id="capture_button">
+                <property name="action-name">win.capture</property>
+                <property name="icon-name">media-record</property>
+                <property name="tooltip-text">Capture</property>
+              </object>
+            </child>
+            <child type="start">
+              <object class="GtkButton" id="stop_button">
+                <property name="action-name">win.stop</property>
+                <property name="icon-name">media-playback-stop</property>
+                <property name="tooltip-text">Stop</property>
+              </object>
+            </child>
+            <child type="start">
+              <object class="GtkLabel">
+                <property name="label"> Device: </property>
+                <property name="margin-end">2</property>
+                <property name="margin-start">2</property>
+              </object>
+            </child>
+            <child type="start">
+              <object class="GtkDropDown" id="dev_dropdown"/>
+            </child>
+            <child type="start">
+              <object class="GtkLabel">
+                <property name="label"> Speed: </property>
+                <property name="margin-end">2</property>
+                <property name="margin-start">2</property>
+              </object>
+            </child>
+            <child type="start">
+              <object class="GtkDropDown" id="speed_dropdown"/>
+            </child>
+            <child type="end">
+              <object class="GtkMenuButton" id="menu_button"/>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSeparator"/>
+        </child>
+        <child>
+          <object class="GtkInfoBar" id="info_bar">
+            <property name="revealed">False</property>
+            <property name="show-close-button">True</property>
+            <child>
+              <object class="GtkLabel" id="info_label">
+                <property name="wrap">True</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkPaned" id="vertical_panes">
+            <property name="orientation">vertical</property>
+            <property name="position">360</property>
+            <property name="wide-handle">True</property>
+            <child>
+              <object class="GtkPaned" id="horizontal_panes">
+                <property name="position">640</property>
+                <property name="wide-handle">True</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <property name="vexpand">True</property>
+                    <child>
+                      <object class="GtkStackSwitcher" id="switcher">
+                        <property name="hexpand">True</property>
+                        <property name="stack">stack</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkStack" id="stack">
+                        <property name="vexpand">True</property>
+                        <child>
+                          <object class="GtkStackPage">
+                            <property name="child">
+                              <object class="GtkScrolledWindow" id="hierarchical">
+                                <property name="child">
+                                  <object class="GtkListView"/>
+                                </property>
+                              </object>
+                            </property>
+                            <property name="title">Hierarchical</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkStackPage">
+                            <property name="child">
+                              <object class="GtkScrolledWindow" id="transactions">
+                                <property name="child">
+                                  <object class="GtkListView"/>
+                                </property>
+                              </object>
+                            </property>
+                            <property name="title">Transactions</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkStackPage">
+                            <property name="child">
+                              <object class="GtkScrolledWindow" id="packets">
+                                <property name="child">
+                                  <object class="GtkListView"/>
+                                </property>
+                              </object>
+                            </property>
+                            <property name="title">Packets</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow" id="device_window">
+                    <property name="child">
+                      <object class="GtkListView"/>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <child>
+                  <object class="GtkTextView">
+                    <property name="buffer">
+                      <object class="GtkTextBuffer" id="detail_text"/>
+                    </property>
+                    <property name="editable">False</property>
+                    <property name="left-margin">5</property>
+                    <property name="vexpand">True</property>
+                    <property name="wrap-mode">word</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSeparator"/>
+        </child>
+        <child>
+          <object class="GtkLabel" id="status_label">
+            <property name="halign">start</property>
+            <property name="hexpand">True</property>
+            <property name="label">Ready</property>
+            <property name="margin-bottom">2</property>
+            <property name="margin-start">3</property>
+            <property name="margin-top">2</property>
+            <property name="single-line-mode">True</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -78,8 +78,7 @@ macro_rules! button_action {
 }
 
 impl PacketryWindow {
-    pub fn setup(application: &Application)
-        -> Result<(PacketryWindow, UserInterface), Error>
+    pub fn setup(application: &Application) -> Result<UserInterface, Error>
     {
         use FileAction::*;
         use TrafficViewMode::*;
@@ -179,6 +178,7 @@ impl PacketryWindow {
         let (_, capture) = create_capture()?;
 
         let ui = UserInterface {
+            window,
             #[cfg(any(test, feature="record-ui-test"))]
             recording: Rc::new(RefCell::new(
                 Recording::new(capture.clone()))),
@@ -207,7 +207,7 @@ impl PacketryWindow {
             metadata_action,
         };
 
-        Ok((window, ui))
+        Ok(ui)
     }
 }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1,0 +1,352 @@
+//! GObject subclass for the application window.
+
+use std::collections::BTreeMap;
+
+use anyhow::Error;
+
+use gtk::{
+    self,
+    prelude::*,
+    glib,
+    gio::{
+        ActionEntry,
+        ActionMap,
+        Menu,
+        MenuItem,
+        SimpleActionGroup,
+    },
+    Align,
+    Application,
+    ApplicationWindow,
+    MenuButton,
+    Orientation,
+    Stack,
+    StackSwitcher,
+    Widget,
+    Window,
+    WrapMode,
+};
+
+use crate::capture::create_capture;
+use crate::ui::{
+    TRAFFIC_MODES,
+    DeviceSelector,
+    DeviceWarning,
+    FileAction,
+    StopState,
+    UserInterface,
+    detect_hardware,
+    display_error,
+    choose_capture_file,
+    show_about,
+    show_metadata,
+    start_capture,
+    stop_operation,
+    with_ui,
+};
+
+#[cfg(any(test, feature="record-ui-test"))]
+use {
+    std::{rc::Rc, cell::RefCell},
+    crate::ui::Recording,
+};
+
+glib::wrapper! {
+    /// The outer type exposed to our Rust code.
+    pub struct PacketryWindow(ObjectSubclass<imp::PacketryWindow>)
+    @extends ApplicationWindow, Window, Widget,
+    @implements ActionMap;
+}
+
+impl Default for PacketryWindow {
+    fn default() -> Self {
+        glib::Object::new::<PacketryWindow>()
+    }
+}
+
+macro_rules! button_action {
+    ($name:literal, $button:ident, $body:expr) => {
+        ActionEntry::builder($name)
+            .activate(|_: &PacketryWindow, _, _| {
+                let mut enabled = false;
+                display_error(with_ui(|ui| {
+                    enabled = ui.$button.get_sensitive(); Ok(())
+                }));
+                if enabled {
+                    display_error($body);
+                }
+            })
+            .build()
+    }
+}
+
+impl PacketryWindow {
+    pub fn setup(application: &Application)
+        -> Result<(PacketryWindow, UserInterface), Error>
+    {
+        use FileAction::*;
+
+        let window = Self::default();
+
+        window.set_application(Some(application));
+        window.set_title(Some("Packetry"));
+
+        window.add_action_entries([
+            button_action!("open", open_button, choose_capture_file(Load)),
+            button_action!("save", save_button, choose_capture_file(Save)),
+            button_action!("scan", scan_button, detect_hardware()),
+            button_action!("capture", capture_button, start_capture()),
+            button_action!("stop", stop_button, stop_operation()),
+        ]);
+
+        #[cfg(not(target_os="macos"))]
+        {
+            application.set_accels_for_action("win.open", &["<Ctrl>o"]);
+            application.set_accels_for_action("win.save", &["<Ctrl>s"]);
+            application.set_accels_for_action("win.scan", &["<Ctrl>r", "F5"]);
+            application.set_accels_for_action("win.capture", &["<Ctrl>b"]);
+            application.set_accels_for_action("win.stop", &["<Ctrl>e"]);
+        }
+
+        #[cfg(target_os="macos")]
+        {
+            application.set_accels_for_action("win.open", &["<Meta>o"]);
+            application.set_accels_for_action("win.save", &["<Meta>s"]);
+            application.set_accels_for_action("win.scan", &["<Meta>r", "F5"]);
+            application.set_accels_for_action("win.capture", &["<Meta>b"]);
+            application.set_accels_for_action("win.stop", &["<Meta>e"]);
+        }
+
+        let action_bar = gtk::ActionBar::new();
+
+        let open_button = gtk::Button::builder()
+            .icon_name("document-open")
+            .tooltip_text("Open")
+            .action_name("win.open")
+            .build();
+        let save_button = gtk::Button::builder()
+            .icon_name("document-save")
+            .tooltip_text("Save")
+            .action_name("win.save")
+            .build();
+        let scan_button = gtk::Button::builder()
+            .icon_name("view-refresh")
+            .tooltip_text("Scan for devices")
+            .action_name("win.scan")
+            .build();
+        let capture_button = gtk::Button::builder()
+            .icon_name("media-record")
+            .tooltip_text("Capture")
+            .action_name("win.capture")
+            .build();
+        let stop_button = gtk::Button::builder()
+            .icon_name("media-playback-stop")
+            .tooltip_text("Stop")
+            .action_name("win.stop")
+            .build();
+
+        open_button.set_sensitive(true);
+        save_button.set_sensitive(false);
+        scan_button.set_sensitive(true);
+
+        let selector = DeviceSelector::new()?;
+        capture_button.set_sensitive(selector.device_available());
+
+        let menu = Menu::new();
+        let meta_item = MenuItem::new(Some("Metadata..."), Some("actions.metadata"));
+        let about_item = MenuItem::new(Some("About..."), Some("actions.about"));
+        menu.append_item(&meta_item);
+        menu.append_item(&about_item);
+        let menu_button = MenuButton::builder()
+            .menu_model(&menu)
+            .build();
+        let action_group = SimpleActionGroup::new();
+        let action_metadata = ActionEntry::builder("metadata")
+            .activate(|_, _, _| display_error(show_metadata()))
+            .build();
+        let action_about = ActionEntry::builder("about")
+            .activate(|_, _, _| display_error(show_about()))
+            .build();
+        action_group.add_action_entries([action_metadata, action_about]);
+        window.insert_action_group("actions", Some(&action_group));
+        let metadata_action = action_group.lookup_action("metadata").unwrap();
+        metadata_action.set_property("enabled", false);
+
+        action_bar.pack_start(&open_button);
+        action_bar.pack_start(&save_button);
+        action_bar.pack_start(&gtk::Separator::new(Orientation::Vertical));
+        action_bar.pack_start(&scan_button);
+        action_bar.pack_start(&capture_button);
+        action_bar.pack_start(&stop_button);
+        action_bar.pack_start(&selector.container);
+        action_bar.pack_end(&menu_button);
+
+        let warning = DeviceWarning::new();
+        warning.update(selector.device_unusable());
+
+        let mut traffic_windows = BTreeMap::new();
+
+        let traffic_stack = Stack::builder()
+            .vexpand(true)
+            .build();
+
+        for mode in TRAFFIC_MODES {
+            let window = gtk::ScrolledWindow::builder()
+                .hscrollbar_policy(gtk::PolicyType::Automatic)
+                .min_content_height(480)
+                .min_content_width(640)
+                .build();
+            traffic_windows
+                .insert(mode, window.clone());
+            traffic_stack
+                .add_child(&window)
+                .set_title(mode.display_name());
+        }
+
+        let traffic_stack_switcher = StackSwitcher::builder()
+            .stack(&traffic_stack)
+            .build();
+
+        let traffic_box = gtk::Box::builder()
+            .orientation(Orientation::Vertical)
+            .vexpand(true)
+            .build();
+
+        traffic_box.append(&traffic_stack_switcher);
+        traffic_box.append(&traffic_stack);
+
+        let device_window = gtk::ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Automatic)
+            .min_content_height(480)
+            .min_content_width(240)
+            .build();
+
+        let detail_text = gtk::TextBuffer::new(None);
+        let detail_view = gtk::TextView::builder()
+            .buffer(&detail_text)
+            .editable(false)
+            .wrap_mode(WrapMode::Word)
+            .vexpand(true)
+            .left_margin(5)
+            .build();
+
+        let detail_window = gtk::ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Automatic)
+            .min_content_width(640)
+            .min_content_height(120)
+            .child(&detail_view)
+            .build();
+
+        let horizontal_panes = gtk::Paned::builder()
+            .orientation(Orientation::Horizontal)
+            .wide_handle(true)
+            .start_child(&traffic_box)
+            .end_child(&device_window)
+            .vexpand(true)
+            .build();
+
+        let vertical_panes = gtk::Paned::builder()
+            .orientation(Orientation::Vertical)
+            .wide_handle(true)
+            .start_child(&horizontal_panes)
+            .end_child(&detail_window)
+            .hexpand(true)
+            .build();
+
+        let separator = gtk::Separator::new(Orientation::Horizontal);
+
+        let progress_bar = gtk::ProgressBar::builder()
+            .show_text(true)
+            .text("")
+            .hexpand(true)
+            .build();
+
+        let status_label = gtk::Label::builder()
+            .label("Ready")
+            .single_line_mode(true)
+            .halign(Align::Start)
+            .hexpand(true)
+            .margin_top(2)
+            .margin_bottom(2)
+            .margin_start(3)
+            .margin_end(3)
+            .build();
+
+        let vbox = gtk::Box::builder()
+            .orientation(Orientation::Vertical)
+            .build();
+
+        vbox.append(&action_bar);
+        vbox.append(&gtk::Separator::new(Orientation::Horizontal));
+        vbox.append(&warning.info_bar);
+        vbox.append(&gtk::Separator::new(Orientation::Horizontal));
+        vbox.append(&vertical_panes);
+        vbox.append(&gtk::Separator::new(Orientation::Horizontal));
+        vbox.append(&status_label);
+        vbox.append(&gtk::Separator::new(Orientation::Horizontal));
+
+        window.set_child(Some(&vbox));
+
+        let (_, capture) = create_capture()?;
+
+        let ui = UserInterface {
+            #[cfg(any(test, feature="record-ui-test"))]
+            recording: Rc::new(RefCell::new(
+                Recording::new(capture.clone()))),
+            capture,
+            selector,
+            file_name: None,
+            stop_state: StopState::Disabled,
+            traffic_windows,
+            device_window,
+            traffic_models: BTreeMap::new(),
+            device_model: None,
+            detail_text,
+            endpoint_count: 2,
+            show_progress: None,
+            progress_bar,
+            separator,
+            vbox,
+            vertical_panes,
+            scan_button,
+            open_button,
+            save_button,
+            capture_button,
+            stop_button,
+            status_label,
+            warning,
+            metadata_action,
+        };
+
+        Ok((window, ui))
+    }
+}
+
+/// The internal implementation module.
+mod imp {
+    use gtk::{
+        self,
+        subclass::prelude::*,
+        glib,
+        ApplicationWindow,
+    };
+
+    /// The inner type to be used in the GObject type system.
+    #[derive(Default)]
+    pub struct PacketryWindow {}
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for PacketryWindow {
+        const NAME: &'static str = "PacketryWindow";
+        type Type = super::PacketryWindow;
+        type ParentType = ApplicationWindow;
+    }
+
+    impl ObjectImpl for PacketryWindow {}
+
+    impl WidgetImpl for PacketryWindow {}
+
+    impl WindowImpl for PacketryWindow {}
+
+    impl ApplicationWindowImpl for PacketryWindow {}
+}

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -8,7 +8,7 @@ use gtk::{
     self,
     prelude::*,
     subclass::prelude::*,
-    glib,
+    glib::{self, Object},
     gio::{
         ActionEntry,
         ActionMap,
@@ -16,22 +16,17 @@ use gtk::{
         MenuItem,
         SimpleActionGroup,
     },
-    Align,
     Application,
     ApplicationWindow,
-    MenuButton,
+    Buildable,
     Orientation,
-    Paned,
-    Stack,
-    StackSwitcher,
     Widget,
     Window,
-    WrapMode,
 };
 
 use crate::capture::create_capture;
+use crate::item::TrafficViewMode;
 use crate::ui::{
-    TRAFFIC_MODES,
     DeviceSelector,
     DeviceWarning,
     FileAction,
@@ -57,20 +52,13 @@ glib::wrapper! {
     /// The outer type exposed to our Rust code.
     pub struct PacketryWindow(ObjectSubclass<imp::PacketryWindow>)
     @extends ApplicationWindow, Window, Widget,
-    @implements ActionMap;
+    @implements ActionMap, Buildable;
 }
 
 impl Default for PacketryWindow {
     fn default() -> Self {
         glib::Object::new::<PacketryWindow>()
     }
-}
-
-#[derive(Default)]
-pub struct Panes {
-    initialised: bool,
-    vertical: Paned,
-    horizontal: Paned,
 }
 
 macro_rules! button_action {
@@ -94,11 +82,11 @@ impl PacketryWindow {
         -> Result<(PacketryWindow, UserInterface), Error>
     {
         use FileAction::*;
+        use TrafficViewMode::*;
 
-        let window = Self::default();
-
-        window.set_application(Some(application));
-        window.set_title(Some("Packetry"));
+        let window: PacketryWindow = Object::builder()
+            .property("application", application)
+            .build();
 
         window.add_action_entries([
             button_action!("open", open_button, choose_capture_file(Load)),
@@ -126,39 +114,21 @@ impl PacketryWindow {
             application.set_accels_for_action("win.stop", &["<Meta>e"]);
         }
 
-        let action_bar = gtk::ActionBar::new();
-
-        let open_button = gtk::Button::builder()
-            .icon_name("document-open")
-            .tooltip_text("Open")
-            .action_name("win.open")
-            .build();
-        let save_button = gtk::Button::builder()
-            .icon_name("document-save")
-            .tooltip_text("Save")
-            .action_name("win.save")
-            .build();
-        let scan_button = gtk::Button::builder()
-            .icon_name("view-refresh")
-            .tooltip_text("Scan for devices")
-            .action_name("win.scan")
-            .build();
-        let capture_button = gtk::Button::builder()
-            .icon_name("media-record")
-            .tooltip_text("Capture")
-            .action_name("win.capture")
-            .build();
-        let stop_button = gtk::Button::builder()
-            .icon_name("media-playback-stop")
-            .tooltip_text("Stop")
-            .action_name("win.stop")
-            .build();
+        let open_button = window.imp().open_button.clone();
+        let save_button = window.imp().save_button.clone();
+        let scan_button = window.imp().scan_button.clone();
+        let capture_button = window.imp().capture_button.clone();
+        let stop_button = window.imp().stop_button.clone();
 
         open_button.set_sensitive(true);
         save_button.set_sensitive(false);
         scan_button.set_sensitive(true);
 
-        let selector = DeviceSelector::new()?;
+        let selector = DeviceSelector::new(
+            window.imp().dev_dropdown.clone(),
+            window.imp().speed_dropdown.clone(),
+        )?;
+
         capture_button.set_sensitive(selector.device_available());
 
         let menu = Menu::new();
@@ -166,9 +136,8 @@ impl PacketryWindow {
         let about_item = MenuItem::new(Some("About..."), Some("actions.about"));
         menu.append_item(&meta_item);
         menu.append_item(&about_item);
-        let menu_button = MenuButton::builder()
-            .menu_model(&menu)
-            .build();
+        let menu_button = window.imp().menu_button.clone();
+        menu_button.set_menu_model(Some(&menu));
         let action_group = SimpleActionGroup::new();
         let action_metadata = ActionEntry::builder("metadata")
             .activate(|_, _, _| display_error(show_metadata()))
@@ -181,88 +150,20 @@ impl PacketryWindow {
         let metadata_action = action_group.lookup_action("metadata").unwrap();
         metadata_action.set_property("enabled", false);
 
-        action_bar.pack_start(&open_button);
-        action_bar.pack_start(&save_button);
-        action_bar.pack_start(&gtk::Separator::new(Orientation::Vertical));
-        action_bar.pack_start(&scan_button);
-        action_bar.pack_start(&capture_button);
-        action_bar.pack_start(&stop_button);
-        action_bar.pack_start(&selector.container);
-        action_bar.pack_end(&menu_button);
-
-        let warning = DeviceWarning::new();
+        let warning = DeviceWarning::new(
+            window.imp().info_bar.clone(),
+            window.imp().info_label.clone()
+        );
         warning.update(selector.device_unusable());
 
         let mut traffic_windows = BTreeMap::new();
+        traffic_windows.insert(Hierarchical, window.imp().hierarchical.clone());
+        traffic_windows.insert(Transactions, window.imp().transactions.clone());
+        traffic_windows.insert(Packets, window.imp().packets.clone());
 
-        let traffic_stack = Stack::builder()
-            .vexpand(true)
-            .build();
-
-        for mode in TRAFFIC_MODES {
-            let window = gtk::ScrolledWindow::builder()
-                .hscrollbar_policy(gtk::PolicyType::Automatic)
-                .build();
-            traffic_windows
-                .insert(mode, window.clone());
-            traffic_stack
-                .add_child(&window)
-                .set_title(mode.display_name());
-        }
-
-        let traffic_stack_switcher = StackSwitcher::builder()
-            .stack(&traffic_stack)
-            .build();
-
-        let traffic_box = gtk::Box::builder()
-            .orientation(Orientation::Vertical)
-            .vexpand(true)
-            .build();
-
-        traffic_box.append(&traffic_stack_switcher);
-        traffic_box.append(&traffic_stack);
-
-        let device_window = gtk::ScrolledWindow::builder()
-            .hscrollbar_policy(gtk::PolicyType::Automatic)
-            .build();
-
-        let detail_text = gtk::TextBuffer::new(None);
-        let detail_view = gtk::TextView::builder()
-            .buffer(&detail_text)
-            .editable(false)
-            .wrap_mode(WrapMode::Word)
-            .vexpand(true)
-            .left_margin(5)
-            .build();
-
-        let detail_window = gtk::ScrolledWindow::builder()
-            .hscrollbar_policy(gtk::PolicyType::Automatic)
-            .child(&detail_view)
-            .build();
-
-        let horizontal_panes = gtk::Paned::builder()
-            .orientation(Orientation::Horizontal)
-            .wide_handle(true)
-            .start_child(&traffic_box)
-            .end_child(&device_window)
-            .vexpand(true)
-            .build();
-
-        let vertical_panes = gtk::Paned::builder()
-            .orientation(Orientation::Vertical)
-            .wide_handle(true)
-            .start_child(&horizontal_panes)
-            .end_child(&detail_window)
-            .hexpand(true)
-            .build();
-
-        window.imp().panes.replace(
-            Panes {
-                initialised: false,
-                vertical: vertical_panes.clone(),
-                horizontal: horizontal_panes.clone(),
-            }
-        );
+        let device_window = window.imp().device_window.clone();
+        let detail_text = window.imp().detail_text.clone();
+        let vertical_panes = window.imp().vertical_panes.clone();
 
         let separator = gtk::Separator::new(Orientation::Horizontal);
 
@@ -272,31 +173,8 @@ impl PacketryWindow {
             .hexpand(true)
             .build();
 
-        let status_label = gtk::Label::builder()
-            .label("Ready")
-            .single_line_mode(true)
-            .halign(Align::Start)
-            .hexpand(true)
-            .margin_top(2)
-            .margin_bottom(2)
-            .margin_start(3)
-            .margin_end(3)
-            .build();
-
-        let vbox = gtk::Box::builder()
-            .orientation(Orientation::Vertical)
-            .build();
-
-        vbox.append(&action_bar);
-        vbox.append(&gtk::Separator::new(Orientation::Horizontal));
-        vbox.append(&warning.info_bar);
-        vbox.append(&gtk::Separator::new(Orientation::Horizontal));
-        vbox.append(&vertical_panes);
-        vbox.append(&gtk::Separator::new(Orientation::Horizontal));
-        vbox.append(&status_label);
-        vbox.append(&gtk::Separator::new(Orientation::Horizontal));
-
-        window.set_child(Some(&vbox));
+        let status_label = window.imp().status_label.clone();
+        let vbox = window.imp().vbox.clone();
 
         let (_, capture) = create_capture()?;
 
@@ -335,19 +213,66 @@ impl PacketryWindow {
 
 /// The internal implementation module.
 mod imp {
-    use std::cell::RefCell;
+    use std::cell::Cell;
     use gtk::{
         self,
         subclass::prelude::*,
-        glib,
+        glib::{self, subclass::InitializingObject},
         ApplicationWindow,
+        Button,
+        CompositeTemplate,
+        DropDown,
+        InfoBar,
+        Label,
+        MenuButton,
+        Paned,
+        ScrolledWindow,
+        TextBuffer,
     };
-    use super::Panes;
 
     /// The inner type to be used in the GObject type system.
-    #[derive(Default)]
+    #[derive(Default, CompositeTemplate)]
+    #[template(file="packetry.ui")]
     pub struct PacketryWindow {
-        pub panes: RefCell<Panes>,
+        panes_initialised: Cell<bool>,
+        #[template_child]
+        pub open_button: TemplateChild<Button>,
+        #[template_child]
+        pub save_button: TemplateChild<Button>,
+        #[template_child]
+        pub scan_button: TemplateChild<Button>,
+        #[template_child]
+        pub capture_button: TemplateChild<Button>,
+        #[template_child]
+        pub stop_button: TemplateChild<Button>,
+        #[template_child]
+        pub dev_dropdown: TemplateChild<DropDown>,
+        #[template_child]
+        pub speed_dropdown: TemplateChild<DropDown>,
+        #[template_child]
+        pub menu_button: TemplateChild<MenuButton>,
+        #[template_child]
+        pub info_bar: TemplateChild<InfoBar>,
+        #[template_child]
+        pub info_label: TemplateChild<Label>,
+        #[template_child]
+        pub hierarchical: TemplateChild<ScrolledWindow>,
+        #[template_child]
+        pub transactions: TemplateChild<ScrolledWindow>,
+        #[template_child]
+        pub packets: TemplateChild<ScrolledWindow>,
+        #[template_child]
+        pub device_window: TemplateChild<ScrolledWindow>,
+        #[template_child]
+        pub detail_text: TemplateChild<TextBuffer>,
+        #[template_child]
+        pub vertical_panes: TemplateChild<Paned>,
+        #[template_child]
+        pub horizontal_panes: TemplateChild<Paned>,
+        #[template_child]
+        pub status_label: TemplateChild<Label>,
+        #[template_child]
+        pub vbox: TemplateChild<gtk::Box>,
     }
 
     #[glib::object_subclass]
@@ -355,6 +280,14 @@ mod imp {
         const NAME: &'static str = "PacketryWindow";
         type Type = super::PacketryWindow;
         type ParentType = ApplicationWindow;
+
+        fn class_init(cls: &mut Self::Class) {
+            cls.bind_template();
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
     }
 
     impl ObjectImpl for PacketryWindow {}
@@ -363,11 +296,10 @@ mod imp {
         // Set the traffic window to 3/4 of initial height and width.
         fn size_allocate(&self, width: i32, height: i32, baseline: i32) {
             self.parent_size_allocate(width, height, baseline);
-            let mut panes = self.panes.borrow_mut();
-            if !panes.initialised {
-                panes.vertical.set_position(3 * height / 4);
-                panes.horizontal.set_position(3 * width / 4);
-                panes.initialised = true;
+            if !self.panes_initialised.get() {
+                self.vertical_panes.set_position(3 * height / 4);
+                self.horizontal_panes.set_position(3 * width / 4);
+                self.panes_initialised.set(true);
             }
         }
     }


### PR DESCRIPTION
Up till now, the main window has been constructed programatically in the `activate` function.

This PR moves that code into a new `PacketryWindow` GObject class which subclasses GTK's `ApplicationWindow`.

The motivation here is that we want to set the initial positions of the horizontal and vertical pane separators to a sensible proportion of the initial window size. Currently we fudge this with some hardcoded minimum sizes in pixels. This has caused various frustrations discussed in #191.

By subclassing `ApplicationWindow`, we can override the `size_allocate` method. This seems to be the only way in GTK4 to consistently be notified when the window size is first known.

With that method hooked, we can set the initial size of the traffic pane to 75% of the initial window size both horizontally and vertically.

Additionally, this PR integrates and extends the work from #231 to define the main window layout in an XML UI file that can be edited visually with the [Cambalache](https://blogs.gnome.org/xjuan/category/programming/cambalache-ui-maker/) tool.

Fixes #132, supersedes #191 and #231.