### PR TITLE
Add the capability to dump the database from the UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,9 +72,12 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -248,7 +257,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.3",
  "object",
  "rustc-demangle",
  "serde",
@@ -516,6 +525,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +605,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -751,6 +780,17 @@ dependencies = [
  "lazy_static",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "libz-rs-sys",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -1525,6 +1565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1692,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -1863,6 +1921,7 @@ dependencies = [
  "tempfile",
  "usb-ids",
  "winapi 0.3.9",
+ "zip-extensions",
 ]
 
 [[package]]
@@ -3190,6 +3249,34 @@ dependencies = [
  "quote",
  "syn 2.0.66",
 ]
+
+[[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "zip-extensions"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f105becb0a5da773e655775dd05fee454ca1475bcc980ec9d940a02f42cee40"
+dependencies = [
+ "zip",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 preferences = "2.0.0"
 indexmap = "2.11.0"
 scoped-panic-hook = "0.1.2"
+zip-extensions = { version = "0.8.3", default-features = false, features = ["deflate-flate2", "deflate-flate2-zlib-rs"] }
 
 [dev-dependencies]
 serde_json = "1.0.113"

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -635,19 +635,44 @@ fn choose_file<F>(
                 .map(gio::File::for_path)
                 .as_ref()
         );
-        let all = gtk::FileFilter::new();
-        let pcap = gtk::FileFilter::new();
-        let pcapng = gtk::FileFilter::new();
-        all.add_suffix("pcap");
-        all.add_suffix("pcapng");
-        pcap.add_suffix("pcap");
-        pcapng.add_suffix("pcapng");
-        all.set_name(Some("All captures (*.pcap, *.pcapng)"));
-        pcap.set_name(Some("pcap (*.pcap)"));
-        pcapng.set_name(Some("pcap-NG (*.pcapng)"));
-        chooser.add_filter(&all);
-        chooser.add_filter(&pcap);
-        chooser.add_filter(&pcapng);
+        match extension {
+            "pcapng" => {
+                let all = gtk::FileFilter::new();
+                let pcap = gtk::FileFilter::new();
+                let pcapng = gtk::FileFilter::new();
+                all.add_suffix("pcap");
+                all.add_suffix("pcapng");
+                pcap.add_suffix("pcap");
+                pcapng.add_suffix("pcapng");
+                all.set_name(Some("All captures (*.pcap, *.pcapng)"));
+                pcap.set_name(Some("pcap (*.pcap)"));
+                pcapng.set_name(Some("pcap-NG (*.pcapng)"));
+                chooser.add_filter(&all);
+                chooser.add_filter(&pcap);
+                chooser.add_filter(&pcapng);
+            },
+            "bin" => {
+                let bin = gtk::FileFilter::new();
+                let all = gtk::FileFilter::new();
+                bin.add_suffix("bin");
+                all.add_pattern("*");
+                bin.set_name(Some("Binary files (*.bin)"));
+                all.set_name(Some("All files (*)"));
+                chooser.add_filter(&bin);
+                chooser.add_filter(&all);
+            },
+            "zip" => {
+                let zip = gtk::FileFilter::new();
+                let all = gtk::FileFilter::new();
+                zip.add_suffix("zip");
+                all.add_pattern("*");
+                zip.set_name(Some("Zip files (*.zip)"));
+                all.set_name(Some("All files (*)"));
+                chooser.add_filter(&zip);
+                chooser.add_filter(&all);
+            }
+            _ => bail!("Filters not defined for extension '.{extension}'")
+        }
         chooser.connect_response(move |dialog, response| {
             let _ = with_ui(|ui| {
                 ui.settings.last_used_directory = dialog

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -93,7 +93,7 @@ use crate::file::{
     PcapNgSaver,
 };
 use crate::usb::{Descriptor, PacketFields, Speed, validate_packet};
-use crate::util::{rcu::SingleWriterRcu, fmt_count, fmt_size};
+use crate::util::{dump::Dump, rcu::SingleWriterRcu, fmt_count, fmt_size};
 use crate::version::{version, version_info};
 
 pub mod capture;
@@ -1215,6 +1215,20 @@ fn save_data(
                 |path| path.to_string_lossy().to_string())
     );
     Ok(())
+}
+
+pub fn choose_dump_dir() -> Result<(), Error> {
+    choose_file(FileAction::Save, "dump directory", "dump", dump_database)
+}
+
+fn dump_database(file: gio::File) -> Result<(), Error> {
+    let path_buf = file
+        .path()
+        .context("Destination has no local path")?;
+    file.make_directory(Cancellable::NONE)?;
+    with_ui(|ui| {
+        ui.capture.reader.dump(path_buf.as_path())
+    })
 }
 
 fn show_metadata() -> Result<(), Error> {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -37,6 +37,7 @@ use crate::ui::{
     UserInterface,
     display_error,
     choose_capture_file,
+    choose_dump_dir,
     show_about,
     show_metadata,
     start_capture,
@@ -129,8 +130,10 @@ impl PacketryWindow {
 
         let menu = Menu::new();
         let meta_item = MenuItem::new(Some("Metadata..."), Some("actions.metadata"));
+        let dump_item = MenuItem::new(Some("Dump database..."), Some("actions.dump"));
         let about_item = MenuItem::new(Some("About..."), Some("actions.about"));
         menu.append_item(&meta_item);
+        menu.append_item(&dump_item);
         menu.append_item(&about_item);
         let menu_button = window.imp().menu_button.clone();
         menu_button.set_menu_model(Some(&menu));
@@ -138,10 +141,13 @@ impl PacketryWindow {
         let action_metadata = ActionEntry::builder("metadata")
             .activate(|_, _, _| display_error(show_metadata()))
             .build();
+        let action_dump = ActionEntry::builder("dump")
+            .activate(|_, _, _| display_error(choose_dump_dir()))
+            .build();
         let action_about = ActionEntry::builder("about")
             .activate(|_, _, _| display_error(show_about()))
             .build();
-        action_group.add_action_entries([action_metadata, action_about]);
+        action_group.add_action_entries([action_metadata, action_dump, action_about]);
         window.insert_action_group("actions", Some(&action_group));
         let metadata_action = action_group.lookup_action("metadata").unwrap();
         metadata_action.set_property("enabled", false);

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -37,7 +37,7 @@ use crate::ui::{
     UserInterface,
     display_error,
     choose_capture_file,
-    choose_dump_dir,
+    choose_dump_file,
     show_about,
     show_metadata,
     start_capture,
@@ -142,7 +142,7 @@ impl PacketryWindow {
             .activate(|_, _, _| display_error(show_metadata()))
             .build();
         let action_dump = ActionEntry::builder("dump")
-            .activate(|_, _, _| display_error(choose_dump_dir()))
+            .activate(|_, _, _| display_error(choose_dump_file()))
             .build();
         let action_about = ActionEntry::builder("about")
             .activate(|_, _, _| display_error(show_about()))

--- a/wix/rust_licenses.py
+++ b/wix/rust_licenses.py
@@ -15,6 +15,7 @@ accepted_license_strings = (
     'BSL-1.0',
     'Unicode-DFS-2016',
     'Unicode-3.0',
+    'Zlib',
 )
 
 # We accept these licenses with manual validation.


### PR DESCRIPTION
Adds an option to the main menu which dumps the complete database state into a `zip` file for debugging.

Among other scenarios, this should be helpful in a case such as #213 where the capture cannot be saved normally.