### PR TITLE
Catch panics in decoder thread and display a dialog, rather than crash

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,7 @@
 //! The backend API for USB capture devices.
 
 use std::collections::BTreeMap;
+use std::panic::UnwindSafe;
 use std::sync::mpsc;
 use std::thread::{JoinHandle, spawn, sleep};
 use std::time::Duration;
@@ -97,7 +98,7 @@ pub struct BackendStop {
 }
 
 pub type EventResult = Result<TimestampedEvent, Error>;
-pub trait EventIterator: Iterator<Item=EventResult> + Send {}
+pub trait EventIterator: Iterator<Item=EventResult> + Send + UnwindSafe {}
 
 /// Configuration for power control.
 #[derive(Clone)]


### PR DESCRIPTION
This change makes issues like bug #262 and https://github.com/greatscottgadgets/packetry/pull/227#issuecomment-3244923590 less disruptive.

When a helper thread spawned from the UI panics, the panic now be caught as an error via `catch_unwind`. The operation will be stopped cleanly and an error message displayed. The application will not crash and the UI will remain usable.