### PR TITLE
quit on cmd+q on macos.

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -134,6 +134,12 @@ impl PacketryWindow {
             application.set_accels_for_action("win.save", &["<Meta>s"]);
             application.set_accels_for_action("win.capture", &["<Meta>b"]);
             application.set_accels_for_action("win.stop", &["<Meta>e"]);
+
+            application.add_action_entries([
+                ActionEntry::builder("quit")
+                    .activate(|app: &Application, _, _| app.quit())
+                    .build(),
+            ]);
         }
 
         let open_button = window.imp().open_button.clone();


### PR DESCRIPTION
Registers the app.quit action so the native macOS menu's Quit item (Cmd+Q) works.