### PR TITLE
Fix "Failed to claim interface" error when hotplugging a device on Windows

### DIFF
--- a/src/backend/cynthion.rs
+++ b/src/backend/cynthion.rs
@@ -34,6 +34,7 @@ use super::{
     PowerConfig,
     TimestampedEvent,
     TransferQueue,
+    claim_interface,
 };
 
 use crate::capture::CaptureMetadata;
@@ -168,10 +169,8 @@ impl CynthionDevice {
                 }
 
                 // Try to claim the interface.
-                let interface = device
-                    .claim_interface(interface_number)
-                    .await
-                    .context("Failed to claim interface")?;
+                let interface =
+                    claim_interface(&device, interface_number).await?;
 
                 // Select the required alternate, if not the default.
                 if alt_setting_number != 0 {

--- a/src/backend/ice40usbtrace.rs
+++ b/src/backend/ice40usbtrace.rs
@@ -32,6 +32,7 @@ use super::{
     Speed,
     TimestampedEvent,
     TransferQueue,
+    claim_interface,
 };
 
 pub const VID_PID: (u16, u16) = (0x1d50, 0x617e);
@@ -84,10 +85,7 @@ impl BackendDevice for Ice40UsbtraceDevice {
             .open()
             .await
             .context("Failed to open device")?;
-        let interface = device
-            .claim_interface(INTERFACE)
-            .await
-            .context("Failed to claim interface")?;
+        let interface = claim_interface(&device, INTERFACE).await?;
         let metadata = CaptureMetadata {
             iface_desc: Some("iCE40-usbtrace".to_string()),
             .. Default::default()


### PR DESCRIPTION
Workaround for https://github.com/kevinmehall/nusb/issues/149.

When hotplugging a device on Windows, if claiming the necessary interface fails, wait 50ms and retry up to 5 times.