### PR TITLE
Convert all blocking USB IO to async

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-        rust: ['stable', '1.85']
+        rust: ['stable', '1.85.1']
 
     runs-on: ${{ matrix.os }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -376,7 +376,7 @@ dependencies = [
  "cairo-sys-rs",
  "glib",
  "libc",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -479,6 +479,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "continue"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f3dc39cda960e9f5594a713c0a4687f85c25f591c67862f107cb009cdd6c46"
+dependencies = [
+ "atomic-waker",
+ "logwise",
+ "thiserror 2.0.16",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,7 +587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -615,7 +637,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -628,7 +650,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -675,7 +697,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -714,7 +736,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -877,7 +899,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1019,7 +1041,7 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1067,7 +1089,7 @@ dependencies = [
  "libc",
  "memchr",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1080,7 +1102,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1188,7 +1210,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1249,7 +1271,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c588dafe431c43a03779628a0214172caef9c3ee2de85aaaafa3ac0a4be24da7"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1267,7 +1289,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e272cc642f49588d581cdb3e7bc2d087d5ce943d03c74dc304235c05ba83b30"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1474,7 +1496,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.61",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1608,6 +1630,24 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "logwise"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08abd1c835aab3cfd8220209d8e29345cf19c4cdf759373f6e9fafac48502fc"
+dependencies = [
+ "logwise_proc",
+ "wasm-bindgen",
+ "web-sys",
+ "web-time",
+]
+
+[[package]]
+name = "logwise_proc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba61263a12347d87ece9286fab931b7f3407b06a94ab952e676b350d7054a57"
 
 [[package]]
 name = "lrumap"
@@ -1811,7 +1851,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1912,6 +1952,7 @@ dependencies = [
  "once_cell",
  "page_size",
  "pcap-file-gsg",
+ "portable_async_sleep",
  "preferences",
  "procspawn",
  "rand 0.8.5",
@@ -1974,7 +2015,7 @@ dependencies = [
  "byteorder_slice",
  "derive-into-owned",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -2066,6 +2107,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable_async_sleep"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29f904ab621c397d940c49f0cfe02aba3db9f2042ae880e7ae760b1479dcd2c"
+dependencies = [
+ "continue",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+ "web-time",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -2244,7 +2300,7 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -2324,6 +2380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,7 +2411,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2371,7 +2433,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2449,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2466,7 +2528,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2506,7 +2568,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -2517,7 +2588,18 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2594,7 +2676,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2729,8 +2811,20 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2751,7 +2845,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2763,10 +2857,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3131,7 +3260,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3182,7 +3311,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
  "zvariant_utils",
 ]
 
@@ -3214,7 +3343,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3248,7 +3377,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3301,7 +3430,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
  "zvariant_utils",
 ]
 
@@ -3313,5 +3442,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.106",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,9 +1860,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "701a6a7ed08d280343b136da239b8d62d2f0733866541dff3a0d6bfa9be50139"
 dependencies = [
+ "blocking",
  "core-foundation",
  "core-foundation-sys",
  "futures-core",
+ "futures-io",
  "io-kit-sys",
  "linux-raw-sys 0.9.4",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1882,6 +1882,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-trait",
  "bitfield",
  "built",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -1924,6 +1924,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-lock",
  "async-trait",
  "bitfield",
  "built",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ scoped-panic-hook = "0.1.2"
 zip-extensions = { version = "0.8.3", default-features = false, features = ["deflate-flate2", "deflate-flate2-zlib-rs"] }
 async-trait = "0.1.89"
 portable_async_sleep = { version = "0.1.1", default-features = false }
+async-lock = "3.4.1"
 
 [dev-dependencies]
 serde_json = "1.0.113"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/greatscottgadgets/packetry"
 repository = "https://github.com/greatscottgadgets/packetry"
 documentation = "https://packetry.readthedocs.io"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.85.1"
 build = "src/build.rs"
 default-run = "packetry"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ preferences = "2.0.0"
 indexmap = "2.11.0"
 scoped-panic-hook = "0.1.2"
 zip-extensions = { version = "0.8.3", default-features = false, features = ["deflate-flate2", "deflate-flate2-zlib-rs"] }
+async-trait = "0.1.89"
 
 [dev-dependencies]
 serde_json = "1.0.113"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ bitfield = "0.14.0"
 num-format = "0.4.4"
 humansize = "2.1.3"
 derive_more = "0.99.17"
-nusb = "0.2.0"
+nusb = { version = "0.2.0", features = ["smol"] }
 futures-lite = "2.0.1"
 futures-channel = "0.3.21"
 futures-util = "0.3.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ indexmap = "2.11.0"
 scoped-panic-hook = "0.1.2"
 zip-extensions = { version = "0.8.3", default-features = false, features = ["deflate-flate2", "deflate-flate2-zlib-rs"] }
 async-trait = "0.1.89"
+portable_async_sleep = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.113"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Read the latest [Packetry Documentation](https://packetry.readthedocs.io/).
 
 Packetry is written in [Rust](https://rust-lang.org/), with its GUI using [GTK 4](https://gtk.org) via the [gtk-rs](https://gtk-rs.org/) bindings.
 
-To build it, you need a working Rust development environment. The minimum supported Rust version is 1.85.
+To build it, you need a working Rust development environment. The minimum supported Rust version is 1.85.1.
 
 You must also have the GTK 4 headers installed and discoverable via `pkg-config`, as this is required for Rust to build the gtk-rs crates.
 
@@ -40,7 +40,7 @@ For Fedora systems:
 
 For other distributions, a similar set of packages should be required.
 
-Note that Packetry requires a minimum Rust version of 1.85. If your distribution's packages are older than this, use [rustup](https://rustup.rs/) to get the latest Rust toolchain and manage your Rust installation.
+Note that Packetry requires a minimum Rust version of 1.85.1. If your distribution's packages are older than this, use [rustup](https://rustup.rs/) to get the latest Rust toolchain and manage your Rust installation.
 
 #### macOS
 

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -41,7 +41,7 @@ Install Packetry
 
                 yum install rust cargo make gcc gcc-c++ gtk4-devel pango-devel git
 
-        Note that Packetry requires a minimum Rust version of 1.85. If your distribution's packages are older than this, use `rustup <https://rustup.rs/>`__ to get the latest Rust toolchain and manage your Rust installation.
+        Note that Packetry requires a minimum Rust version of 1.85.1. If your distribution's packages are older than this, use `rustup <https://rustup.rs/>`__ to get the latest Rust toolchain and manage your Rust installation.
 
         **Download Packetry Source Code**
 

--- a/src/ui/power.rs
+++ b/src/ui/power.rs
@@ -1,9 +1,8 @@
 //! Power controls.
 
-use anyhow::Error;
-
 use gtk::{
     prelude::*,
+    glib::{self, SignalHandlerId},
     ActionBar,
     CheckButton,
     DropDown,
@@ -12,6 +11,7 @@ use gtk::{
 };
 
 use crate::backend::{BackendHandle, PowerConfig};
+use crate::ui::{display_error, with_ui};
 
 pub struct PowerControl {
     pub action_bar: ActionBar,
@@ -21,24 +21,75 @@ pub struct PowerControl {
     pub source_strings: StringList,
     pub start_on: CheckButton,
     pub stop_off: CheckButton,
+    pub signals: Option<PowerSignals>,
+}
+
+pub struct PowerSignals {
+    pub switch_active: SignalHandlerId,
+    pub start_on_toggled: SignalHandlerId,
+    pub stop_off_toggled: SignalHandlerId,
+    pub dropdown_selected: SignalHandlerId,
 }
 
 impl PowerControl {
     pub fn connect_signals(&self, f: fn()) {
+        // Defer connection until UI setup is complete.
         let switch = self.switch.clone();
         let source_strings = self.source_strings.clone();
-        self.source_dropdown.connect_selected_notify(move |dropdown| {
-            update_tooltip(&switch, dropdown, &source_strings);
-            f();
+        let source_dropdown = self.source_dropdown.clone();
+        let start_on = self.start_on.clone();
+        let stop_off = self.stop_off.clone();
+        glib::idle_add_local_once(move || {
+            // Collect the signal IDs, we need these for blocking signals.
+            let signals = PowerSignals {
+                switch_active: switch.connect_active_notify(move |_| f()),
+                start_on_toggled: start_on.connect_toggled(move |_| f()),
+                stop_off_toggled: stop_off.connect_toggled(move |_| f()),
+                dropdown_selected: source_dropdown.connect_selected_notify(
+                    move |dropdown| {
+                        update_tooltip(&switch, dropdown, &source_strings);
+                        f();
+                    }
+                ),
+            };
+            // Store the collected signal IDs.
+            display_error(with_ui(|ui| {
+                ui.power.signals = Some(signals);
+                Ok(())
+            }));
         });
-        self.switch.connect_active_notify(move |_| f());
-        self.start_on.connect_toggled(move |_| f());
-        self.stop_off.connect_toggled(move |_| f());
     }
 
-    pub fn update_controls(&self, device: Option<&mut Box<dyn BackendHandle>>) {
+    fn block_signals(&self) {
+        if let Some(signals) = &self.signals {
+            self.switch.block_signal(&signals.switch_active);
+            self.start_on.block_signal(&signals.start_on_toggled);
+            self.stop_off.block_signal(&signals.stop_off_toggled);
+            self.source_dropdown.block_signal(&signals.dropdown_selected);
+        }
+    }
+
+    fn unblock_signals(&self) {
+        if let Some(signals) = &self.signals {
+            self.switch.unblock_signal(&signals.switch_active);
+            self.start_on.unblock_signal(&signals.start_on_toggled);
+            self.stop_off.unblock_signal(&signals.stop_off_toggled);
+            self.source_dropdown.unblock_signal(&signals.dropdown_selected);
+        }
+    }
+
+    pub fn update_controls(
+        &self,
+        device: Option<&mut Box<dyn BackendHandle>>,
+        config: Option<PowerConfig>,
+    ) {
+        // We're overriding the state of these controls. We don't
+        // want to emit the usual signals, as these would trigger
+        // updates to the device as if a user had changed them.
+        self.block_signals();
+
         if let Some(device) = device {
-            match (device.power_sources(), device.power_config()) {
+            match (device.power_sources(), config) {
                 (Some(sources), Some(config)) => {
                     self.enable(sources);
                     self.set_config(config);
@@ -48,27 +99,33 @@ impl PowerControl {
         } else {
             self.disable();
         }
-    }
 
-    pub fn update_device(&self, device: Option<&mut Box<dyn BackendHandle>>)
-        -> Result<(), Error>
-    {
-        if let Some(device) = device {
-            device.set_power_config(self.config())?;
-        }
-        Ok(())
+        // Now we want the usual signals again when the user changes them.
+        self.unblock_signals();
     }
 
     pub fn started(&self) {
+        // The state was already changed on the device when the capture started,
+        // so block signals while we update the control state.
+        self.block_signals();
+
         if self.enabled() && self.start_on.is_active() {
             self.switch.set_active(true);
         }
+
+        self.unblock_signals();
     }
 
     pub fn stopped(&self) {
+        // The state was already changed on the device when the capture stopped,
+        // so block signals while we update the control state.
+        self.block_signals();
+
         if self.enabled() && self.stop_off.is_active() {
             self.switch.set_active(false);
         }
+
+        self.unblock_signals();
     }
 
     fn enabled(&self) -> bool {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -166,6 +166,7 @@ impl PacketryWindow {
             source_strings: window.imp().power_source_strings.clone(),
             start_on: window.imp().power_start_on.clone(),
             stop_off: window.imp().power_stop_off.clone(),
+            signals: None,
         };
 
         let mut traffic_windows = BTreeMap::new();

--- a/wix/manual-licenses/LICENSE-logwise_proc-0.1.1.txt
+++ b/wix/manual-licenses/LICENSE-logwise_proc-0.1.1.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2025 Drew Crawford; https://sealedabstract.com/code/logwise
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
We're still doing a fair bit of blocking IO from the UI thread.

In practice this hasn't generally been an issue since everything normally responds quickly.

However, it sometimes feels laggy, and working around https://github.com/kevinmehall/nusb/issues/149 is going to require adding some deliberate delays during hotplugging.

So, let's do this properly.

- Convert all functions that do blocking nusb IO to `async`.
- Either run async functions with [`block_on`](https://docs.rs/futures-lite/latest/futures_lite/future/fn.block_on.html) in a dedicated thread, or integrate them into the GTK main loop by spawning them with [`glib::spawn_future_local`](https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/fn.spawn_future_local.html).
- Enable the `smol` feature of `nusb` to support usage with `block_on`.
- Use [`portable_async_sleep`](https://docs.rs/portable_async_sleep/latest/portable_async_sleep/) to implement delays as a future that works correctly with either executor.
- Use [`async_lock::Mutex`](https://docs.rs/async-lock/latest/async_lock/struct.Mutex.html) rather than `std::sync::Mutex` to manage access to the `CynthionInner` structure.
- Use the [`async_trait`](https://github.com/dtolnay/async-trait) crate to work around the fact that traits with `async` functions are not yet `dyn` compatible in stable Rust.