### PR TITLE
Enable the use of GTK 4.12 APIs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ built = { version = "0.7.4", features = ["cargo-lock", "git2"] }
 [dependencies]
 bytemuck = "1.14.1"
 bytemuck_derive = "1.5.0"
-gtk = { version = "0.8.0", package = "gtk4", features = ["v4_4"] }
+gtk = { version = "0.8.0", package = "gtk4", features = ["v4_12"] }
 num_enum = "0.7.2"
 once_cell = "1.19.0"
 pcap-file-gsg = "3.0.0-rc4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ fn main() {
                 window.set_child(Some(&vbox));
                 vbox.append(&label);
                 vbox.append(&button);
-                window.show();
+                window.set_visible(true);
             });
             application.run();
         } else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,8 @@
 //! The Packetry user interface.
 
+// We use a number of deprecated GTK4 APIs.
+#![allow(deprecated)]
+
 use std::backtrace::Backtrace;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -270,7 +273,8 @@ fn create_view<Item, Model, RowData, ViewMode>(
         )).expect("Failed to create model");
     let selection_model = SingleSelection::new(Some(model.clone()));
     let factory = SignalListItemFactory::new();
-    factory.connect_setup(move |_, list_item| {
+    factory.connect_setup(move |_, list_item: &Object| {
+        let list_item: &ListItem = list_item.downcast_ref().unwrap();
         let widget = ItemWidget::new();
         list_item.set_child(Some(&widget));
     });
@@ -364,8 +368,14 @@ fn create_view<Item, Model, RowData, ViewMode>(
 
         Ok(())
     };
-    factory.connect_bind(move |_, item| display_error(bind(item)));
-    factory.connect_unbind(move |_, item| display_error(unbind(item)));
+    factory.connect_bind(move |_, item: &Object| {
+        let item: &ListItem = item.downcast_ref().unwrap();
+        display_error(bind(item))
+    });
+    factory.connect_unbind(move |_, item: &Object| {
+        let item: &ListItem = item.downcast_ref().unwrap();
+        display_error(unbind(item));
+    });
 
     let view = ColumnView::new(Some(selection_model.clone()));
     let column = ColumnViewColumn::new(Some(title), Some(factory));
@@ -375,7 +385,8 @@ fn create_view<Item, Model, RowData, ViewMode>(
     if Model::HAS_TIMES {
         let model = model.clone();
         let factory = SignalListItemFactory::new();
-        factory.connect_setup(move |_, list_item| {
+        factory.connect_setup(move |_, list_item: &Object| {
+            let list_item: &ListItem = list_item.downcast_ref().unwrap();
             let label = Label::new(None);
             list_item.set_child(Some(&label));
         });
@@ -405,7 +416,10 @@ fn create_view<Item, Model, RowData, ViewMode>(
             Ok(())
         };
 
-        factory.connect_bind(move |_, item| display_error(bind(item)));
+        factory.connect_bind(move |_, item: &Object| {
+            let item: &ListItem = item.downcast_ref().unwrap();
+            display_error(bind(item))
+        });
 
         let timestamp_column =
             ColumnViewColumn::new(Some("Time"), Some(factory));


### PR DESCRIPTION
Implements #274, by enabling the `v4_12` feature of the `gtk4` crate, and deals with the resulting warnings and errors.