### PR TITLE
CI: Fix authentication to ghcr.io by disabling wrapping of base64 output

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -54,10 +54,11 @@ jobs:
         id: exists
         shell: bash
         run: |
+          AUTH=$(echo -n ${{ secrets.GITHUB_TOKEN}} | base64 -w 0)
           declare -a HEADERS=(
             '-H' "Accept: application/vnd.oci.image.manifest.v1+json"
             '-H' "Accept: application/vnd.oci.image.index.v1+json"
-            '-H' "Authorization: Bearer $(echo ${{ secrets.GITHUB_TOKEN }} | base64)"
+            '-H' "Authorization: Bearer ${AUTH}"
           )
           RESULT=$(curl "${HEADERS[@]}" https://ghcr.io/v2/${IMAGE_NAME}/manifests/${IMAGE_TAG})
           echo 'dockerimage<<EOF' >> $GITHUB_OUTPUT


### PR DESCRIPTION
The `GITHUB_TOKEN` string is now longer than it used to be, and the `base64` command wraps its output at 76 characters by default, so we've started getting a multiline base64 output.

The resulting multiline header is invalid, and rejected by libcurl as an invalid argument, resulting in the rather unhelpful error message `curl: (43) Failed sending HTTP request`.

Passing `-w 0` to `base64` disables the wrapping and solves the problem.