### PR TITLE
CI: Explicitly install cargo-clippy component with toolchain.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install toolchain
         run: |
-          rustup toolchain install stable
+          rustup toolchain install stable --component clippy
           rustup default stable
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
This is no longer included by default with Rust 1.90.