### PR TITLE
CI: Lock cargo subcommands to specific versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,18 +100,20 @@ jobs:
         if: matrix.os == 'macos-latest'
 
       - name: Install cargo-all-features
-        run: cargo install cargo-all-features
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-all-features@1.10.0
 
       - name: Install cargo-wix (Windows)
         uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: cargo-wix
+          tool: cargo-wix@0.3.9
         if: matrix.os == 'windows-latest'
 
       - name: Install cargo-license (Windows)
         uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: cargo-license
+          tool: cargo-license@0.6.1
         if: matrix.os == 'windows-latest'
 
       - name: Restore vcpkg cache (Windows)


### PR DESCRIPTION
The latest `cargo-license` release [0.7.0](https://crates.io/crates/cargo-license/0.7.0) requires Rust 1.86.

We test with our MSRV which is currently 1.83, so that failed with the new crate.

Fixed by pinning `cargo-license` to 0.6.

To avoid similar issues in future I have locked the versions of `cargo-wix` and `cargo-all-features` as well.

Also took the opportunity to cache the `cargo-all-features` install.