### PR TITLE
Replace StringList when updating a dropdown, rather than splicing

### DIFF
--- a/src/ui/device.rs
+++ b/src/ui/device.rs
@@ -170,12 +170,7 @@ impl DeviceSelector {
             .iter()
             .map(T::as_ref)
             .collect::<Vec<_>>();
-        if let Some(model) = dropdown.model() {
-            let num_items = model.n_items();
-            if let Ok(list) = model.downcast::<StringList>() {
-                list.splice(0, num_items, strings.as_slice());
-            }
-        }
+        dropdown.set_model(Some(&StringList::new(&strings)));
     }
 }
 


### PR DESCRIPTION
Fixes #257.

Calling `StringList::splice` to replace all its strings does not cause the `DropDown` using it to emit a selection change. Instead, make a whole new `StringList`.