### PR TITLE
Use archive.debian.org for Debian Buster docker image.

### DIFF
--- a/appimage/docker/Dockerfile
+++ b/appimage/docker/Dockerfile
@@ -20,6 +20,10 @@ ENV HOME="/home/$RUNNER"
 
 USER root
 
+# Point sources.list at archive.debian.org
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
+
 # add image dependencies
 RUN apt update && apt upgrade -y && apt install -y \
     bison \


### PR DESCRIPTION
Debian Buster has reached end of life and, as such, packages can no longer be downloaded from `deb.debian.org`.

This PR replaces the reference to `deb.debian.org` and `security.debian.org` with `archive.debian.org`.