### PR TITLE
CI: update vcpkg to fix pango build failure.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      VCPKG_COMMIT: ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0 # 2025.06.13 release
+      VCPKG_COMMIT: 2041718d8942de33c7d10e9e2fbf22b5e24d352e # vcpkg PR 48711
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg/installed
 
     steps:


### PR DESCRIPTION
Our Windows builds have been failing due to https://github.com/microsoft/vcpkg/issues/47984.

This should fix it by updating to include the fix from https://github.com/microsoft/vcpkg/pull/48454.