### PR TITLE
Adapt SignalListItemFactory usage to work with gtk4's v4_8 feature

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -271,6 +271,7 @@ fn create_view<Item, Model, RowData, ViewMode>(
     let selection_model = SingleSelection::new(Some(model.clone()));
     let factory = SignalListItemFactory::new();
     factory.connect_setup(move |_, list_item| {
+        let list_item: &ListItem = list_item.downcast_ref().unwrap();
         let widget = ItemWidget::new();
         list_item.set_child(Some(&widget));
     });
@@ -364,8 +365,14 @@ fn create_view<Item, Model, RowData, ViewMode>(
 
         Ok(())
     };
-    factory.connect_bind(move |_, item| display_error(bind(item)));
-    factory.connect_unbind(move |_, item| display_error(unbind(item)));
+    factory.connect_bind(move |_, item| {
+        let item: &ListItem = item.downcast_ref().unwrap();
+        display_error(bind(item))
+    });
+    factory.connect_unbind(move |_, item| {
+        let item: &ListItem = item.downcast_ref().unwrap();
+        display_error(unbind(item));
+    });
 
     let view = ColumnView::new(Some(selection_model.clone()));
     let column = ColumnViewColumn::new(Some(title), Some(factory));
@@ -376,6 +383,7 @@ fn create_view<Item, Model, RowData, ViewMode>(
         let model = model.clone();
         let factory = SignalListItemFactory::new();
         factory.connect_setup(move |_, list_item| {
+            let list_item: &ListItem = list_item.downcast_ref().unwrap();
             let label = Label::new(None);
             list_item.set_child(Some(&label));
         });
@@ -405,7 +413,10 @@ fn create_view<Item, Model, RowData, ViewMode>(
             Ok(())
         };
 
-        factory.connect_bind(move |_, item| display_error(bind(item)));
+        factory.connect_bind(move |_, item| {
+            let item: &ListItem = item.downcast_ref().unwrap();
+            display_error(bind(item))
+        });
 
         let timestamp_column =
             ColumnViewColumn::new(Some("Time"), Some(factory));


### PR DESCRIPTION
The `connect_*` methods on `SignalListItemFactory` switch from taking a `&ListItem` to an `&Object` when the `v4_8` feature or higher is enabled.

We're not enabling that yet, but this change prevents a compile error when developing with it enabled.